### PR TITLE
test(server): make graph snapshots version-agnostic

### DIFF
--- a/packages/server/src/core/introspection/test/EmitGraph.test.ts
+++ b/packages/server/src/core/introspection/test/EmitGraph.test.ts
@@ -114,7 +114,7 @@ describe('registerBootGraphEmission', () => {
       expect(graph.source).toBe('boot');
 
       // Committed shape check, modulo the only timestamp in the document.
-      expect({ ...graph, emittedAt: '<emittedAt>' }).toMatchSnapshot();
+      expect({ ...graph, emittedAt: '<emittedAt>', taujs: { server: '<version>' } }).toMatchSnapshot();
     } finally {
       cwdSpy.mockRestore();
     }

--- a/packages/server/src/core/introspection/test/RequestGraph.test.ts
+++ b/packages/server/src/core/introspection/test/RequestGraph.test.ts
@@ -11,6 +11,11 @@ import type { CoreTaujsConfig } from '../../config/types';
 // Fixed emission options: createRequestGraph owns no clock, so snapshots pin exact bytes.
 const OPTS = { source: 'boot', emittedAt: '2026-07-09T10:12:03.412Z' } as const;
 
+// taujs.server is release-variant by design (the emitting package's version) — snapshots
+// must not break on version bumps, so it is normalised. Found by the first Version
+// Packages PR: the 0.7.1 → 0.8.0 bump failed all seven graph snapshots.
+const versionAgnostic = (graph: ReturnType<typeof createRequestGraph>) => ({ ...graph, taujs: { server: '<version>' } });
+
 // --- fixture (b) registry: one parse-style schema, one bare-function validator ---
 
 const catalogService = defineService({
@@ -154,19 +159,19 @@ const fixturePlayground: CoreTaujsConfig = {
 
 describe('createRequestGraph — fixture snapshots (spec 02 schema v1)', () => {
   it('(a) minimal single app', () => {
-    expect(createRequestGraph(fixtureMinimal, OPTS)).toMatchSnapshot();
+    expect(versionAgnostic(createRequestGraph(fixtureMinimal, OPTS))).toMatchSnapshot();
   });
 
   it('(b) multi-app with registry: kinds, usedBy, csp variants', () => {
-    expect(createRequestGraph(fixtureMultiApp, { ...OPTS, serviceRegistry: registry })).toMatchSnapshot();
+    expect(versionAgnostic(createRequestGraph(fixtureMultiApp, { ...OPTS, serviceRegistry: registry }))).toMatchSnapshot();
   });
 
   it('(b) without a registry: services is null, never []', () => {
-    expect(createRequestGraph(fixtureMultiApp, { ...OPTS, source: 'build' })).toMatchSnapshot();
+    expect(versionAgnostic(createRequestGraph(fixtureMultiApp, { ...OPTS, source: 'build' }))).toMatchSnapshot();
   });
 
   it('(c) app-shell wildcard: fallthrough unreachable', () => {
-    expect(createRequestGraph(fixtureAppShell, OPTS)).toMatchSnapshot();
+    expect(versionAgnostic(createRequestGraph(fixtureAppShell, OPTS))).toMatchSnapshot();
   });
 
   it('(e) playground fixture: the P0B-05 app shape, registry-enriched', () => {
@@ -174,7 +179,7 @@ describe('createRequestGraph — fixture snapshots (spec 02 schema v1)', () => {
 
     expect(graph.fallthrough.reachable).toBe(true);
     expect(graph.routes.map((r) => r.data.kind)).toEqual(expect.arrayContaining(['service', 'dynamic', 'none']));
-    expect(graph).toMatchSnapshot();
+    expect(versionAgnostic(graph)).toMatchSnapshot();
   });
 
   it('(d) every warning code fires at least once', () => {
@@ -183,7 +188,7 @@ describe('createRequestGraph — fixture snapshots (spec 02 schema v1)', () => {
     expect(new Set(graph.warnings.map((w) => w.code))).toEqual(
       new Set(['routes.duplicate_path', 'streaming.missing_meta', 'render.defaulted', 'csp.dev_directives', 'fallthrough.unreachable']),
     );
-    expect(graph).toMatchSnapshot();
+    expect(versionAgnostic(graph)).toMatchSnapshot();
   });
 });
 

--- a/packages/server/src/core/introspection/test/__snapshots__/EmitGraph.test.ts.snap
+++ b/packages/server/src/core/introspection/test/__snapshots__/EmitGraph.test.ts.snap
@@ -52,7 +52,7 @@ exports[`registerBootGraphEmission > registers an onListen hook that writes node
   "services": null,
   "source": "boot",
   "taujs": {
-    "server": "0.7.1",
+    "server": "<version>",
   },
   "warnings": [
     {

--- a/packages/server/src/core/introspection/test/__snapshots__/RequestGraph.test.ts.snap
+++ b/packages/server/src/core/introspection/test/__snapshots__/RequestGraph.test.ts.snap
@@ -52,7 +52,7 @@ exports[`createRequestGraph — fixture snapshots (spec 02 schema v1) > (a) mini
   "services": null,
   "source": "boot",
   "taujs": {
-    "server": "0.7.1",
+    "server": "<version>",
   },
   "warnings": [
     {
@@ -289,7 +289,7 @@ exports[`createRequestGraph — fixture snapshots (spec 02 schema v1) > (b) mult
   ],
   "source": "boot",
   "taujs": {
-    "server": "0.7.1",
+    "server": "<version>",
   },
   "warnings": [],
 }
@@ -462,7 +462,7 @@ exports[`createRequestGraph — fixture snapshots (spec 02 schema v1) > (b) with
   "services": null,
   "source": "build",
   "taujs": {
-    "server": "0.7.1",
+    "server": "<version>",
   },
   "warnings": [],
 }
@@ -545,7 +545,7 @@ exports[`createRequestGraph — fixture snapshots (spec 02 schema v1) > (c) app-
   "services": null,
   "source": "boot",
   "taujs": {
-    "server": "0.7.1",
+    "server": "<version>",
   },
   "warnings": [
     {
@@ -716,7 +716,7 @@ exports[`createRequestGraph — fixture snapshots (spec 02 schema v1) > (d) ever
   "services": null,
   "source": "boot",
   "taujs": {
-    "server": "0.7.1",
+    "server": "<version>",
   },
   "warnings": [
     {
@@ -964,7 +964,7 @@ exports[`createRequestGraph — fixture snapshots (spec 02 schema v1) > (e) play
   ],
   "source": "boot",
   "taujs": {
-    "server": "0.7.1",
+    "server": "<version>",
   },
   "warnings": [
     {


### PR DESCRIPTION
taujs.server in the emitted graph is release-variant by design (the emitting package's version), so pinning it in snapshots broke all seven on the first Version Packages PR (0.7.1 -> 0.8.0). Snapshots now normalise it to '<version>' alongside the existing emittedAt normalisation; verified green under a simulated bump. No changeset: test-only, nothing shipped changes.