### PR TITLE
fix(server): write streaming dev stamp into <head>, not #root

### DIFF
--- a/.changeset/streaming-devstamp-head.md
+++ b/.changeset/streaming-devstamp-head.md
@@ -1,10 +1,10 @@
 ---
-"@taujs/server": patch
+'@taujs/server': patch
 ---
 
 Fix Vue streaming routes rendering the app twice in dev. The dev introspection stamp
 was written as the first child of `#root` (before the streamed app HTML), which Vue
-hydration reports as a node mismatch — it re-renders the whole app as a duplicate
+hydration reports as a node mismatch - it re-renders the whole app as a duplicate
 sibling of the server-rendered tree. The stamp now lands in `<head>` on the streaming
 path. React is unaffected either way (its hydration skips unexpected scripts) and was
 verified against both playgrounds; production HTML never carried the stamp. The ssr

--- a/.changeset/streaming-devstamp-head.md
+++ b/.changeset/streaming-devstamp-head.md
@@ -1,0 +1,11 @@
+---
+"@taujs/server": patch
+---
+
+Fix Vue streaming routes rendering the app twice in dev. The dev introspection stamp
+was written as the first child of `#root` (before the streamed app HTML), which Vue
+hydration reports as a node mismatch — it re-renders the whole app as a duplicate
+sibling of the server-rendered tree. The stamp now lands in `<head>` on the streaming
+path. React is unaffected either way (its hydration skips unexpected scripts) and was
+verified against both playgrounds; production HTML never carried the stamp. The ssr
+path (stamp after the app HTML, tolerated by both renderers) is unchanged.

--- a/packages/server/src/utils/HandleRender.ts
+++ b/packages/server/src/utils/HandleRender.ts
@@ -365,7 +365,10 @@ export const handleRender = async (
             if (manifest && cssLink) aggregateHeadContent += cssLink;
 
             commitHead();
-            reply.raw.write(`${templateParts.beforeHead}${aggregateHeadContent}${templateParts.afterHead}${templateParts.beforeBody}${devStamp}`);
+            // devStamp lives in <head>, never inside #root: a leading <script> before the
+            // streamed app HTML is a Vue hydration node mismatch (the whole app re-renders
+            // as a duplicate sibling). React skips unexpected scripts, Vue does not.
+            reply.raw.write(`${templateParts.beforeHead}${aggregateHeadContent}${devStamp}${templateParts.afterHead}${templateParts.beforeBody}`);
             recorder?.streamPhase({ traceId, phase: 'head' });
 
             if (!pipedToReply) {

--- a/packages/server/src/utils/test/HandleRenderRecorder.test.ts
+++ b/packages/server/src/utils/test/HandleRenderRecorder.test.ts
@@ -237,6 +237,13 @@ describe('dev stamp injection (P0B-04, spec 03 §7)', () => {
     });
 
     expect(writes[0]).toContain(`window.__TAUJS_TRACE_ID__="${T}"`);
+
+    // Regression: the stamp must sit in <head>, never inside the app container. A <script>
+    // preceding the streamed app HTML inside #root is a Vue hydration node mismatch — Vue
+    // re-renders the whole app as a duplicate sibling (React skips unexpected scripts).
+    const firstWrite = writes[0]!;
+    expect(firstWrite.indexOf('__TAUJS_TRACE_ID__')).toBeLessThan(firstWrite.indexOf('</head>'));
+    expect(firstWrite.endsWith('<main>')).toBe(true);
   });
 
   it('the fallthrough shell gets its own stamp', async () => {


### PR DESCRIPTION
A <script> preceding the streamed app HTML inside #root is a Vue hydration node mismatch: Vue discards hydration and client-renders the app as a duplicate sibling of the server tree, doubling the page on every dev streaming route. React skips unexpected scripts, so it never surfaced there. Move the stamp into the head write (strictly earlier, framework-neutral) and pin its position in the streaming stamp test.

Verified headless against both playgrounds in dev: vue /streaming now hydrates in place (single app, anchors reused); react /product/:id and both ssr routes unchanged.