### PR TITLE
fix(server): declare picocolors as a runtime dependency

### DIFF
--- a/.changeset/server-picocolors-dependency.md
+++ b/.changeset/server-picocolors-dependency.md
@@ -1,0 +1,5 @@
+---
+'@taujs/server': patch
+---
+
+Declare `picocolors` as a dependency. It is imported at runtime (logging, network, and server bootstrap) but was previously undeclared and resolved only via package hoisting — which fails under pnpm's strict `node_modules` layout and for consumers installing the package on its own.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -47,7 +47,8 @@
   "dependencies": {
     "@fastify/static": "^9.1.3",
     "fastify-plugin": "^5.1.0",
-    "path-to-regexp": "^8.1.0"
+    "path-to-regexp": "^8.1.0",
+    "picocolors": "^1.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
       path-to-regexp:
         specifier: ^8.1.0
         version: 8.4.2
+      picocolors:
+        specifier: ^1.0.0
+        version: 1.1.1
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.15.4


### PR DESCRIPTION
picocolors is imported at runtime (constants, CreateServer, network/Network, logging/Logger) but was never declared, resolving only via flat hoisting. That breaks under pnpm's strict node_modules layout (CI 'Could not resolve "picocolors"') and for consumers installing @taujs/server standalone. Also adds a changeset for a patch release.