### PR TITLE
feat(react,vue,server): renderer hardening - RFC 0003 complete (R0-R3)

### DIFF
--- a/.changeset/r0-01-crash-safe-done-react.md
+++ b/.changeset/r0-01-crash-safe-done-react.md
@@ -1,0 +1,10 @@
+---
+'@taujs/react': patch
+---
+
+R0-01: make `renderStream().done` crash-safe by default. `createStreamController` now
+pre-attaches a no-op rejection handler to its settled promise, so an unobserved `done` can
+never raise `unhandledRejection` - which Node's default mode escalates to a
+process-terminating `uncaughtException` - when a stream aborts fatally. Consumers who
+`await done` still receive the fatal error. A child-process regression test (run under
+Node's default rejection mode) proves the process no longer exits on an unobserved rejection.

--- a/.changeset/r0-01-crash-safe-done-server.md
+++ b/.changeset/r0-01-crash-safe-done-server.md
@@ -1,0 +1,17 @@
+---
+'@taujs/server': minor
+---
+
+R0-01: export `RenderStreamHandle` (`{ abort(): void; done: Promise<void> }`) as the return
+type of `RenderStream`, and observe `done` at the streaming render call site.
+
+Both framework renderers already returned `{ abort, done }` at runtime, but the published
+`RenderStream` type promised only `{ abort(): void }`, so the server could not capture `done`.
+A fatal stream error rejects `done`; left unobserved, that surfaced as an `unhandledRejection`
+— which Node's default mode turns into a process-terminating `uncaughtException`. The server
+now captures and acknowledges `done` (fatal errors remain fully handled via the `onError`
+callback; the acknowledgement is also defence in depth if a renderer omits its own handler).
+
+Type-level breaking change for third-party `RenderStream` implementers: they must now return a
+`done` promise. Both first-party renderers already conform. Bumped `minor` as an additive
+contract type (precedent: V1-05), keeping `@taujs/server` below 1.0.0.

--- a/.changeset/r0-01-crash-safe-done-vue.md
+++ b/.changeset/r0-01-crash-safe-done-vue.md
@@ -1,0 +1,10 @@
+---
+'@taujs/vue': patch
+---
+
+R0-01: make `renderStream().done` crash-safe by default - a byte-identical drift-copy of the
+`@taujs/react` fix (`utils/Streaming.ts` is kept in sync by the drift guard).
+`createStreamController` pre-attaches a no-op rejection handler so an unobserved `done` can
+never crash the process (via `unhandledRejection` → `uncaughtException`) when a stream aborts
+fatally; consumers who `await done` still receive the error. Mirrored child-process regression
+test included.

--- a/.changeset/r0-02-benign-classification-react.md
+++ b/.changeset/r0-02-benign-classification-react.md
@@ -1,0 +1,16 @@
+---
+'@taujs/react': patch
+---
+
+R0-02: classify benign stream errors by ORIGIN, not by message substring. `isBenignStreamErr`
+now takes a `source: 'socket' | 'render'`. Only socket/writable-origin errors — by `err.code`
+(`ECONNRESET`, `EPIPE`, `ERR_STREAM_PREMATURE_CLOSE`, `ERR_STREAM_DESTROYED`), an `AbortError`
+name, or an exact node/undici socket message — are treated as benign client disconnects;
+render-origin errors are never benign by shape. An application error whose message merely
+contains "aborted"/"premature" (or carries a spoofed `code`) is no longer swallowed as a
+disconnect. The `DEFAULT_BENIGN_ERRORS` regex and `wireWritableGuards`' `benignErrorPattern`
+option are retired.
+
+Interim behaviour: a render-origin disconnect-lookalike now routes to the error path (fatal
+until the R1-01 streaming rework makes post-shell errors log-only) instead of being silently
+dropped — an observable error beats silent data loss.

--- a/.changeset/r0-02-benign-classification-server.md
+++ b/.changeset/r0-02-benign-classification-server.md
@@ -1,0 +1,14 @@
+---
+'@taujs/server': patch
+---
+
+R0-02: origin-aware benign-error classification in `HandleRender`. Replaces the broad
+`REGEX.BENIGN_NET_ERR` substring match (now removed) with a strict socket taxonomy — disconnect
+`code`, `AbortError` name, or exact node/undici socket message.
+
+Fixes a hung-request hole: a `renderSSR` failure is render-origin, so it is benign only when the
+request was actually aborted. A disconnect-shaped render error on a live request previously
+returned silently without sending a response (hanging the request); it now produces a real 500.
+Socket-origin paths (send failure, PassThrough/HTTP socket errors, stream `onError`) use the same
+strict socket check, so an application error whose message merely contains "aborted"/"premature"
+is no longer mistaken for a client disconnect.

--- a/.changeset/r0-02-benign-classification-vue.md
+++ b/.changeset/r0-02-benign-classification-vue.md
@@ -1,0 +1,12 @@
+---
+'@taujs/vue': patch
+---
+
+R0-02: origin-aware benign-error classification (byte-identical drift-copy of the `@taujs/react`
+`Streaming.ts` change). `isBenignStreamErr(err, source)` treats only socket/writable-origin
+errors (by `code`, `AbortError` name, or exact socket message) as benign disconnects; the sink's
+`destroy` path is render-origin and so is never benign by shape. Real client disconnects continue
+to be handled benignly via the writable guards ('socket') and the AbortSignal.
+
+Interim behaviour: a render-origin disconnect-lookalike now routes to the fatal path instead of
+being silently dropped.

--- a/.changeset/r0-03-logger-visibility-react.md
+++ b/.changeset/r0-03-logger-visibility-react.md
@@ -1,0 +1,15 @@
+---
+'@taujs/react': patch
+---
+
+R0-03: `enableDebug` now gates only log VERBOSITY, not error visibility. In `createUILogger`,
+`warn` and `error` always route — to the provided logger if any, else `console.warn`/
+`console.error`; only `log` is silenced when `enableDebug` is false.
+
+**Behaviour change:** production consumers that did not enable debug will now see renderer
+warnings and errors (data-promise rejections, stream/`onHead`/`onShellReady` callback errors,
+missing root element, recoverable hydration errors) on their logger/console. This is the intended
+observability fix (RFC S2), not a regression. Call sites explicitly wrapped in `if (enableDebug)`
+(e.g. the CSR-fallback "no initial data" notice) remain debug-only. Note: `benignAbort`'s warning
+on a client disconnect is now visible too and may be frequent under load — filter by level if
+undesired.

--- a/.changeset/r0-03-logger-visibility-vue.md
+++ b/.changeset/r0-03-logger-visibility-vue.md
@@ -1,0 +1,14 @@
+---
+'@taujs/vue': patch
+---
+
+R0-03: `enableDebug` now gates only log VERBOSITY, not error visibility (byte-identical
+drift-copy of the `@taujs/react` `Logger.ts` change). `createUILogger`'s `warn` and `error`
+always route — to the provided logger if any, else `console`; only `log` is silenced when
+`enableDebug` is false. `createVueErrorHandler` therefore now reports Vue errors to the logger
+even without debug enabled.
+
+**Behaviour change:** production consumers that did not enable debug will now see renderer
+warnings and errors (Vue errors, data-promise rejections, callback errors, missing root element,
+hydration warnings) on their logger/console. This is the intended observability fix (RFC S2), not
+a regression. Call sites explicitly wrapped in `if (enableDebug)` remain debug-only.

--- a/.changeset/r0-04-safe-inline-serialization.md
+++ b/.changeset/r0-04-safe-inline-serialization.md
@@ -1,0 +1,16 @@
+---
+'@taujs/server': patch
+---
+
+R0-04: eliminate the second process-crash class — a `JSON.stringify` failure thrown from the
+streaming `finish` listener, which runs on a stream tick OUTSIDE the request `try/catch`, so an
+uncaught throw becomes an `uncaughtException` → process exit.
+
+A single server-owned `serializeInlineData` boundary now serializes the inline
+`window.__INITIAL_DATA__` script for BOTH render modes. It escapes `<` (output is byte-identical
+to the previous inline expression for every valid input, so cached pages are unaffected), treats
+circular references, `BigInt`, a throwing `toJSON`, and `undefined` as deterministic failures, and
+NEVER throws. The SSR path throws an `AppError.internal` into the existing 500 machinery on
+failure; the streaming path logs, records (`recorder.failed`), and terminates the response
+deterministically without a data script — with the entire listener wrapped in a `try/catch` belt.
+The JSON data contract is unchanged (no new serializer dependency).

--- a/.changeset/r0-gate-recheck-callback-settlement.md
+++ b/.changeset/r0-gate-recheck-callback-settlement.md
@@ -1,0 +1,20 @@
+---
+'@taujs/server': patch
+'@taujs/react': patch
+'@taujs/vue': patch
+---
+
+R0 gate recheck fix — a throwing host `onError` callback can no longer veto stream
+cleanup/settlement:
+
+- **Renderers** (`@taujs/react`, `@taujs/vue`): every fatal path now routes through a single
+  helper that invokes the host `onError` under `try/catch` (the throw is logged and swallowed) and
+  ALWAYS runs `controller.fatalAbort`. So a throwing callback — or one called from a shell timer or
+  a writable EventEmitter listener — can neither skip cleanup / `done` settlement nor escape as an
+  `uncaughtException`; the ORIGINAL render error stays the rejection reason. React additionally no
+  longer double-fires `onError` for a fatal writable error.
+- **Server** (`@taujs/server`): the streaming render `onError` callback is now non-throwing for an
+  arbitrary/hostile `unknown`. Telemetry (message / kind / normalise / reason) is extracted through
+  safe, never-throwing helpers and belted, so formatting a hostile error (a throwing `message`
+  getter or `Symbol.toPrimitive`) can no longer prevent the deterministic response teardown
+  (500 / socket destroy).

--- a/.changeset/r0-gate-recheck2-react-coercion.md
+++ b/.changeset/r0-gate-recheck2-react-coercion.md
@@ -1,0 +1,11 @@
+---
+'@taujs/react': patch
+---
+
+R0 recheck-2 fix: React's `renderToPipeableStream` `onError` no longer coerces the error before
+reaching the crash-safe `failFatal` helper. It previously did `String((err)?.message ?? '')` at
+the top of the callback, so a hostile framework error (an object with a throwing `message` getter,
+or a `message` whose `Symbol.toPrimitive` throws) threw at that line BEFORE `failFatal` — skipping
+`controller.fatalAbort` (no cleanup, `done` never settled) and escaping React's asynchronous
+renderer callback as an uncaught exception. The raw error is now passed to the non-throwing UI
+logger and routed straight to `failFatal`, so settlement/cleanup always run with the original error.

--- a/.changeset/r0-gate-review-fixes.md
+++ b/.changeset/r0-gate-review-fixes.md
@@ -1,0 +1,20 @@
+---
+'@taujs/server': patch
+'@taujs/react': patch
+'@taujs/vue': patch
+---
+
+R0 gate-review fixes:
+
+- **Server:** the streaming render `onError` is the renderer's FATAL channel and is now trusted —
+  benign classification uses ACTUAL request-abort state, not the shape (`code`/`name`/exact
+  message) of an application-controlled error. This closes an origin-blind reclassification at the
+  renderer/server join: a render/data failure that happens to look like a disconnect (e.g.
+  `code: 'EPIPE'`, `name: 'AbortError'`, or the exact message `"aborted"`) now enters the failure
+  path and is recorded, instead of being silently treated as a client disconnect.
+- **Renderers** (`@taujs/react` upstream, `@taujs/vue` byte-identical drift-copy): the shared UI
+  logger is now NON-THROWING — formatting arbitrary `unknown` values (`BigInt`, circular objects,
+  symbols, a throwing `toJSON`/`Symbol.toPrimitive`) and calls to a user-provided logger method are
+  isolated, so a diagnostic on an error path can never break control flow. The stream controller
+  additionally cleans up and settles `done` even if its logger throws. Together these make R0-03's
+  always-on `warn`/`error` safe for arbitrary thrown values.

--- a/.changeset/r1-01-streaming-rework-react.md
+++ b/.changeset/r1-01-streaming-rework-react.md
@@ -36,8 +36,15 @@ response, and so render errors are classified honestly.
   re-entrant benign-cancel win the one-shot controller and RESOLVE `done`, silently downgrading a
   fatal — contradicting the `RenderStreamHandle` contract.
 
+- **Data deadline teardown is controller-owned, not `'close'`-dependent.** The route-data deadline is
+  disarmed by controller cleanup on any termination (its idempotent `disarm` is composed into the
+  cleanup), with the writable's `'close'` as a secondary signal — a writable created with
+  `emitClose: false` is destroyed without emitting `'close'`, so relying on that event would retain the
+  timer/listener until `dataTimeoutMs`.
+
 New public surface: `onRenderError` callback, `RenderErrorInfo` type, and the `dataTimeoutMs` stream
 option. `Writable` is kept a type-only import so this server-only renderer never pulls `node:stream`
-into a client bundle (mirrors `@taujs/vue`). Verified against real `react-dom/server` by a 17-test
+into a client bundle (mirrors `@taujs/vue`). Verified against real `react-dom/server` by an 18-test
 integration suite (post/pre-shell error timing, bounded gate, store-error, onHead, backpressure,
-abort-during-data-wait, undefined-data, suspend-forever liveness, re-entrant-abort, Suspense intact).
+abort-during-data-wait, undefined-data, suspend-forever liveness, re-entrant-abort, emitClose:false
+deadline teardown, Suspense intact).

--- a/.changeset/r1-01-streaming-rework-react.md
+++ b/.changeset/r1-01-streaming-rework-react.md
@@ -1,0 +1,34 @@
+---
+'@taujs/react': patch
+---
+
+R1-01: rework `renderStream` so late-resolving route data can no longer be lost or hang the
+response, and so render errors are classified honestly.
+
+- **Bounded end-gate.** React pipes into a delegating sink that forwards every write to the real
+  writable (React still drives backpressure against it) but DEFERS `end()` until the store's route
+  data has settled, raced against a new `dataTimeoutMs` option (default 30000ms). A never-settling
+  loader now fails the response deterministically instead of holding it — and its sockets/listeners —
+  open. Final data is delivered exactly once from the gate, replacing the previous thrown-thenable
+  retry dance. Fixes the silent data-loss class where the stream could finish serializing `{}` before
+  late data arrived.
+- **`onRenderError` (new, advisory, non-fatal).** React's `onError` fires for EVERY render error,
+  including post-shell boundary errors it recovers client-side. Treating that as fatal over-aborted
+  otherwise-recoverable responses. `onError` no longer fails the response; render errors are surfaced
+  through a new `onRenderError({ error, phase, recoverable })` callback (`phase` is observed timing,
+  never a fatality signal). Fatality stays with `onShellError` / shell-timeout / writable guards.
+- **`onHead` is now fatal.** It commits the response head and connects the sink; a throwing `onHead`
+  can no longer leave a half-committed response streaming into an unconsumed head.
+- **Internal store readiness.** `createSSRStore` attaches its settle promise under a package-internal
+  symbol (not part of the public `SSRStore<T>` type) so the gate can await readiness without a public
+  `ready` surface. The Suspense throw mechanism is unchanged.
+- **Abort-safe end-gate.** A client disconnect (or manual `abort()`) DURING the data wait now clears
+  the armed data-timer promptly, suppresses delivery, and never `end()`s a torn-down writable — so it
+  cannot leak the timer/closure or fire a spurious/duplicate fatal `onError` after settlement. A
+  loader that resolves to `undefined` becomes a clean fatal instead of a hung response.
+
+New public surface: `onRenderError` callback, `RenderErrorInfo` type, and the `dataTimeoutMs` stream
+option. `Writable` is kept a type-only import so this server-only renderer never pulls `node:stream`
+into a client bundle (mirrors `@taujs/vue`). Verified against real `react-dom/server` by a 15-test
+integration suite (post/pre-shell error timing, bounded gate, store-error, onHead, backpressure,
+abort-during-data-wait, undefined-data, Suspense intact).

--- a/.changeset/r1-01-streaming-rework-react.md
+++ b/.changeset/r1-01-streaming-rework-react.md
@@ -26,9 +26,18 @@ response, and so render errors are classified honestly.
   the armed data-timer promptly, suppresses delivery, and never `end()`s a torn-down writable — so it
   cannot leak the timer/closure or fire a spurious/duplicate fatal `onError` after settlement. A
   loader that resolves to `undefined` becomes a clean fatal instead of a hung response.
+- **Liveness is bounded even when a `<Suspense>` consumer suspends forever.** The route-data deadline
+  is now armed at shell commit, INDEPENDENT of React calling the sink's `end()`. A `useSSRStore()`
+  consumer suspending on never-settling data keeps React's stream open (so React never ends), but the
+  response is still bounded by `dataTimeoutMs` and torn down deterministically.
+- **A fatal always rejects `done`, even if the host `onError` re-entrantly aborts.** `failFatal` now
+  claims the terminal fatal state before invoking the (isolated) host callback. Previously, a host
+  `onError` that synchronously aborted the passed `AbortSignal` (as the server does) let the
+  re-entrant benign-cancel win the one-shot controller and RESOLVE `done`, silently downgrading a
+  fatal — contradicting the `RenderStreamHandle` contract.
 
 New public surface: `onRenderError` callback, `RenderErrorInfo` type, and the `dataTimeoutMs` stream
 option. `Writable` is kept a type-only import so this server-only renderer never pulls `node:stream`
-into a client bundle (mirrors `@taujs/vue`). Verified against real `react-dom/server` by a 15-test
+into a client bundle (mirrors `@taujs/vue`). Verified against real `react-dom/server` by a 17-test
 integration suite (post/pre-shell error timing, bounded gate, store-error, onHead, backpressure,
-abort-during-data-wait, undefined-data, Suspense intact).
+abort-during-data-wait, undefined-data, suspend-forever liveness, re-entrant-abort, Suspense intact).

--- a/.changeset/r1-01-streaming-rework-server.md
+++ b/.changeset/r1-01-streaming-rework-server.md
@@ -14,7 +14,9 @@ R1-01: add the additive `onRenderError` render-error contract and propagate the 
   JSDoc documents which callbacks are fatal vs advisory.
 - **AbortSignal into data context.** The request `AbortController.signal` is now threaded into the
   data-resolution context for both the SSR and streaming branches, so loaders can observe client
-  disconnects. Non-throwing error formatting on the logging path is preserved.
+  disconnects — proven end-to-end by a test that fires the streaming disconnect handler and asserts
+  the loader's `ctx.signal.aborted` flips. Non-throwing error formatting on the logging path is
+  preserved.
 
 `onRenderError` is OPTIONAL and non-breaking in either direction (unlike R0-01's `RenderStream`
 return-type change), so existing `RenderCallbacks` users are unaffected — `patch` per the R1-01

--- a/.changeset/r1-01-streaming-rework-server.md
+++ b/.changeset/r1-01-streaming-rework-server.md
@@ -1,0 +1,21 @@
+---
+'@taujs/server': patch
+---
+
+R1-01: add the additive `onRenderError` render-error contract and propagate the request
+`AbortSignal` into route data resolution.
+
+- **`RenderErrorInfo` + `onRenderError`** are added to the exported `RenderCallbacks` contract. This
+  is the advisory, NON-FATAL structured render-error channel (notably for post-shell boundary errors
+  the renderer recovers client-side). The server wires it to the request logger at `warn` with a
+  message keyed on `recoverable` (`phase`/`recoverable`/`clientRoot`/`url` as structured fields), so a
+  recoverable render error is surfaced without being escalated to a fatal response and without
+  double-logging a pre-shell error at `error` level (the fatal channel owns that). Callback-policy
+  JSDoc documents which callbacks are fatal vs advisory.
+- **AbortSignal into data context.** The request `AbortController.signal` is now threaded into the
+  data-resolution context for both the SSR and streaming branches, so loaders can observe client
+  disconnects. Non-throwing error formatting on the logging path is preserved.
+
+`onRenderError` is OPTIONAL and non-breaking in either direction (unlike R0-01's `RenderStream`
+return-type change), so existing `RenderCallbacks` users are unaffected — `patch` per the R1-01
+changeset plan, keeping `@taujs/server` below 1.0.0.

--- a/.changeset/r2-01-fix-reporter-useid.md
+++ b/.changeset/r2-01-fix-reporter-useid.md
@@ -1,0 +1,12 @@
+---
+'@taujs/react': patch
+---
+
+Fix: the internal hydration commit reporter now WRAPS the app instead of sitting beside it.
+
+React's `useId` is tree-position sensitive: a SIBLING of the app shifts every `useId` value in the app,
+so the sibling reporter introduced with the hydration-observability work made the client tree's ids
+diverge from the SSR markup (which renders the app without it) - a hydration mismatch for any app using
+`useId`. The reporter is now a pass-through wrapper: it adds tree DEPTH only (which `useId` ignores) and
+no extra DOM, so a `useId` app hydrates with no mismatch. First-commit detection (onSuccess /
+hydration:success) is unchanged.

--- a/.changeset/r2-01-hydration-observability.md
+++ b/.changeset/r2-01-hydration-observability.md
@@ -22,10 +22,11 @@ R2-01: make client-side render failures observable and the success signal honest
 - **Missing root** now routes to `onHydrationError` + a `hydration:error` beacon (error-without-start,
   vue precedent) instead of logging and returning silently.
 - **Global error surfacing preserved.** Overriding `onUncaughtError` replaces React's default, which
-  re-surfaces uncaught errors globally (`reportError` → a `window` `'error'` event). `onUncaughtError`
-  now calls `reportError` so `window.onerror`-based monitoring (Sentry/Bugsnag globalHandlers) keeps
-  seeing uncaught render errors — including after hydration has settled — on top of the taujs bootstrap
-  routing.
+  re-surfaces uncaught errors globally. `onUncaughtError` now mirrors React's `reportGlobalError`:
+  prefer `globalThis.reportError`, else dispatch a cancelable `window` `ErrorEvent` — so
+  `window.onerror`-based monitoring (Sentry/Bugsnag globalHandlers) keeps seeing uncaught render
+  errors — including after hydration has settled, and on runtimes/older browsers without
+  `reportError` — on top of the taujs bootstrap routing.
 - **Lifecycle callbacks are isolated observers.** `onStart` / `onSuccess` / `onHydrationError` throws
   are logged and swallowed. This is load-bearing: `onSuccess` runs inside the reporter's React effect
   and `onHydrationError` inside the root `onUncaughtError` handler, so an un-isolated throw would enter

--- a/.changeset/r2-01-hydration-observability.md
+++ b/.changeset/r2-01-hydration-observability.md
@@ -1,0 +1,37 @@
+---
+'@taujs/react': patch
+---
+
+R2-01: make client-side render failures observable and the success signal honest.
+
+- **One root-error adapter, wired to BOTH roots.** A single adapter object is passed to `hydrateRoot`
+  AND `createRoot`: `onUncaughtError` (a render error with no boundary — the real, ASYNC client-error
+  channel that a sync try/catch around `hydrateRoot`/`createRoot` cannot see) routes to a single
+  failure path; `onCaughtError` (boundary-handled) and `onRecoverableError` (auto-recovered mismatch)
+  are logged only, never treated as bootstrap failures. Previously the hydrate path had only a
+  sync-only try/catch (which never fired for real async render errors) and the CSR path had NO error
+  routing at all.
+- **Provable success.** `onSuccess` / `hydration:success` now fire on the FIRST ROOT COMMIT (an
+  internal reporter effect), not synchronously when `hydrateRoot` returns (React root work is async,
+  so the old signal was false). Documented semantics: "first root commit — does NOT claim every
+  `<Suspense>` boundary hydrated". This fires slightly LATER than before (at commit).
+- **CSR path now reports.** A CSR-fallback mount now emits `onSuccess` on commit and `onHydrationError`
+  on an uncaught render error — but NO beacon events (a CSR mount is not a hydration; vue parity).
+- **Single settlement.** Exactly one of `onSuccess` | `onHydrationError` fires per `hydrateApp` call
+  (first commit vs first uncaught error wins); later signals are telemetry, logged only.
+- **Missing root** now routes to `onHydrationError` + a `hydration:error` beacon (error-without-start,
+  vue precedent) instead of logging and returning silently.
+- **Global error surfacing preserved.** Overriding `onUncaughtError` replaces React's default, which
+  re-surfaces uncaught errors globally (`reportError` → a `window` `'error'` event). `onUncaughtError`
+  now calls `reportError` so `window.onerror`-based monitoring (Sentry/Bugsnag globalHandlers) keeps
+  seeing uncaught render errors — including after hydration has settled — on top of the taujs bootstrap
+  routing.
+- **Lifecycle callbacks are isolated observers.** `onStart` / `onSuccess` / `onHydrationError` throws
+  are logged and swallowed. This is load-bearing: `onSuccess` runs inside the reporter's React effect
+  and `onHydrationError` inside the root `onUncaughtError` handler, so an un-isolated throw would enter
+  React's root-error domain (a throwing `onSuccess` could tear the committed root down while success
+  had already "won" settlement). An observability hook can no longer destroy the root it observes.
+
+Beacon event names are unchanged (`hydration:start|success|error`); `emitDevHook` stays
+dev-only/no-throw. `HydrateAppOptions` is fully JSDoc'd. Verified against real `react-dom/client` in
+jsdom (async error timing, first-commit success, StrictMode single-fire, mismatch recoverability).

--- a/.changeset/r2-02-bootstrap-attr-escape-server.md
+++ b/.changeset/r2-02-bootstrap-attr-escape-server.md
@@ -1,0 +1,12 @@
+---
+'@taujs/server': patch
+---
+
+R2-02 (SEC2): attribute-escape the bootstrap-module `src` at both server emission sites.
+
+A new server-local `escapeHtmlAttribute` (the server is renderer-agnostic and does not import the
+renderers' `escapeHtml`) now escapes the config-controlled bootstrap-module URL where it is
+interpolated into a `<script … src="…">` tag — the SSR-path tag in `HandleRender` AND
+`injectBootstrapModule` in `Templates` (used by the not-found path). Defence-in-depth: the value is
+config-controlled, so a normal module URL is unchanged; this closes the raw-attribute interpolation.
+`patch` per the versioning cap (no server major/minor for this).

--- a/.changeset/r2-02-escapehtml-react.md
+++ b/.changeset/r2-02-escapehtml-react.md
@@ -1,0 +1,16 @@
+---
+'@taujs/react': minor
+---
+
+R2-02: export `escapeHtml` and document the `headContent` raw-HTML contract.
+
+- **New export `escapeHtml(value)`** (from the package root) — escapes the five HTML-sensitive
+  characters (`& < > " '` → `&amp; &lt; &gt; &quot; &#39;`), so it is safe for both element text AND
+  attribute values (single- and double-quoted). Non-string input is coerced via `String(value)`.
+  Ships the helper the head-management guide previously told users to hand-roll (and whose hand-rolled
+  version missed `'`).
+- **`headContent` contract JSDoc** on the `createRenderer` option and `HeadContext`: the return value
+  is written into `<head>` as RAW HTML and is intentionally NOT auto-escaped, so any value
+  interpolated from services/user input must be escaped with `escapeHtml`.
+
+No render-path behaviour change. `minor` for the additive export.

--- a/.changeset/r2-02-escapehtml-vue.md
+++ b/.changeset/r2-02-escapehtml-vue.md
@@ -1,0 +1,15 @@
+---
+'@taujs/vue': minor
+---
+
+R2-02: export `escapeHtml` and document the `headContent` raw-HTML contract.
+
+- **New export `escapeHtml(value)`** (from the package root) — escapes the five HTML-sensitive
+  characters (`& < > " '` → `&amp; &lt; &gt; &quot; &#39;`), text- AND attribute-safe (single- and
+  double-quoted). Non-string input is coerced via `String(value)`. Byte-identical to `@taujs/react`'s
+  helper (enforced by the utils drift guard).
+- **`headContent` contract JSDoc** on the `createRenderer` option and `HeadContext`: the return value
+  is written into `<head>` as RAW HTML and is intentionally NOT auto-escaped, so any value
+  interpolated from services/user input must be escaped with `escapeHtml`.
+
+No render-path behaviour change. `minor` for the additive export.

--- a/.changeset/r2-03-vue-hydration-twin.md
+++ b/.changeset/r2-03-vue-hydration-twin.md
@@ -1,0 +1,18 @@
+---
+'@taujs/vue': patch
+---
+
+R2-03: close the two vue-side sweep items (twin of react's R2-01/R2-02).
+
+- **Missing root is now reported.** A missing root element in `hydrateApp`'s bootstrap previously
+  logged and returned silently; it now also emits a `hydration:error` beacon and calls
+  `onHydrationError` (mirroring react's R2-01). It emits an error WITHOUT a preceding `hydration:start`
+  (hydration never began; vue already does this for a setupApp failure). The `onHydrationError` call is
+  isolated so a throwing observer cannot escape bootstrap.
+- **Bootstrap attributes are escaped (SEC2).** The manually-written streaming bootstrap `<script>` now
+  passes its `src` (bootstrapModules) and `nonce` (cspNonce) through the shared `escapeHtml`.
+  Defence-in-depth: `escapeHtml` is a no-op on clean module URLs and base64 nonces, so the tag is
+  byte-unchanged for valid input.
+
+No behaviour change on the success path. Vue's existing hydration-phase/single-settlement machinery is
+unchanged (the missing-root case precedes it).

--- a/.changeset/r2-04-identifier-prefix.md
+++ b/.changeset/r2-04-identifier-prefix.md
@@ -1,0 +1,15 @@
+---
+'@taujs/react': patch
+---
+
+R2-04: plumb React's `identifierPrefix` through the renderer and hydrator so multi-root pages get
+stable, collision-free `useId` values.
+
+- `createRenderer({ identifierPrefix })` is passed to `renderToString` (SSR) and
+  `renderToPipeableStream` (streaming).
+- `hydrateApp({ identifierPrefix })` is passed to BOTH `hydrateRoot` and the CSR-fallback `createRoot`.
+
+It must be identical on the server and client for a given root (React requires this, or `useId`
+hydration mismatches). Set it when rendering more than one taujs root on a page (the app-per-boundary
+/ micro-frontend model) so each root's ids are disjoint. Additive option, no behaviour change when
+unset. Both surfaces are JSDoc'd; a server-derived default from `appId` is left as an R3-03 note.

--- a/.changeset/r2-gate-vue-lifecycle-fixes.md
+++ b/.changeset/r2-gate-vue-lifecycle-fixes.md
@@ -1,0 +1,25 @@
+---
+'@taujs/vue': patch
+---
+
+Gate R2 review: fix four Vue lifecycle defects that the React hardening work had already fixed but
+which were never backported. No change on any success path.
+
+- **A fatal stream error can no longer be downgraded to a benign completion.** `fail` now claims the
+  terminal fatal state (`controller.fatalAbort`) BEFORE invoking the host `onError`. The server's
+  `onError` synchronously calls `ac.abort()`, and that same `AbortSignal` is wired to the renderer's
+  benign-cancel path, so the callback-first ordering let the re-entrant benign abort win the one-shot
+  controller and RESOLVE `done` for a fatal render failure, breaking the `RenderStreamHandle` contract.
+- **A throwing `onHead` is now fatal, not advisory.** `onHead` is operationally required: at the server
+  boundary it commits the response prefix and connects the renderer's stream to the HTTP response. Vue
+  previously warned and carried on, writing application bytes into an unconnected sink and yielding a
+  malformed "successful" response with no head or body. It now enters the fatal path, stops before
+  rendering, and `done` rejects with the callback error (parity with React).
+- **Hydration observers are isolated.** `onStart` / `onSuccess` / `onHydrationError` throws are logged
+  and swallowed everywhere (hydrate, CSR, missing-root). Previously a throwing `onStart` was misread as
+  a hydration failure and PREVENTED the app mounting; a throwing `onSuccess` manufactured a
+  `hydration:error` for an attempt that had already emitted `hydration:success`; and a throwing
+  `onHydrationError` escaped `hydrateApp` from inside a catch block.
+- **Final-data observers are isolated independently.** A throwing `onAllReady` or `onFinish` no longer
+  reaches the data-rejection path (turning resolved data plus a completed render into a fatal stream
+  failure), and a throwing `onAllReady` no longer suppresses the legacy `onFinish` alias.

--- a/.changeset/r3-01-conformance-packaging-react.md
+++ b/.changeset/r3-01-conformance-packaging-react.md
@@ -1,0 +1,30 @@
+---
+'@taujs/react': patch
+---
+
+R3-01: contract conformance test, and fix a peer contract that broke `npm install` for scaffolded apps.
+
+- **Fixes a broken install.** The `@vitejs/plugin-react` peer was `^5.1.2` while `create-taujs`
+  scaffolds `^4.6.0`, so a freshly generated React app hard-failed `npm install` with ERESOLVE. The
+  range is now `^4.6.0 || ^5.0.0`. NB `peerDependenciesMeta.optional` permits a peer to be ABSENT; it
+  does NOT relax its version range when the peer is present, so marking tooling optional did not fix
+  this on its own.
+- **Peer contract corrected.** Runtime peers `react` / `react-dom` are now REQUIRED (they were marked
+  optional, yet the root entry imports them) with an honest `^19.0.0` floor - the previous `^19.2.3`
+  was a devDependency mirror that needlessly blocked the whole React 19.0.x and 19.1.x lines. Tooling
+  peers (`vite`, `typescript`, `@vitejs/plugin-react`) are now OPTIONAL, with `vite` lowered to `^7.0.0`
+  (the old `^7.3.1` floor rejected vite 7.2.x even though the tooling is optional).
+- **Types the published `.d.ts` needs are now declared** as optional peers: `@types/react`,
+  `@types/react-dom` (the `react` package ships no types, and `dist/index.d.ts` imports from it) and
+  `@types/node` (the root types reference `node:stream`). Previously undeclared, so a TypeScript
+  consumer could silently degrade `React` to `any` under `skipLibCheck`.
+- **Contract conformance test** (`src/test/contract.test-d.ts`, tsc-enforced via `typecheck`, outside
+  the vitest glob): proves `createRenderer(...)` satisfies `@taujs/server`'s `RenderModule` with ZERO
+  casts, and pins the `renderStream` RETURN shape against `RenderStreamHandle` in both directions -
+  function assignability alone can hide a capability gap through width-subtyping. Verified to bite:
+  narrowing a param, dropping `done` from the renderer's return, and weakening the contract itself
+  (making `done` optional) each fail `typecheck`; the last is caught ONLY by the return-shape
+  assertions, which the plain module assertion tolerates.
+- `"sideEffects": false` and a real `description` (was a placeholder).
+
+No runtime source change.

--- a/.changeset/r3-01-conformance-packaging-vue.md
+++ b/.changeset/r3-01-conformance-packaging-vue.md
@@ -1,0 +1,21 @@
+---
+'@taujs/vue': patch
+---
+
+R3-01: peer contract corrections and a strengthened contract conformance test.
+
+- **Peer contract corrected.** `vue` is now a REQUIRED peer alongside `@vue/server-renderer` (it was
+  marked optional, yet the root entry imports it). Tooling peers (`vite`, `typescript`,
+  `@vitejs/plugin-vue`) remain OPTIONAL, with ranges widened so they no longer reject working setups:
+  `vite` `^7.0.0` (was `^7.1.9`), `typescript` `^5.5.0`, `@vitejs/plugin-vue` `^5.0.0 || ^6.0.0`. NB
+  `peerDependenciesMeta.optional` permits a peer to be ABSENT; it does NOT relax its version range when
+  the peer is present.
+- **`@types/node` is now declared** as an optional peer - the published root `.d.ts` references
+  `node:stream` (the `renderStream` sink), which was previously an undeclared type dependency.
+- `"sideEffects": false`.
+- **Contract test strengthened** (test-only): `contract.test-d.ts` now pins the `renderStream` RETURN
+  shape against `RenderStreamHandle` in both directions, derived from the CONCRETE renderer output
+  rather than the contract-typed alias (deriving it from the annotated module made the assertion a
+  tautology). Catches a contract weakening the plain module assertion tolerates.
+
+No runtime source change.

--- a/.changeset/r3-02-react-hygiene.md
+++ b/.changeset/r3-02-react-hygiene.md
@@ -1,0 +1,20 @@
+---
+'@taujs/react': patch
+---
+
+R3-02: three contained hygiene fixes in the store and utils.
+
+- **Error normalisation.** A rejected data load that threw a STRING produced a quoted message
+  (`'"boom"'`), and one that threw a CIRCULAR object made `JSON.stringify` THROW inside the store's
+  error handler - turning a data-load failure into an unhandled rejection. The store now normalises via
+  the same pattern as `@taujs/vue`: an `Error` passes through unchanged, a string keeps its message
+  unquoted, an object is JSON-stringified, and an unserialisable value falls back to `String(error)`
+  without throwing.
+- **`useSSRStore` reads the store directly.** Removed `useMemo(() => deferred, [deferred])` (an identity
+  memo - a no-op by definition) and `useDeferredValue`, which was introduced with no stated rationale, is
+  relied on by no test, has no `@taujs/vue` equivalent, and measurably cost an extra render pass per
+  update while serving one-render-stale data. Consumers now observe `setData` immediately. The Suspense
+  path is unaffected (suspension happens inside `useSyncExternalStore`, before any value reaches the
+  removed hooks).
+- Deleted the dead `utils/index.ts` barrel (`export * from './'` - self-referential, exported nothing,
+  imported by nothing).

--- a/.changeset/r3-05-entry-hygiene-react.md
+++ b/.changeset/r3-05-entry-hygiene-react.md
@@ -1,0 +1,13 @@
+---
+'@taujs/react': patch
+---
+
+R3-05 (Q6): client bundles no longer include `react-dom/server`. The dist previously shipped as a
+single module whose top-level imports coupled the SSR renderer into the client entry, so every
+production browser bundle of `import { hydrateApp } from '@taujs/react'` retained react-dom's CJS
+browser server build (measured: -49% raw / -48% gzip after the fix, with `react-dom/server`
+provably absent from the module graph). The dist now preserves the source module graph (explicit
+`.js` specifiers + unbundled build); the public API, exports map, and `create-taujs` scaffold are
+unchanged - no consumer migration needed. Durable guards added: a module-graph absence test that
+builds a real production browser bundle, and a specifier-extension lint test. Also documents the
+official `useSyncExternalStore` suspension caveat on `useSSRStore` (R3-03 §0).

--- a/.changeset/r3-05-entry-hygiene-vue.md
+++ b/.changeset/r3-05-entry-hygiene-vue.md
@@ -1,0 +1,10 @@
+---
+'@taujs/vue': patch
+---
+
+R3-05 (Q6): the dist now preserves the source module graph (explicit `.js` specifiers + unbundled
+build), matching `@taujs/react`. For vue this is structural hardening, not a defect fix - client
+bundles already tree-shook `@vue/server-renderer` to ~0 bytes; the unbundled graph removes the
+latent dependence on that build staying tree-shakeable. A module-graph guard test now pins the
+absence (builds a real production browser bundle of the client entry and asserts zero rendered
+`@vue/server-renderer` bytes), plus a specifier-extension lint test. No API change.

--- a/.changeset/r3-06-prerender-policy-a.md
+++ b/.changeset/r3-06-prerender-policy-a.md
@@ -1,0 +1,15 @@
+---
+'@taujs/react': patch
+---
+
+R3-06 (Q3, Policy A): the `ssr` strategy now renders COMPLETE HTML via `prerenderToNodeStream`
+instead of `renderToString`. Previously any `React.lazy`/`use()` subtree was SILENTLY replaced by
+its Suspense fallback plus a client-render marker, with zero diagnostics - the page lost its SSR
+content. Behaviour change to note: a route that was accidentally fast because it silently dropped
+its lazy content now correctly waits for it, bounded by the new `ssrOptions.prerenderTimeoutMs`
+(default 10s; `0` = wait forever). On deadline expiry a page whose shell completed is served with
+its unfinished boundaries in the fallback state (the client completes them after hydration; an
+advisory warning is logged) and a page whose shell never completed fails the request instead of
+serving a blank page. Output for non-suspending trees is byte-identical to `renderToString`
+(pinned by test), route data is unaffected (the server resolves it before rendering), and the
+`RenderSSR` server contract is untouched. Requires no consumer migration.

--- a/.changeset/r3-06-prerender-policy-a.md
+++ b/.changeset/r3-06-prerender-policy-a.md
@@ -13,3 +13,10 @@ advisory warning is logged) and a page whose shell never completed fails the req
 serving a blank page. Output for non-suspending trees is byte-identical to `renderToString`
 (pinned by test), route data is unaffected (the server resolves it before rendering), and the
 `RenderSSR` server contract is untouched. Requires no consumer migration.
+
+Gate-review hardening: `ssrOptions.prerenderTimeoutMs` is validated at `createRenderer` (a
+positive finite number, `0`, or `Infinity`; anything else throws a `TypeError` instead of
+silently waiting forever), and the prerender API is imported from the CONDITIONAL
+`react-dom/static` subpath so browser bundlers resolve a browser-safe build - the earlier
+Node-only subpath produced browser-compatibility warnings (and could hard-fail stricter
+bundlers) even though final bundle bytes were clean.

--- a/.changeset/r3-07-vue-ready-hardening.md
+++ b/.changeset/r3-07-vue-ready-hardening.md
@@ -1,0 +1,11 @@
+---
+'@taujs/vue': patch
+---
+
+R3-07 (S1): harden the public `ready` promise against unhandled rejections. A user-constructed
+store (`createSSRStore` is public API) whose loader rejects and whose `ready` is never observed
+previously produced an `unhandledRejection` - a process-terminating crash under Node's default
+mode. A no-op rejection handler is now pre-attached at creation; `await store.ready` still
+rejects with the loader error for consumers who observe it, and a recovering `setData` leaves
+`ready` rejected (promises settle once - now pinned by tests). Regression proven in a child
+process under default rejection flags (the R0-01 methodology).

--- a/.changeset/r3-08-setdata-supersedes-react.md
+++ b/.changeset/r3-08-setdata-supersedes-react.md
@@ -1,0 +1,11 @@
+---
+'@taujs/react': patch
+---
+
+R3-08 (S2): an explicit `setData` now supersedes the store's in-flight initial promise. Previously
+a LATE loader rejection flipped the store to `'error'`, made `getSnapshot` throw, and tore down a
+tree already committed with the explicitly-set data (uncaught render error, DOM wiped); a late
+loader resolution silently overwrote the explicit value. Both settlements are now ignored once
+`setData` has run. Unreachable via taujs's own paths (`hydrateApp` builds the store from resolved
+data) - this hardens the public `createSSRStore`. The internal readiness promise still settles
+when the loader does, so the streaming end-gate is unaffected (pinned by test).

--- a/.changeset/r3-08-setdata-supersedes-vue.md
+++ b/.changeset/r3-08-setdata-supersedes-vue.md
@@ -1,0 +1,9 @@
+---
+'@taujs/vue': patch
+---
+
+R3-08 (S2, twin of the react fix): an explicit `setData` now supersedes the store's in-flight
+initial promise. Previously a LATE loader rejection flipped `status` to `'error'` (contradicting
+the explicitly-set data in every reactive consumer, with a misleading "Failed to load initial
+data" log) and a late loader resolution silently overwrote `data.value`. Both settlements are now
+ignored once `setData` has run. `ready` semantics are unchanged (`setData` already resolved it).

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@taujs/react",
   "version": "0.2.1",
-  "description": "taujs | τjs",
+  "description": "Framework-agnostic React SSR primitives - transport layer for server-side rendering and hydration",
   "author": "Aoede <taujs@aoede.uk.net> (https://www.aoede.uk.net)",
   "license": "MIT",
   "homepage": "https://taujs.dev/",
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.4",
     "@babel/preset-typescript": "^7.24.7",
+    "@taujs/server": "workspace:*",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.1.0",
     "@types/node": "^24.0.7",
@@ -59,17 +60,32 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
-    "@vitejs/plugin-react": "^5.1.2",
-    "react": "^19.2.3",
-    "react-dom": "^19.2.3",
-    "typescript": "^5.5.4",
-    "vite": "^7.3.1"
+    "@vitejs/plugin-react": "^4.6.0 || ^5.0.0",
+    "@types/node": ">=20",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "typescript": "^5.5.0",
+    "vite": "^7.0.0"
   },
   "peerDependenciesMeta": {
-    "react": {
+    "@vitejs/plugin-react": {
       "optional": true
     },
-    "react-dom": {
+    "@types/node": {
+      "optional": true
+    },
+    "@types/react": {
+      "optional": true
+    },
+    "@types/react-dom": {
+      "optional": true
+    },
+    "typescript": {
+      "optional": true
+    },
+    "vite": {
       "optional": true
     }
   },
@@ -82,5 +98,6 @@
     "format": "prettier --write .",
     "check-format": "prettier --check .",
     "check-exports": "attw --pack . --profile esm-only"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/react/src/SSRDataStore.tsx
+++ b/packages/react/src/SSRDataStore.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useSyncExternalStore, useDeferredValue, useMemo } from 'react';
+import React, { createContext, useContext, useSyncExternalStore } from 'react';
 
 import { STORE_READINESS } from './internal';
 
@@ -11,6 +11,21 @@ export type SSRStore<T> = {
   readonly lastError?: Error;
 };
 
+/**
+ * Normalise a thrown value into an Error (pattern parity with @taujs/vue's store; these files are not
+ * drift-guarded, so the PATTERN matches rather than the bytes). The previous
+ * `new Error(String(JSON.stringify(error)))` quoted a thrown string ("boom" -> '"boom"') and THREW on a
+ * circular object, turning a data-load failure into an unhandled rejection.
+ */
+function normaliseError(error: unknown): Error {
+  if (error instanceof Error) return error;
+  try {
+    return new Error(typeof error === 'string' ? error : JSON.stringify(error));
+  } catch {
+    return new Error(String(error));
+  }
+}
+
 export function createSSRStore<T>(initialDataOrPromise: T | Promise<T> | (() => Promise<T>)): SSRStore<T> {
   let currentData: T | undefined;
   let status: 'pending' | 'success' | 'error';
@@ -22,9 +37,10 @@ export function createSSRStore<T>(initialDataOrPromise: T | Promise<T> | (() => 
   const notify = () => subscribers.forEach((cb) => cb());
 
   const handleError = (error: unknown) => {
-    const normalised = error instanceof Error ? error : new Error(String(JSON.stringify(error)));
-    console.error('Failed to load initial data:', normalised);
-    lastError = normalised;
+    const e = normaliseError(error);
+    // NOTE: keep this console.error: it's useful in environments without logger wiring.
+    console.error('Failed to load initial data:', e);
+    lastError = e;
     status = 'error';
     notify();
   };
@@ -115,8 +131,10 @@ export const useSSRStore = <T,>(): T => {
 
   if (!store) throw new Error('useSSRStore must be used within a SSRStoreProvider');
 
-  const syncVal = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getServerSnapshot);
-  const deferred = useDeferredValue(syncVal);
-
-  return useMemo(() => deferred, [deferred]);
+  // R3-02 (C3): read the store directly. The previous `useMemo(() => deferred, [deferred])` was an
+  // identity memo (a no-op by definition), and `useDeferredValue` was introduced with no stated
+  // rationale, is depended on by no test, has no @taujs/vue equivalent, and MEASURABLY cost an extra
+  // render pass per update while serving one-render-stale data from a store whose consumers want the
+  // current value. Both removed; see decisions.md.
+  return useSyncExternalStore(store.subscribe, store.getSnapshot, store.getServerSnapshot);
 };

--- a/packages/react/src/SSRDataStore.tsx
+++ b/packages/react/src/SSRDataStore.tsx
@@ -1,5 +1,7 @@
 import React, { createContext, useContext, useSyncExternalStore, useDeferredValue, useMemo } from 'react';
 
+import { STORE_READINESS } from './internal';
+
 export type SSRStore<T> = {
   getSnapshot: () => T;
   getServerSnapshot: () => T;
@@ -82,7 +84,7 @@ export function createSSRStore<T>(initialDataOrPromise: T | Promise<T> | (() => 
     return currentData;
   };
 
-  return {
+  const store: SSRStore<T> = {
     getSnapshot,
     getServerSnapshot,
     setData,
@@ -94,6 +96,12 @@ export function createSSRStore<T>(initialDataOrPromise: T | Promise<T> | (() => 
       return lastError;
     },
   };
+
+  // R1-01: attach package-internal readiness for the streaming end-gate WITHOUT adding it to the
+  // public SSRStore<T> type (design 1 / decisions item 10).
+  (store as Record<symbol, unknown>)[STORE_READINESS] = serverDataPromise;
+
+  return store;
 }
 
 const SSRStoreContext = createContext<SSRStore<any> | null>(null);

--- a/packages/react/src/SSRDataStore.tsx
+++ b/packages/react/src/SSRDataStore.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useSyncExternalStore } from 'react';
 
-import { STORE_READINESS } from './internal';
+import { STORE_READINESS } from './internal.js';
 
 export type SSRStore<T> = {
   getSnapshot: () => T;
@@ -126,6 +126,17 @@ export const SSRStoreProvider = <T,>({ store, children }: React.PropsWithChildre
   <SSRStoreContext.Provider value={store}>{children}</SSRStoreContext.Provider>
 );
 
+/**
+ * Read the current store value. Suspends while the initial load is pending; throws on load error.
+ *
+ * Caveat (react.dev, `useSyncExternalStore`): a render triggered by a store MUTATION cannot be a
+ * non-blocking Transition. If the render caused by a `setData` suspends through app-level
+ * constructs derived from the store value (a `React.lazy` component selected by it, or a `use()`
+ * promise built from it), React replaces already-revealed content with the nearest Suspense
+ * fallback. After hydration, drive suspension-prone UI from component state inside
+ * `startTransition` rather than directly from store values.
+ * See https://react.dev/reference/react/useSyncExternalStore#caveats (R3-03 §0 ruling).
+ */
 export const useSSRStore = <T,>(): T => {
   const store = useContext(SSRStoreContext) as SSRStore<T> | null;
 

--- a/packages/react/src/SSRDataStore.tsx
+++ b/packages/react/src/SSRDataStore.tsx
@@ -32,6 +32,14 @@ export function createSSRStore<T>(initialDataOrPromise: T | Promise<T> | (() => 
   let lastError: Error | undefined;
   let serverDataPromise: Promise<void>;
 
+  // R3-08 (S2): an explicit `setData` SUPERSEDES the in-flight initial promise. Without this, a
+  // late loader REJECTION flipped status to 'error' and tore down a committed tree (getSnapshot
+  // starts throwing), and a late loader RESOLUTION silently overwrote the explicitly-set data.
+  // Unreachable via taujs's own paths (hydrateApp builds from resolved data) — this hardens the
+  // public `createSSRStore`. The internal readiness promise still settles when the loader does
+  // (the guarded continuations resolve the chain), so the streaming end-gate is unaffected.
+  let superseded = false;
+
   const subscribers = new Set<() => void>();
 
   const notify = () => subscribers.forEach((cb) => cb());
@@ -45,26 +53,26 @@ export function createSSRStore<T>(initialDataOrPromise: T | Promise<T> | (() => 
     notify();
   };
 
+  const loaderResolved = (data: T) => {
+    if (superseded) return;
+    currentData = data;
+    status = 'success';
+    notify();
+  };
+
+  const loaderRejected = (error: unknown) => {
+    if (superseded) return;
+    handleError(error);
+  };
+
   if (typeof initialDataOrPromise === 'function') {
     // Lazy promise
     status = 'pending';
-    serverDataPromise = (initialDataOrPromise as () => Promise<T>)()
-      .then((data) => {
-        currentData = data;
-        status = 'success';
-        notify();
-      })
-      .catch(handleError);
+    serverDataPromise = (initialDataOrPromise as () => Promise<T>)().then(loaderResolved).catch(loaderRejected);
   } else if (initialDataOrPromise instanceof Promise) {
     // Immediate promise
     status = 'pending';
-    serverDataPromise = initialDataOrPromise
-      .then((data) => {
-        currentData = data;
-        status = 'success';
-        notify();
-      })
-      .catch(handleError);
+    serverDataPromise = initialDataOrPromise.then(loaderResolved).catch(loaderRejected);
   } else {
     // Raw data
     currentData = initialDataOrPromise;
@@ -72,7 +80,13 @@ export function createSSRStore<T>(initialDataOrPromise: T | Promise<T> | (() => 
     serverDataPromise = Promise.resolve();
   }
 
+  /**
+   * Explicitly set the store value. Supersedes the in-flight initial promise: a later settlement
+   * of that promise (success or failure) is ignored — it can neither overwrite this value nor
+   * flip the store into an error state (R3-08).
+   */
   const setData = (newData: T) => {
+    superseded = true;
     currentData = newData;
     status = 'success';
     notify();

--- a/packages/react/src/SSRHydration.tsx
+++ b/packages/react/src/SSRHydration.tsx
@@ -20,6 +20,30 @@ const emitDevHook = (event: 'hydration:start' | 'hydration:success' | 'hydration
   }
 };
 
+// React 19 root error-info shapes (narrowed from @types/react-dom). Descriptive only.
+type RootErrorInfo = { componentStack?: string };
+
+/**
+ * Options for {@link hydrateApp}.
+ *
+ * Lifecycle signals (R2-01):
+ * - `onStart` — fires once when hydration BEGINS (hydrate path only; paired with the
+ *   `hydration:start` dev beacon, internal-first). NOT fired on the CSR-fallback path.
+ * - `onSuccess` — fires once on the FIRST ROOT COMMIT (a component effect, not `hydrateRoot`'s
+ *   return). It proves the root committed; it does NOT claim every `<Suspense>` boundary hydrated.
+ *   On the hydrate path it is paired with the `hydration:success` beacon (internal-first); on the
+ *   CSR-fallback path it fires WITHOUT any beacon (a CSR mount is not a hydration — vue parity).
+ * - `onHydrationError` — fires once for a bootstrap failure: an UNCAUGHT client render error
+ *   (React's async `onUncaughtError` — a throwing component with no error boundary), a synchronous
+ *   setup/invalid-container throw, or a missing root element. On the hydrate path it is paired with
+ *   the `hydration:error` beacon; on the CSR path it fires WITHOUT a beacon.
+ *
+ * Single settlement: EXACTLY ONE of `onSuccess` | `onHydrationError` fires per `hydrateApp` call.
+ * Whichever event happens first (first commit vs first uncaught error) wins; any later signal is
+ * telemetry — logged only, never re-fired. Errors handled by an app error boundary
+ * (`onCaughtError`) and auto-recovered mismatches (`onRecoverableError`, e.g. server/client HTML
+ * mismatch) are NOT bootstrap failures — they are logged (`error`/`warn`) and never settle.
+ */
 export type HydrateAppOptions<T> = {
   appComponent: React.ReactElement;
   rootElementId?: string;
@@ -29,6 +53,18 @@ export type HydrateAppOptions<T> = {
   onHydrationError?: (err: unknown) => void;
   onStart?: () => void;
   onSuccess?: () => void;
+};
+
+// Internal reporter (design 2): renders no DOM; its mount effect fires once after the first root
+// commit. Mounted INSIDE the provider wrapper, outside user control, so a committed root is provable
+// on both the hydrate and CSR paths. StrictMode double-invokes effects in dev — the single-settlement
+// flag in the parent makes the repeated `onCommit` a no-op after the first.
+const CommitReporter = ({ onCommit }: { onCommit: () => void }): null => {
+  React.useEffect(() => {
+    onCommit();
+  }, [onCommit]);
+
+  return null;
 };
 
 export function hydrateApp<T>({
@@ -43,22 +79,115 @@ export function hydrateApp<T>({
 }: HydrateAppOptions<T>) {
   const { log, warn, error } = createUILogger(logger, { debugCategory: 'ssr', context: { scope: 'react-hydration' }, enableDebug });
 
+  // User lifecycle callbacks are ADVISORY observers — every one is isolated here. This is not mere
+  // defensiveness: `onSuccess` runs INSIDE the reporter's React effect and `onHydrationError` runs
+  // inside our root `onUncaughtError` handler. An un-isolated throw from either becomes an exception
+  // in React's root-error domain — a throwing `onSuccess` would be routed to our OWN `onUncaughtError`,
+  // mis-classified as post-settlement telemetry (success already won), WHILE React tears the committed
+  // root down. An observability hook must never destroy the root it observes, escape the adapter, or
+  // alter settlement. A throw is logged only. (`emitDevHook` is already self-isolating.)
+  const runObserver = (label: string, run: () => void) => {
+    try {
+      run();
+    } catch (cbErr) {
+      error(`Hydration ${label} callback threw (ignored):`, cbErr);
+    }
+  };
+
+  // Beacon policy (path-scoped): the hydrate path emits `hydration:*` beacons; the CSR-fallback path
+  // emits NONE (a CSR mount is not a hydration — vue parity). Set once when the path is chosen, and
+  // read by the SINGLE report pair below — so one adapter object serves both roots.
+  let emitBeacons = false;
+
+  // Single-settlement (design 3): exactly one of success | failure, event-driven (first commit vs
+  // first uncaught error). Later signals are runtime telemetry — log-only.
+  let settled = false;
+
+  const reportSuccess = () => {
+    if (settled) return;
+    settled = true;
+    if (enableDebug) log('Hydration succeeded (first root commit)');
+    if (emitBeacons) emitDevHook('hydration:success');
+    runObserver('onSuccess', () => onSuccess?.());
+  };
+
+  const reportFailure = (err: unknown) => {
+    if (settled) {
+      // Post-settlement runtime error: telemetry only (stricter than vue's errored-guard — a
+      // deliberate choice recorded in decisions.md as a vue backport candidate).
+      error('Post-hydration error (telemetry, not a bootstrap failure):', err);
+
+      return;
+    }
+    settled = true;
+    if (emitBeacons) emitDevHook('hydration:error', err);
+    runObserver('onHydrationError', () => onHydrationError?.(err));
+  };
+
+  // ONE root-error adapter (design 1), the SAME object passed to whichever root is created
+  // (hydrateRoot or createRoot). All client render errors route through the single `reportFailure`.
+  const rootErrorOptions = {
+    onUncaughtError: (err: unknown, info: RootErrorInfo) => {
+      // A render error with no error boundary. React surfaces this ASYNCHRONOUSLY (not as a throw
+      // from hydrateRoot/createRoot), so a sync try/catch cannot see it; this is the real client
+      // error channel.
+      error('Uncaught render error:', err, info);
+      // Overriding onUncaughtError REPLACES React's default for the root's ENTIRE lifetime — and its
+      // default re-surfaces uncaught errors globally (reportError → a window 'error' event). Without
+      // restoring that, post-hydration uncaught render/commit/effect errors (no boundary) would be
+      // hidden from window.onerror-based monitoring (Sentry/Bugsnag globalHandlers) — a net
+      // observability REGRESSION. Re-surface it (React's own guidance for overriding onUncaughtError)
+      // so global observability is preserved ON TOP OF taujs's bootstrap routing below.
+      try {
+        (globalThis as { reportError?: (e: unknown) => void }).reportError?.(err);
+      } catch {
+        // global surfacing must never affect hydration
+      }
+      reportFailure(err);
+    },
+    onCaughtError: (err: unknown, info: RootErrorInfo) => {
+      // Handled by an app error boundary — the app chose how to render it; NOT a bootstrap failure.
+      error('Error handled by an app error boundary:', err, info);
+    },
+    onRecoverableError: (err: unknown, info: RootErrorInfo) => {
+      // Auto-recovered (e.g. server/client HTML mismatch → client re-render). A warning, never a
+      // failure — do NOT classify a mismatch as a hydration failure.
+      warn('Recoverable hydration error:', err, info);
+    },
+  };
+
+  // The tree React renders, with the internal commit reporter alongside the user's app (renders no
+  // DOM, so hydration structure is unaffected). Its effect calls the single `reportSuccess`.
+  const buildTree = (store: ReturnType<typeof createSSRStore<T>>) => (
+    <React.StrictMode>
+      <SSRStoreProvider store={store}>
+        {appComponent}
+        <CommitReporter onCommit={reportSuccess} />
+      </SSRStoreProvider>
+    </React.StrictMode>
+  );
+
   const mountCSR = (rootEl: HTMLElement, initialData: T) => {
+    // emitBeacons stays false: the CSR path reports onSuccess/onHydrationError but no beacons.
     rootEl.innerHTML = '';
     const store = createSSRStore(initialData);
-    const root = createRoot(rootEl);
 
-    root.render(
-      <React.StrictMode>
-        <SSRStoreProvider store={store}>{appComponent}</SSRStoreProvider>
-      </React.StrictMode>,
-    );
+    try {
+      const root = createRoot(rootEl, rootErrorOptions);
+      root.render(buildTree(store));
+    } catch (err) {
+      // Sync belt: invalid container / synchronous setup throw.
+      error('CSR mount error:', err);
+      reportFailure(err);
+    }
   };
 
   const startHydration = (rootEl: HTMLElement, initialData: T) => {
+    emitBeacons = true; // hydrate path: emit hydration:start/success/error beacons
+
     if (enableDebug) log('Hydration started');
     emitDevHook('hydration:start');
-    onStart?.();
+    runObserver('onStart', () => onStart?.());
 
     if (enableDebug) log('Initial data loaded:', initialData);
 
@@ -66,31 +195,23 @@ export function hydrateApp<T>({
     if (enableDebug) log('Store created:', store);
 
     try {
-      hydrateRoot(
-        rootEl,
-        <React.StrictMode>
-          <SSRStoreProvider store={store}>{appComponent}</SSRStoreProvider>
-        </React.StrictMode>,
-        {
-          onRecoverableError: (err, info) => {
-            warn('Recoverable hydration error:', err, info);
-          },
-        },
-      );
-      if (enableDebug) log('Hydration completed');
-      emitDevHook('hydration:success');
-      onSuccess?.();
+      hydrateRoot(rootEl, buildTree(store), rootErrorOptions);
     } catch (err) {
+      // Sync belt: invalid container / synchronous setup throw (async render errors arrive via
+      // onUncaughtError above, not here).
       error('Hydration error:', err);
-      emitDevHook('hydration:error', err);
-      onHydrationError?.(err);
+      reportFailure(err);
     }
   };
 
   const bootstrap = () => {
     const rootEl = document.getElementById(rootElementId);
     if (!rootEl) {
+      // R5 (design 4): a missing root IS a bootstrap failure. Route it through the same single
+      // failure path — the beacon emits an error without a preceding `start` (vue precedent).
+      emitBeacons = true;
       error(`Root element with id "${rootElementId}" not found.`);
+      reportFailure(new Error(`Root element with id "${rootElementId}" not found.`));
 
       return;
     }
@@ -98,9 +219,9 @@ export function hydrateApp<T>({
     const data = (window as any)[dataKey] as T | undefined;
 
     if (data === undefined) {
-      const data = {} as T;
+      const csrData = {} as T;
       if (enableDebug) warn(`No initial SSR data at window["${dataKey}"]. Mounting CSR.`);
-      mountCSR(rootEl, data);
+      mountCSR(rootEl, csrData);
 
       return;
     }

--- a/packages/react/src/SSRHydration.tsx
+++ b/packages/react/src/SSRHydration.tsx
@@ -86,16 +86,22 @@ export type HydrateAppOptions<T> = {
   onSuccess?: () => void;
 };
 
-// Internal reporter (design 2): renders no DOM; its mount effect fires once after the first root
-// commit. Mounted INSIDE the provider wrapper, outside user control, so a committed root is provable
-// on both the hydrate and CSR paths. StrictMode double-invokes effects in dev — the single-settlement
+// Internal reporter (design 2): a pass-through WRAPPER around the app (renders `children`, adds no
+// DOM) whose mount effect fires once after the first root commit, so a committed root is provable on
+// both the hydrate and CSR paths. StrictMode double-invokes effects in dev — the single-settlement
 // flag in the parent makes the repeated `onCommit` a no-op after the first.
-const CommitReporter = ({ onCommit }: { onCommit: () => void }): null => {
+//
+// It MUST wrap the app, not sit beside it (R2-04). React's `useId` is tree-position sensitive: a
+// SIBLING of the app shifts every `useId` in the app (verified against react-dom 19.2), so the
+// original sibling reporter made the client tree's ids diverge from the SSR markup (which renders the
+// app without it) — a hydration mismatch for any app using `useId`. A pass-through wrapper adds tree
+// DEPTH only, which `useId` ignores, so the app's ids are identical to the server render.
+const CommitReporter = ({ onCommit, children }: React.PropsWithChildren<{ onCommit: () => void }>): React.ReactNode => {
   React.useEffect(() => {
     onCommit();
   }, [onCommit]);
 
-  return null;
+  return children;
 };
 
 export function hydrateApp<T>({
@@ -182,13 +188,12 @@ export function hydrateApp<T>({
     },
   };
 
-  // The tree React renders, with the internal commit reporter alongside the user's app (renders no
-  // DOM, so hydration structure is unaffected). Its effect calls the single `reportSuccess`.
+  // The tree React renders. The commit reporter WRAPS the app (adds tree depth only, no DOM and no
+  // `useId` shift — see CommitReporter); its effect calls the single `reportSuccess`.
   const buildTree = (store: ReturnType<typeof createSSRStore<T>>) => (
     <React.StrictMode>
       <SSRStoreProvider store={store}>
-        {appComponent}
-        <CommitReporter onCommit={reportSuccess} />
+        <CommitReporter onCommit={reportSuccess}>{appComponent}</CommitReporter>
       </SSRStoreProvider>
     </React.StrictMode>
   );

--- a/packages/react/src/SSRHydration.tsx
+++ b/packages/react/src/SSRHydration.tsx
@@ -84,6 +84,13 @@ export type HydrateAppOptions<T> = {
   onHydrationError?: (err: unknown) => void;
   onStart?: () => void;
   onSuccess?: () => void;
+  /**
+   * React's `identifierPrefix` for `useId` (passed to BOTH `hydrateRoot` and the CSR-fallback
+   * `createRoot`). It MUST be identical to the value the SERVER rendered with (`createRenderer`'s
+   * `identifierPrefix`) for this root, or hydration mismatches. Set it when mounting MORE THAN ONE τjs
+   * root on a page (app-per-boundary / micro-frontend) so each root's `useId` values are collision-free.
+   */
+  identifierPrefix?: string;
 };
 
 // Internal reporter (design 2): a pass-through WRAPPER around the app (renders `children`, adds no
@@ -113,6 +120,7 @@ export function hydrateApp<T>({
   onHydrationError,
   onStart,
   onSuccess,
+  identifierPrefix,
 }: HydrateAppOptions<T>) {
   const { log, warn, error } = createUILogger(logger, { debugCategory: 'ssr', context: { scope: 'react-hydration' }, enableDebug });
 
@@ -161,9 +169,11 @@ export function hydrateApp<T>({
     runObserver('onHydrationError', () => onHydrationError?.(err));
   };
 
-  // ONE root-error adapter (design 1), the SAME object passed to whichever root is created
+  // ONE root-options object (design 1), the SAME object passed to whichever root is created
   // (hydrateRoot or createRoot). All client render errors route through the single `reportFailure`.
+  // `identifierPrefix` rides along here so both call sites (hydrate + CSR) get it (R2-04).
   const rootErrorOptions = {
+    identifierPrefix,
     onUncaughtError: (err: unknown, info: RootErrorInfo) => {
       // A render error with no error boundary. React surfaces this ASYNCHRONOUSLY (not as a throw
       // from hydrateRoot/createRoot), so a sync try/catch cannot see it; this is the real client

--- a/packages/react/src/SSRHydration.tsx
+++ b/packages/react/src/SSRHydration.tsx
@@ -20,6 +20,37 @@ const emitDevHook = (event: 'hydration:start' | 'hydration:success' | 'hydration
   }
 };
 
+// Re-surface an uncaught error on the GLOBAL error channel (window.onerror /
+// addEventListener('error')) that overriding React's `onUncaughtError` otherwise suppresses. Mirrors
+// React's own `reportGlobalError`: prefer `globalThis.reportError`, else dispatch a cancelable window
+// `ErrorEvent` — so `window.onerror`-based monitoring (Sentry/Bugsnag globalHandlers) still fires on
+// runtimes/older browsers that do NOT expose `reportError` (a plain `reportError?.()` is a silent
+// no-op there). The caller already logs via the taujs logger, so there is no console fallback here.
+// Node `uncaughtException` re-emission is intentionally omitted: this module is browser-only. Never
+// throws into hydration.
+const surfaceGlobalUncaughtError = (err: unknown): void => {
+  try {
+    const g = globalThis as { reportError?: (e: unknown) => void };
+    if (typeof g.reportError === 'function') {
+      g.reportError(err);
+
+      return;
+    }
+
+    if (typeof window !== 'undefined' && typeof ErrorEvent === 'function' && typeof window.dispatchEvent === 'function') {
+      let message = 'Uncaught render error';
+      try {
+        if (err instanceof Error && typeof err.message === 'string') message = err.message;
+      } catch {
+        // hostile message getter — keep the generic message
+      }
+      window.dispatchEvent(new ErrorEvent('error', { error: err, message, cancelable: true }));
+    }
+  } catch {
+    // global surfacing must never affect hydration
+  }
+};
+
 // React 19 root error-info shapes (narrowed from @types/react-dom). Descriptive only.
 type RootErrorInfo = { componentStack?: string };
 
@@ -133,16 +164,11 @@ export function hydrateApp<T>({
       // error channel.
       error('Uncaught render error:', err, info);
       // Overriding onUncaughtError REPLACES React's default for the root's ENTIRE lifetime — and its
-      // default re-surfaces uncaught errors globally (reportError → a window 'error' event). Without
-      // restoring that, post-hydration uncaught render/commit/effect errors (no boundary) would be
-      // hidden from window.onerror-based monitoring (Sentry/Bugsnag globalHandlers) — a net
-      // observability REGRESSION. Re-surface it (React's own guidance for overriding onUncaughtError)
-      // so global observability is preserved ON TOP OF taujs's bootstrap routing below.
-      try {
-        (globalThis as { reportError?: (e: unknown) => void }).reportError?.(err);
-      } catch {
-        // global surfacing must never affect hydration
-      }
+      // default re-surfaces uncaught errors globally. Without restoring that, post-hydration uncaught
+      // render/commit/effect errors (no boundary) would be hidden from window.onerror-based monitoring
+      // (Sentry/Bugsnag globalHandlers) — a net observability REGRESSION. Re-surface it (mirroring
+      // React's reportGlobalError, incl. the ErrorEvent fallback) on top of taujs's routing below.
+      surfaceGlobalUncaughtError(err);
       reportFailure(err);
     },
     onCaughtError: (err: unknown, info: RootErrorInfo) => {

--- a/packages/react/src/SSRHydration.tsx
+++ b/packages/react/src/SSRHydration.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 
-import { createSSRStore, SSRStoreProvider } from './SSRDataStore';
-import { createUILogger } from './utils/Logger';
+import { createSSRStore, SSRStoreProvider } from './SSRDataStore.js';
+import { createUILogger } from './utils/Logger.js';
 
-import type { LoggerLike } from './utils/Logger';
+import type { LoggerLike } from './utils/Logger.js';
 
 // Dev-only introspection hook, set by the server-injected dev script (never by users).
 // Absent in production: emission costs one property check and can never throw into

--- a/packages/react/src/SSRRender.tsx
+++ b/packages/react/src/SSRRender.tsx
@@ -211,13 +211,26 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
       });
     }
 
+    // Set by armDataDeadline (below) to its idempotent disarm. Composed into the controller's cleanup
+    // so ANY termination path tears the data deadline down PROMPTLY — the recheck showed relying on the
+    // writable's 'close' event is unsound (a writable created with `emitClose: false` is destroyed
+    // without emitting 'close', leaving the timer/closure/listener live until dataTimeoutMs).
+    let stopDataDeadline: (() => void) | undefined;
+
     // Writable guards (handles error/close/finish)
     const { cleanup: guardsCleanup } = wireWritableGuards(writable, {
       benignAbort: (why) => controller.benignAbort(why),
       fatalAbort: (err) => failFatal(err),
       onFinish: () => controller.complete('Stream finished (normal completion)'),
     });
-    controller.setGuardsCleanup(guardsCleanup);
+    controller.setGuardsCleanup(() => {
+      try {
+        guardsCleanup();
+      } catch {}
+      try {
+        stopDataDeadline?.();
+      } catch {}
+    });
 
     // Shell timeout guard
     const stopShellTimer = startShellTimer(effectiveShellTimeout, () => {
@@ -274,33 +287,46 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
       // loader React NEVER ends — and if the deadline lived only in the end path (below) nothing would
       // ever fire. Arm it explicitly once the shell is committed (a post-shell data budget matching
       // `dataTimeoutMs`), independent of end(). On expiry it enters the single fatal path (which aborts
-      // React + tears the response down); it is disarmed when route data settles OR the controller
-      // terminates (abort destroys the writable → 'close').
+      // React + tears the response down).
+      //
+      // Teardown (recheck finding): it is disarmed when route data settles, on controller termination
+      // (via `stopDataDeadline`, composed into the controller cleanup above — the AUTHORITATIVE path,
+      // since a writable with `emitClose: false` never emits 'close'), and defensively on 'close'.
+      // `teardown` ALWAYS clears the timer and removes the listener idempotently, including after the
+      // timer itself has won — so nothing (timer, closure, listener, readiness continuation) is
+      // retained past the terminal event.
       let dataDeadlineArmed = false;
       const armDataDeadline = () => {
         if (dataDeadlineArmed) return;
         dataDeadlineArmed = true;
         if (store.status !== 'pending') return; // already settled — nothing to bound
 
-        let fired = false;
         let timer: ReturnType<typeof setTimeout>;
-        const disarm = () => {
-          if (fired) return;
-          fired = true;
+        const teardown = () => {
           clearTimeout(timer);
           try {
             writable.removeListener('close', disarm);
           } catch {}
         };
+        let settled = false;
+        const disarm = () => {
+          if (settled) return;
+          settled = true;
+          teardown();
+        };
         timer = setTimeout(() => {
-          if (fired || controller.isAborted) return;
-          fired = true;
+          if (settled) return;
+          settled = true;
+          teardown(); // clear our own listener even when the timer wins
+          if (controller.isAborted) return; // another path already owns settlement
           failFatal(new Error(`Route data not ready after ${effectiveDataTimeout}ms`));
         }, effectiveDataTimeout);
 
-        // Data settled (resolve OR swallowed error) → disarm. Controller torn down → 'close' → disarm.
+        // Data settled (resolve OR swallowed error) → disarm. Controller termination → stopDataDeadline
+        // (authoritative). 'close' is a secondary signal for the emitClose:true case.
         readiness.then(disarm, disarm);
         writable.once('close', disarm);
+        stopDataDeadline = disarm;
       };
 
       // Deferred end (design 2/3): React pipes final output into the delegating sink; we defer the

--- a/packages/react/src/SSRRender.tsx
+++ b/packages/react/src/SSRRender.tsx
@@ -171,18 +171,26 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
     // Stream controller centralises cleanup & settlement
     const controller = createStreamController(writable, { log, warn, error });
 
-    // Recheck: EVERY fatal path routes through here so the host `onError` callback can NEVER veto
-    // controller cleanup/settlement. A throwing `onError` is logged and SWALLOWED — it must not
-    // veto `fatalAbort` (below, always runs) NOR escape, since this may be called from a timer or a
-    // writable EventEmitter listener where a throw would be an uncaughtException. The ORIGINAL error
-    // is the rejection reason. Also the single site that fires `cb.onError` for a fatal (no double-fire).
+    // EVERY fatal path routes through here (single site that fires `cb.onError` for a fatal —
+    // no double-fire). The ORIGINAL error is the rejection reason.
+    //
+    // Ordering (gate-review finding 2): claim the terminal fatal state via `controller.fatalAbort`
+    // FIRST, THEN run the isolated host `cb.onError`. The host callback may SYNCHRONOUSLY abort the
+    // very AbortSignal we wired to `controller.benignAbort` (the server's `onError` calls
+    // `ac.abort()`, and `ac.signal` is this renderer's `signal`). If that re-entrant benign abort
+    // ran BEFORE we claimed fatal, it would win the one-shot controller and RESOLVE `done` — silently
+    // downgrading a fatal to a benign completion and violating the `RenderStreamHandle` contract
+    // (fatal ⇒ `done` rejects). fatalAbort-first makes the re-entrant `benignAbort` a no-op.
+    //
+    // `cb.onError` is still SWALLOWED on throw (and cannot veto settlement, already claimed) — it may
+    // run from a timer or a writable EventEmitter listener where a throw would be an uncaughtException.
     const failFatal = (err: unknown) => {
+      controller.fatalAbort(err);
       try {
         cb.onError(err);
       } catch (cbErr) {
         warn('onError callback threw:', cbErr);
       }
-      controller.fatalAbort(err);
     };
 
     // Wire AbortSignal (benign cancel)
@@ -260,54 +268,54 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
         }
       };
 
-      // Bounded end-gate (design 3): React pipes into this delegating SINK. Every write/destroy/
-      // event is forwarded to the REAL writable — React drives backpressure itself against it (via
-      // write()'s boolean return + a 'drain' listener it attaches through `on`), exactly as the
-      // pre-rework renderer did when it piped straight into the writable. The ONLY interception is
-      // end(): it is DEFERRED until route data has settled, RACED against dataTimeoutMs, so a
-      // never-settling loader cannot hold the response (and its listeners/streams) open.
-      //
-      // It is a plain delegating object rather than `new Writable(...)` on purpose: this server-only
-      // module must never pull a `node:stream` VALUE import into the client bundle (the barrel
-      // re-exports it). @taujs/vue keeps `Writable` type-only for the same reason; this mirrors it.
+      // Route-data liveness deadline (design 3, gate-review finding 1). The bound on route-data
+      // settlement must NOT depend on React calling the sink's end(): a <Suspense> consumer of the
+      // store keeps React's stream open until the thrown data promise settles, so for a never-settling
+      // loader React NEVER ends — and if the deadline lived only in the end path (below) nothing would
+      // ever fire. Arm it explicitly once the shell is committed (a post-shell data budget matching
+      // `dataTimeoutMs`), independent of end(). On expiry it enters the single fatal path (which aborts
+      // React + tears the response down); it is disarmed when route data settles OR the controller
+      // terminates (abort destroys the writable → 'close').
+      let dataDeadlineArmed = false;
+      const armDataDeadline = () => {
+        if (dataDeadlineArmed) return;
+        dataDeadlineArmed = true;
+        if (store.status !== 'pending') return; // already settled — nothing to bound
+
+        let fired = false;
+        let timer: ReturnType<typeof setTimeout>;
+        const disarm = () => {
+          if (fired) return;
+          fired = true;
+          clearTimeout(timer);
+          try {
+            writable.removeListener('close', disarm);
+          } catch {}
+        };
+        timer = setTimeout(() => {
+          if (fired || controller.isAborted) return;
+          fired = true;
+          failFatal(new Error(`Route data not ready after ${effectiveDataTimeout}ms`));
+        }, effectiveDataTimeout);
+
+        // Data settled (resolve OR swallowed error) → disarm. Controller torn down → 'close' → disarm.
+        readiness.then(disarm, disarm);
+        writable.once('close', disarm);
+      };
+
+      // Deferred end (design 2/3): React pipes final output into the delegating sink; we defer the
+      // real writable's end() until route data has settled so LATE data (no-consumer path) is
+      // serialized before finish. Liveness is owned by armDataDeadline above, NOT here — so a Suspense
+      // consumer whose data never settles (React never reaches this end()) is still bounded.
       let endStarted = false;
       const deferredEnd = () => {
         if (controller.isAborted || endStarted) return;
         endStarted = true;
 
-        let gateSettled = false;
-        let timer: ReturnType<typeof setTimeout>;
-
-        // If the response is torn down through ANY other path while we wait on data — client
-        // disconnect / AbortSignal, manual abort(), or a fatal writable error — the controller
-        // destroys the writable, which emits 'close'. Clear the armed data-timer promptly on that
-        // so it neither leaks its closure nor fires a spurious/duplicate fatal after settlement.
-        // (`once` self-removes; the readiness continuations also remove it on the normal path.)
-        const onWritableClose = () => {
-          if (gateSettled) return;
-          gateSettled = true;
-          clearTimeout(timer);
-        };
-        writable.once('close', onWritableClose);
-
-        timer = setTimeout(() => {
-          if (gateSettled) return;
-          gateSettled = true;
-          writable.removeListener('close', onWritableClose);
-          // Mirror the shell-timer idiom: if the controller already aborted through another path,
-          // it owns settlement — this net must not fire a second/late fatal.
-          if (controller.isAborted) return;
-          failFatal(new Error(`Route data not ready after ${effectiveDataTimeout}ms`));
-        }, effectiveDataTimeout);
-
         readiness
           .then(() => {
-            if (gateSettled) return;
-            gateSettled = true;
-            clearTimeout(timer);
-            writable.removeListener('close', onWritableClose);
-            // Aborted during the data wait: the writable is already destroyed — do not deliver to a
-            // gone response nor end() a torn-down stream.
+            // Aborted during the data wait (incl. the data deadline firing): the writable is already
+            // torn down — do not deliver to a gone response nor end() a destroyed stream.
             if (controller.isAborted) return;
             if (store.status === 'error') {
               failFatal(store.lastError ?? new Error('SSR data fetch failed'));
@@ -319,10 +327,6 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
             writable.end();
           })
           .catch((e) => {
-            if (gateSettled) return;
-            gateSettled = true;
-            clearTimeout(timer);
-            writable.removeListener('close', onWritableClose);
             if (controller.isAborted) return;
             failFatal(e);
           });
@@ -394,6 +398,11 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
               // The delegating sink duck-types the Node Writable surface React's pipe uses.
               stream.pipe(endGate as unknown as Writable);
             }
+
+            // Shell is committed: bound the remaining route-data wait independent of React's end()
+            // (finding 1) — a Suspense consumer whose data never settles keeps React streaming, so
+            // React may never call end(); this deadline fires regardless.
+            armDataDeadline();
 
             // Advisory (design 6): a throw is logged, not fatal.
             try {

--- a/packages/react/src/SSRRender.tsx
+++ b/packages/react/src/SSRRender.tsx
@@ -1,26 +1,63 @@
 import React from 'react';
 import { renderToPipeableStream, renderToString } from 'react-dom/server';
 
+import type { Writable } from 'node:stream';
+
 import { createSSRStore, SSRStoreProvider } from './SSRDataStore';
+import { getStoreReadiness } from './internal';
 import { createUILogger } from './utils/Logger';
 
-import type { Writable } from 'node:stream';
 import type { LoggerLike } from './utils/Logger';
 
-import { createStreamController, isBenignStreamErr, startShellTimer, wireWritableGuards } from './utils/Streaming';
+import { createStreamController, startShellTimer, wireWritableGuards } from './utils/Streaming';
+
+/**
+ * R1-01: structured, NON-FATAL render-error observation.
+ *
+ * `phase` is the OBSERVED timing — had the shell committed when React's `onError` fired? It is
+ * descriptive only and NEVER a fatality signal (a `pre-shell` `onError` can be followed by a
+ * successful shell commit, verified against real react-dom/server). `recoverable` is `true` only
+ * for `post-shell` errors (boundary-scoped — React recovers them client-side) and `'unknown'` for
+ * `pre-shell` (its outcome is resolved by the separate fatal channels: a subsequent `onShellError`
+ * fails the render, a subsequent shell commit means it recovered).
+ */
+export type RenderErrorInfo = {
+  error: unknown;
+  phase: 'pre-shell' | 'post-shell';
+  recoverable: boolean | 'unknown';
+};
 
 export type RenderCallbacks<T> = {
+  /**
+   * REQUIRED (operationally): commits the response head + connects the sink. A throwing `onHead`
+   * enters the fatal path — the response cannot proceed without it.
+   */
   onHead?: (head: string) => void;
+  /** Advisory (observes; isolated — a throw is logged, not fatal). */
   onShellReady?: () => void;
+  /** Advisory. Fires exactly once with the resolved route data. */
   onAllReady?: (data: T) => void;
   /** @deprecated Legacy alias of `onAllReady`, fires when final data is available. Use `onAllReady`. */
   onFinish?: (data: T) => void;
+  /** FATAL error channel: a fatal stream error (shell error / timeout / guard / non-recoverable). */
   onError?: (err: unknown) => void;
+  /**
+   * Advisory, NON-FATAL structured render-error channel (R1-01). Fires for React render errors that
+   * do NOT themselves fail the response — notably post-shell boundary errors React recovers
+   * client-side. Never a fatality signal; fatality stays with `onError`/`onShellError`/timers/guards.
+   */
+  onRenderError?: (info: RenderErrorInfo) => void;
 };
 
 export type StreamOptions = {
   /** Timeout in ms for shell to be ready (default: 10000) */
   shellTimeoutMs?: number;
+  /**
+   * R1-01: timeout in ms for route data to settle AFTER React has finished rendering, before the
+   * response is failed (default: 30000). Bounds the end-gate so a never-settling loader cannot hold
+   * the response (and its listeners/streams) open indefinitely.
+   */
+  dataTimeoutMs?: number;
 };
 
 export type HeadContext<T extends Record<string, unknown> = Record<string, unknown>, R = unknown> = {
@@ -51,7 +88,7 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
   logger?: LoggerLike;
   streamOptions?: StreamOptions;
 }) {
-  const { shellTimeoutMs = 10_000 } = streamOptions;
+  const { shellTimeoutMs = 10_000, dataTimeoutMs = 30_000 } = streamOptions;
 
   const renderSSR = async (
     initialData: T,
@@ -118,6 +155,7 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
       onAllReady: callbacks.onAllReady ?? NOOP,
       onFinish: callbacks.onFinish ?? NOOP,
       onError: callbacks.onError ?? NOOP,
+      onRenderError: callbacks.onRenderError ?? (NOOP as (info: RenderErrorInfo) => void),
     };
     const { log, warn, error } = createUILogger(opts?.logger ?? logger, {
       debugCategory: 'ssr',
@@ -128,6 +166,7 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
 
     // Merge renderer defaults with per-call overrides
     const effectiveShellTimeout = opts?.shellTimeoutMs ?? shellTimeoutMs;
+    const effectiveDataTimeout = opts?.dataTimeoutMs ?? dataTimeoutMs;
 
     // Stream controller centralises cleanup & settlement
     const controller = createStreamController(writable, { log, warn, error });
@@ -184,9 +223,130 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
     log('Starting stream:', location);
 
     let piped = false;
+    let shellCommitted = false;
+    let delivered = false;
 
     try {
+      // Store is created here so the renderer can read its INTERNAL readiness (design 1) for the
+      // bounded end-gate; the public SSRStore type is unchanged.
       const store = createSSRStore(initialData);
+      const readiness = getStoreReadiness(store) ?? Promise.resolve();
+
+      // Single-fire delivery (design 2): fires onAllReady/onFinish exactly once, from the end-gate
+      // after data has settled — replacing the thrown-thenable retry dance. Reading the snapshot can
+      // still throw (e.g. a loader that resolves to `undefined` settles status:'success' with no
+      // data): route that through failFatal so it becomes a clean fatal, never a hung response.
+      const deliverFinalData = () => {
+        if (delivered) return;
+
+        let data: T;
+        try {
+          data = store.getSnapshot();
+        } catch (snapErr) {
+          failFatal(snapErr instanceof Error ? snapErr : new Error('SSR data unavailable at delivery'));
+          return;
+        }
+
+        delivered = true;
+        try {
+          cb.onAllReady(data);
+        } catch (cbErr) {
+          error('onAllReady callback threw:', cbErr);
+        }
+        try {
+          cb.onFinish(data);
+        } catch (cbErr) {
+          error('onFinish callback threw:', cbErr);
+        }
+      };
+
+      // Bounded end-gate (design 3): React pipes into this delegating SINK. Every write/destroy/
+      // event is forwarded to the REAL writable — React drives backpressure itself against it (via
+      // write()'s boolean return + a 'drain' listener it attaches through `on`), exactly as the
+      // pre-rework renderer did when it piped straight into the writable. The ONLY interception is
+      // end(): it is DEFERRED until route data has settled, RACED against dataTimeoutMs, so a
+      // never-settling loader cannot hold the response (and its listeners/streams) open.
+      //
+      // It is a plain delegating object rather than `new Writable(...)` on purpose: this server-only
+      // module must never pull a `node:stream` VALUE import into the client bundle (the barrel
+      // re-exports it). @taujs/vue keeps `Writable` type-only for the same reason; this mirrors it.
+      let endStarted = false;
+      const deferredEnd = () => {
+        if (controller.isAborted || endStarted) return;
+        endStarted = true;
+
+        let gateSettled = false;
+        let timer: ReturnType<typeof setTimeout>;
+
+        // If the response is torn down through ANY other path while we wait on data — client
+        // disconnect / AbortSignal, manual abort(), or a fatal writable error — the controller
+        // destroys the writable, which emits 'close'. Clear the armed data-timer promptly on that
+        // so it neither leaks its closure nor fires a spurious/duplicate fatal after settlement.
+        // (`once` self-removes; the readiness continuations also remove it on the normal path.)
+        const onWritableClose = () => {
+          if (gateSettled) return;
+          gateSettled = true;
+          clearTimeout(timer);
+        };
+        writable.once('close', onWritableClose);
+
+        timer = setTimeout(() => {
+          if (gateSettled) return;
+          gateSettled = true;
+          writable.removeListener('close', onWritableClose);
+          // Mirror the shell-timer idiom: if the controller already aborted through another path,
+          // it owns settlement — this net must not fire a second/late fatal.
+          if (controller.isAborted) return;
+          failFatal(new Error(`Route data not ready after ${effectiveDataTimeout}ms`));
+        }, effectiveDataTimeout);
+
+        readiness
+          .then(() => {
+            if (gateSettled) return;
+            gateSettled = true;
+            clearTimeout(timer);
+            writable.removeListener('close', onWritableClose);
+            // Aborted during the data wait: the writable is already destroyed — do not deliver to a
+            // gone response nor end() a torn-down stream.
+            if (controller.isAborted) return;
+            if (store.status === 'error') {
+              failFatal(store.lastError ?? new Error('SSR data fetch failed'));
+              return;
+            }
+            deliverFinalData();
+            // deliverFinalData may itself fatal-abort (e.g. undefined snapshot); don't end() then.
+            if (controller.isAborted) return;
+            writable.end();
+          })
+          .catch((e) => {
+            if (gateSettled) return;
+            gateSettled = true;
+            clearTimeout(timer);
+            writable.removeListener('close', onWritableClose);
+            if (controller.isAborted) return;
+            failFatal(e);
+          });
+      };
+
+      // React only ever calls write(view) [single chunk arg], end(), destroy(err), on/once/
+      // removeListener(event, handler), and (guarded) flush(). We omit flush() so React skips it,
+      // and forward the rest to the real writable so its own listeners/backpressure are authoritative.
+      const endGate = {
+        write: (chunk: unknown): boolean => (controller.isAborted ? true : writable.write(chunk as Uint8Array)),
+        end: () => deferredEnd(),
+        destroy: (err?: unknown) => writable.destroy(err as Error | undefined),
+        on: (event: string, handler: (...args: unknown[]) => void) => (writable.on(event, handler), endGate),
+        once: (event: string, handler: (...args: unknown[]) => void) => (writable.once(event, handler), endGate),
+        removeListener: (event: string, handler: (...args: unknown[]) => void) => (writable.removeListener(event, handler), endGate),
+        emit: (event: string, ...args: unknown[]) => writable.emit(event, ...args),
+        get destroyed() {
+          return writable.destroyed;
+        },
+        get writable() {
+          return writable.writable;
+        },
+      };
+
       const appElement = <SSRStoreProvider store={store}>{appComponent({ location, routeContext })}</SSRStoreProvider>;
 
       const stream = renderToPipeableStream(appElement, {
@@ -219,50 +379,37 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
 
             const head = headContent({ data: headData ?? ({} as T), meta, routeContext });
 
+            // onHead is REQUIRED (design 6): it commits the response head and connects the sink. A
+            // throwing onHead is fatal — do NOT pipe into an unconsumed sink (hung response).
             try {
               cb.onHead(head);
             } catch (cbErr) {
-              warn('onHead callback threw:', cbErr);
+              failFatal(cbErr);
+              return;
             }
 
             if (!piped) {
               piped = true;
-              stream.pipe(writable);
+              shellCommitted = true;
+              // The delegating sink duck-types the Node Writable surface React's pipe uses.
+              stream.pipe(endGate as unknown as Writable);
             }
 
+            // Advisory (design 6): a throw is logged, not fatal.
             try {
               cb.onShellReady();
             } catch (cbErr) {
-              warn('onShellReady callback threw:', cbErr);
+              error('onShellReady callback threw:', cbErr);
             }
           } catch (err) {
             failFatal(err);
           }
         },
         onAllReady() {
+          // Delivery is owned by the bounded end-gate (deferred until data readiness). This is
+          // advisory — React signalling all content is ready.
           if (controller.isAborted) return;
           log('All content ready:', location);
-
-          const deliver = () => {
-            try {
-              const data = store.getSnapshot();
-              cb.onAllReady(data);
-              cb.onFinish(data);
-            } catch (thrown) {
-              // Suspense rethrow - retry after resolution
-              if (thrown && typeof (thrown as any).then === 'function') {
-                (thrown as Promise<unknown>).then(deliver).catch((e) => {
-                  error('Data promise rejected:', e);
-                  failFatal(e);
-                });
-              } else {
-                error('Unexpected throw from getSnapshot:', thrown);
-                failFatal(thrown);
-              }
-            }
-          };
-
-          deliver();
         },
 
         onShellError(err) {
@@ -277,22 +424,27 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
 
         onError(err) {
           if (controller.isAborted) return;
-          // R0-02: this error is render-origin (React's server render surfaced it), so it is
-          // never benign by shape — a disconnect-shaped message/code thrown from app code must
-          // not be swallowed. Real client disconnects arrive via wireWritableGuards ('socket').
-          // Recheck-2: pass the RAW error to the non-throwing UI logger — do NOT coerce
-          // `err.message` here. A hostile error (throwing `message` getter / `Symbol.toPrimitive`)
-          // would throw at this line BEFORE `failFatal`, skipping settlement/cleanup and escaping
-          // React's async renderer callback as an uncaughtException.
-          warn('React stream error:', err);
 
-          if (isBenignStreamErr(err, 'render')) {
-            controller.benignAbort('Client disconnected before stream finished');
+          // R3 + recoverability ruling (decisions 2026-07-11): React's onError fires for EVERY
+          // render error, INCLUDING post-shell boundary errors it recovers client-side. `phase` is
+          // the OBSERVED timing (had the shell committed when onError fired) — descriptive only,
+          // NEVER a fatality signal. `recoverable` is true only post-shell (boundary-scoped by
+          // React's semantics), 'unknown' pre-shell (its outcome is resolved by the separate fatal
+          // channels: a subsequent onShellError fails it; a subsequent shell commit means it
+          // recovered). This channel is NON-FATAL — fatality stays with onShellError / timers /
+          // guards / outer catch.
+          const phase: RenderErrorInfo['phase'] = shellCommitted ? 'post-shell' : 'pre-shell';
+          const recoverable: RenderErrorInfo['recoverable'] = phase === 'post-shell' ? true : 'unknown';
 
-            return;
+          // Recheck-2: pass the RAW error to the non-throwing UI logger (no eager coercion).
+          error('React render error:', err);
+
+          // Advisory (design 6): isolate a throwing onRenderError.
+          try {
+            cb.onRenderError({ error: err, phase, recoverable });
+          } catch (cbErr) {
+            error('onRenderError callback threw:', cbErr);
           }
-
-          failFatal(err);
         },
       });
 

--- a/packages/react/src/SSRRender.tsx
+++ b/packages/react/src/SSRRender.tsx
@@ -280,8 +280,11 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
           // R0-02: this error is render-origin (React's server render surfaced it), so it is
           // never benign by shape — a disconnect-shaped message/code thrown from app code must
           // not be swallowed. Real client disconnects arrive via wireWritableGuards ('socket').
-          const msg = String((err as any)?.message ?? '');
-          warn('React stream error:', msg);
+          // Recheck-2: pass the RAW error to the non-throwing UI logger — do NOT coerce
+          // `err.message` here. A hostile error (throwing `message` getter / `Symbol.toPrimitive`)
+          // would throw at this line BEFORE `failFatal`, skipping settlement/cleanup and escaping
+          // React's async renderer callback as an uncaughtException.
+          warn('React stream error:', err);
 
           if (isBenignStreamErr(err, 'render')) {
             controller.benignAbort('Client disconnected before stream finished');

--- a/packages/react/src/SSRRender.tsx
+++ b/packages/react/src/SSRRender.tsx
@@ -132,6 +132,20 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
     // Stream controller centralises cleanup & settlement
     const controller = createStreamController(writable, { log, warn, error });
 
+    // Recheck: EVERY fatal path routes through here so the host `onError` callback can NEVER veto
+    // controller cleanup/settlement. A throwing `onError` is logged and SWALLOWED — it must not
+    // veto `fatalAbort` (below, always runs) NOR escape, since this may be called from a timer or a
+    // writable EventEmitter listener where a throw would be an uncaughtException. The ORIGINAL error
+    // is the rejection reason. Also the single site that fires `cb.onError` for a fatal (no double-fire).
+    const failFatal = (err: unknown) => {
+      try {
+        cb.onError(err);
+      } catch (cbErr) {
+        warn('onError callback threw:', cbErr);
+      }
+      controller.fatalAbort(err);
+    };
+
     // Wire AbortSignal (benign cancel)
     if (signal) {
       const handleAbortSignal = () => controller.benignAbort(`AbortSignal triggered; aborting stream for location: ${location}`);
@@ -153,11 +167,7 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
     // Writable guards (handles error/close/finish)
     const { cleanup: guardsCleanup } = wireWritableGuards(writable, {
       benignAbort: (why) => controller.benignAbort(why),
-      fatalAbort: (err) => {
-        cb.onError(err);
-        controller.fatalAbort(err);
-      },
-      onError: cb.onError,
+      fatalAbort: (err) => failFatal(err),
       onFinish: () => controller.complete('Stream finished (normal completion)'),
     });
     controller.setGuardsCleanup(guardsCleanup);
@@ -167,8 +177,7 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
       if (controller.isAborted) return;
 
       const timeoutErr = new Error(`Shell not ready after ${effectiveShellTimeout}ms`);
-      cb.onError(timeoutErr);
-      controller.fatalAbort(timeoutErr);
+      failFatal(timeoutErr);
     });
     controller.setStopShellTimer(stopShellTimer);
 
@@ -227,8 +236,7 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
               warn('onShellReady callback threw:', cbErr);
             }
           } catch (err) {
-            cb.onError(err);
-            controller.fatalAbort(err);
+            failFatal(err);
           }
         },
         onAllReady() {
@@ -245,13 +253,11 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
               if (thrown && typeof (thrown as any).then === 'function') {
                 (thrown as Promise<unknown>).then(deliver).catch((e) => {
                   error('Data promise rejected:', e);
-                  cb.onError(e);
-                  controller.fatalAbort(e);
+                  failFatal(e);
                 });
               } else {
                 error('Unexpected throw from getSnapshot:', thrown);
-                cb.onError(thrown);
-                controller.fatalAbort(thrown);
+                failFatal(thrown);
               }
             }
           };
@@ -266,8 +272,7 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
             stopShellTimer();
           } catch {}
 
-          cb.onError(err);
-          controller.fatalAbort(err);
+          failFatal(err);
         },
 
         onError(err) {
@@ -284,15 +289,13 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
             return;
           }
 
-          cb.onError(err);
-          controller.fatalAbort(err);
+          failFatal(err);
         },
       });
 
       controller.setStreamAbort(() => stream.abort());
     } catch (err) {
-      cb.onError(err);
-      controller.fatalAbort(err);
+      failFatal(err);
     }
 
     return {

--- a/packages/react/src/SSRRender.tsx
+++ b/packages/react/src/SSRRender.tsx
@@ -87,6 +87,7 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
   streamOptions = {},
   logger,
   enableDebug = false,
+  identifierPrefix,
 }: {
   appComponent: (props: { location: string; routeContext?: R }) => React.ReactElement;
   /**
@@ -101,6 +102,14 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
   enableDebug?: boolean;
   logger?: LoggerLike;
   streamOptions?: StreamOptions;
+  /**
+   * React's `identifierPrefix` for `useId` (passed to `renderToString` and `renderToPipeableStream`).
+   * It MUST be identical on the server and the client for a given root (pass the same value to
+   * `hydrateApp`), or hydration mismatches. Set it when rendering MORE THAN ONE τjs root on a page
+   * (the app-per-boundary / micro-frontend model) so each root's `useId` values are collision-free.
+   * A server-derived default from `appId` is a possible future (R3-03); today it is app-supplied.
+   */
+  identifierPrefix?: string;
 }) {
   const { shellTimeoutMs = 10_000, dataTimeoutMs = 30_000 } = streamOptions;
 
@@ -134,7 +143,9 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
 
       const dynamicHead = headContent({ data: initialData, meta, routeContext });
       const store = createSSRStore(initialData);
-      const html = renderToString(<SSRStoreProvider store={store}>{appComponent({ location, routeContext })}</SSRStoreProvider>);
+      const html = renderToString(<SSRStoreProvider store={store}>{appComponent({ location, routeContext })}</SSRStoreProvider>, {
+        identifierPrefix,
+      });
 
       if (aborted) {
         warn('SSR completed after client abort', { location });
@@ -395,6 +406,7 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
 
       const stream = renderToPipeableStream(appElement, {
         nonce: cspNonce,
+        identifierPrefix,
         bootstrapModules: bootstrapModules ? [bootstrapModules] : undefined,
 
         onShellReady() {

--- a/packages/react/src/SSRRender.tsx
+++ b/packages/react/src/SSRRender.tsx
@@ -60,6 +60,12 @@ export type StreamOptions = {
   dataTimeoutMs?: number;
 };
 
+/**
+ * Context passed to `headContent`: `data` is the resolved route data, `meta`/`routeContext` the
+ * route's static metadata and per-request context. NB `headContent` returns RAW `<head>` HTML — any
+ * value interpolated from `data` (or other services/user input) must be escaped with `escapeHtml`
+ * (see the `headContent` option's docs).
+ */
 export type HeadContext<T extends Record<string, unknown> = Record<string, unknown>, R = unknown> = {
   data: T;
   meta: Record<string, unknown>;
@@ -83,6 +89,14 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
   enableDebug = false,
 }: {
   appComponent: (props: { location: string; routeContext?: R }) => React.ReactElement;
+  /**
+   * Returns the per-route `<head>` inner HTML. The return value is written into `<head>` VERBATIM as
+   * RAW HTML — it is deliberately NOT auto-escaped, so you can emit `<meta>`/`<link>`/`<script>` tags.
+   * Therefore any value interpolated from `data` (services or user input) MUST be escaped first with
+   * `escapeHtml` (exported from `@taujs/react`), e.g.
+   * `` `<meta property="og:image" content="${escapeHtml(data.ogImage)}">` ``. See the head-management
+   * guide, "Best Practices — Escape User Content".
+   */
   headContent: (ctx: HeadContext<T, R>) => string;
   enableDebug?: boolean;
   logger?: LoggerLike;

--- a/packages/react/src/SSRRender.tsx
+++ b/packages/react/src/SSRRender.tsx
@@ -3,13 +3,13 @@ import { renderToPipeableStream, renderToString } from 'react-dom/server';
 
 import type { Writable } from 'node:stream';
 
-import { createSSRStore, SSRStoreProvider } from './SSRDataStore';
-import { getStoreReadiness } from './internal';
-import { createUILogger } from './utils/Logger';
+import { createSSRStore, SSRStoreProvider } from './SSRDataStore.js';
+import { getStoreReadiness } from './internal.js';
+import { createUILogger } from './utils/Logger.js';
 
-import type { LoggerLike } from './utils/Logger';
+import type { LoggerLike } from './utils/Logger.js';
 
-import { createStreamController, startShellTimer, wireWritableGuards } from './utils/Streaming';
+import { createStreamController, startShellTimer, wireWritableGuards } from './utils/Streaming.js';
 
 /**
  * R1-01: structured, NON-FATAL render-error observation.

--- a/packages/react/src/SSRRender.tsx
+++ b/packages/react/src/SSRRender.tsx
@@ -272,12 +272,13 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
 
         onError(err) {
           if (controller.isAborted) return;
-          // wireWritableGuards handles most stream errors via 'error'/'close',
-          // but React may surface errors here too; treat client disconnects as benign
+          // R0-02: this error is render-origin (React's server render surfaced it), so it is
+          // never benign by shape — a disconnect-shaped message/code thrown from app code must
+          // not be swallowed. Real client disconnects arrive via wireWritableGuards ('socket').
           const msg = String((err as any)?.message ?? '');
           warn('React stream error:', msg);
 
-          if (isBenignStreamErr(err)) {
+          if (isBenignStreamErr(err, 'render')) {
             controller.benignAbort('Client disconnected before stream finished');
 
             return;

--- a/packages/react/src/SSRRender.tsx
+++ b/packages/react/src/SSRRender.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { renderToPipeableStream, renderToString } from 'react-dom/server';
+import { renderToPipeableStream } from 'react-dom/server';
+// R3-06: the explicit `.node` subpath resolves to the Node build under EVERY condition set (its
+// exports map has only `react-server`/`default`), so neither a browser-conditioned test resolver
+// nor a bundler can pick a build without `prerenderToNodeStream`. Node-only by design — safe here
+// because R3-05's unbundled dist keeps this module out of the client entry's graph.
+import { prerenderToNodeStream } from 'react-dom/static.node';
 
 import type { Writable } from 'node:stream';
 
@@ -60,6 +65,21 @@ export type StreamOptions = {
   dataTimeoutMs?: number;
 };
 
+export type SSROptions = {
+  /**
+   * R3-06 (Q3, Policy A - signed 2026-07-12): deadline in ms for the `ssr` strategy's render
+   * (default: 10000; `0`/`Infinity` = wait forever). The `ssr` strategy now renders COMPLETE HTML -
+   * it waits for `React.lazy`/`use()` content that `renderToString` silently dropped. Nothing is
+   * served until the render finishes, so this deadline is a TTFB ceiling (hence the SHELL-class
+   * default, matching `shellTimeoutMs` - route data does not count against it; the server resolves
+   * data BEFORE the render starts). On expiry: if the shell completed, the fallback-state HTML is
+   * SERVED (React's documented abort degrade - the client completes the boundaries; an advisory
+   * warning is logged, since the `ssr` path has no `onRenderError` callback channel); if the shell
+   * never completed, the render THROWS into the host's error path instead of serving a blank page.
+   */
+  prerenderTimeoutMs?: number;
+};
+
 /**
  * Context passed to `headContent`: `data` is the resolved route data, `meta`/`routeContext` the
  * route's static metadata and per-request context. NB `headContent` returns RAW `<head>` HTML — any
@@ -85,6 +105,7 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
   appComponent,
   headContent,
   streamOptions = {},
+  ssrOptions = {},
   logger,
   enableDebug = false,
   identifierPrefix,
@@ -102,8 +123,9 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
   enableDebug?: boolean;
   logger?: LoggerLike;
   streamOptions?: StreamOptions;
+  ssrOptions?: SSROptions;
   /**
-   * React's `identifierPrefix` for `useId` (passed to `renderToString` and `renderToPipeableStream`).
+   * React's `identifierPrefix` for `useId` (passed to `prerenderToNodeStream` and `renderToPipeableStream`).
    * It MUST be identical on the server and the client for a given root (pass the same value to
    * `hydrateApp`), or hydration mismatches. Set it when rendering MORE THAN ONE τjs root on a page
    * (the app-per-boundary / micro-frontend model) so each root's `useId` values are collision-free.
@@ -112,6 +134,7 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
   identifierPrefix?: string;
 }) {
   const { shellTimeoutMs = 10_000, dataTimeoutMs = 30_000 } = streamOptions;
+  const { prerenderTimeoutMs = 10_000 } = ssrOptions;
 
   const renderSSR = async (
     initialData: T,
@@ -133,7 +156,15 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
     }
 
     let aborted = false;
-    const onAbort = () => (aborted = true);
+    // One controller composes the caller's signal with the internal deadline (R3-06). Manual
+    // composition instead of `AbortSignal.any`: portable to every environment this renders in
+    // (jsdom's AbortSignal has no `.any`, and hosts may shim the global), and which source fired
+    // stays distinguishable via `aborted` (caller) vs `deadlineHit` (deadline).
+    const renderAbort = new AbortController();
+    const onAbort = () => {
+      aborted = true;
+      renderAbort.abort(signal?.reason ?? new Error('SSR aborted by caller'));
+    };
     signal?.addEventListener('abort', onAbort, { once: true });
 
     const routeContext = opts?.routeContext;
@@ -143,9 +174,47 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
 
       const dynamicHead = headContent({ data: initialData, meta, routeContext });
       const store = createSSRStore(initialData);
-      const html = renderToString(<SSRStoreProvider store={store}>{appComponent({ location, routeContext })}</SSRStoreProvider>, {
-        identifierPrefix,
-      });
+
+      // R3-06 (Q3, Policy A): `prerenderToNodeStream` replaces `renderToString`, which could not
+      // suspend - any `React.lazy`/`use()` subtree SILENTLY became its fallback plus a
+      // client-render marker, with zero diagnostics (route data is unaffected either way: the
+      // server resolves it before calling renderSSR, so the store never suspends on this path).
+      //
+      // Deadline semantics (probes 04/05, react-dom 19.2.7): an aborted prerender NEVER rejects.
+      // Abort with the shell complete resolves with fallback-state boundaries in the prelude
+      // (the client completes them on hydration - React's documented degrade); abort before the
+      // shell completes resolves with a 0-BYTE prelude, which must become an error, never a blank
+      // 200. Real render errors outside a boundary reject the promise into the host's error path,
+      // as renderToString's throw did.
+      let deadlineHit = false;
+      const deadlineTimer =
+        Number.isFinite(prerenderTimeoutMs) && prerenderTimeoutMs > 0
+          ? setTimeout(() => {
+              deadlineHit = true;
+              renderAbort.abort(new Error(`SSR prerender deadline (${prerenderTimeoutMs}ms) reached`));
+            }, prerenderTimeoutMs)
+          : undefined;
+
+      let appHtml = '';
+      try {
+        const { prelude } = await prerenderToNodeStream(<SSRStoreProvider store={store}>{appComponent({ location, routeContext })}</SSRStoreProvider>, {
+          identifierPrefix,
+          signal: renderAbort.signal,
+          onError(err) {
+            // Advisory: boundary errors, abort reasons, and pre-reject errors all surface here.
+            // Raw value to the non-throwing UI logger - never coerce error properties eagerly
+            // (recheck-2 lesson). Fatality is decided by the outcome policy below, never here.
+            warn('SSR prerender onError:', err);
+          },
+        });
+
+        // Concat as buffers - naive string += can split a multi-byte character across chunks.
+        const chunks: Buffer[] = [];
+        for await (const chunk of prelude) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string));
+        appHtml = Buffer.concat(chunks).toString('utf8');
+      } finally {
+        if (deadlineTimer) clearTimeout(deadlineTimer);
+      }
 
       if (aborted) {
         warn('SSR completed after client abort', { location });
@@ -153,9 +222,23 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
         return { headContent: '', appHtml: '', aborted: true };
       }
 
+      if (deadlineHit) {
+        if (appHtml.length === 0) {
+          // The shell never completed (suspension outside any boundary): never serve a blank 200.
+          throw new Error(`SSR render exceeded prerenderTimeoutMs (${prerenderTimeoutMs}ms) before the shell completed`);
+        }
+
+        // Policy A degrade: serve the fallback-state HTML; the client completes the boundaries.
+        // The `ssr` path has no `onRenderError` callback channel, so the logger IS the advisory.
+        warn('SSR render hit prerenderTimeoutMs; serving fallback-state HTML (client completes the pending boundaries)', {
+          location,
+          prerenderTimeoutMs,
+        });
+      }
+
       log('Completed SSR:', location);
 
-      return { headContent: dynamicHead, appHtml: html, aborted: false };
+      return { headContent: dynamicHead, appHtml, aborted: false };
     } finally {
       try {
         signal?.removeEventListener('abort', onAbort);

--- a/packages/react/src/SSRRender.tsx
+++ b/packages/react/src/SSRRender.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import { renderToPipeableStream } from 'react-dom/server';
-// R3-06: the explicit `.node` subpath resolves to the Node build under EVERY condition set (its
-// exports map has only `react-server`/`default`), so neither a browser-conditioned test resolver
-// nor a bundler can pick a build without `prerenderToNodeStream`. Node-only by design — safe here
-// because R3-05's unbundled dist keeps this module out of the client entry's graph.
-import { prerenderToNodeStream } from 'react-dom/static.node';
+// R3-06 (+ gate-review fix): the CONDITIONAL subpath, deliberately. Node resolves it to
+// static.node.js (which exports prerenderToNodeStream); a browser bundler resolves it to
+// static.browser.js, which is browser-COMPATIBLE (no node builtins) and tree-shaken from client
+// output like the rest of this module. The earlier `react-dom/static.node` import resolved the
+// NODE build into browser graphs — clean final bytes, but externalization warnings for
+// util/crypto/async_hooks/stream, and a hard resolve error under stricter bundlers (webpack 5).
+// Namespace import + destructure: static.browser.js lacks this export, so a named import could
+// trip CJS named-export detection in some bundlers; property access cannot.
+import * as ReactDOMStatic from 'react-dom/static';
+
+const { prerenderToNodeStream } = ReactDOMStatic;
 
 import type { Writable } from 'node:stream';
 
@@ -135,6 +141,19 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
 }) {
   const { shellTimeoutMs = 10_000, dataTimeoutMs = 30_000 } = streamOptions;
   const { prerenderTimeoutMs = 10_000 } = ssrOptions;
+
+  // Gate-review fix: validate ONCE at the factory. The timer site arms only for finite positive
+  // values, so without this check every invalid input (-1, NaN, null, a string from untyped JS,
+  // -Infinity) silently became "wait forever" — only 0 and Infinity are documented sentinels.
+  const validTimeout =
+    prerenderTimeoutMs === 0 ||
+    prerenderTimeoutMs === Infinity ||
+    (typeof prerenderTimeoutMs === 'number' && Number.isFinite(prerenderTimeoutMs) && prerenderTimeoutMs > 0);
+  if (!validTimeout) {
+    throw new TypeError(
+      `createRenderer: ssrOptions.prerenderTimeoutMs must be a positive finite number of milliseconds, 0, or Infinity (received ${String(prerenderTimeoutMs)})`,
+    );
+  }
 
   const renderSSR = async (
     initialData: T,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,6 +1,6 @@
-export * from './SSRDataStore';
-export * from './SSRHydration';
-export * from './SSRRender';
+export * from './SSRDataStore.js';
+export * from './SSRHydration.js';
+export * from './SSRRender.js';
 
-export type { ServerLogs } from './utils/Logger';
-export { escapeHtml } from './utils/Html';
+export type { ServerLogs } from './utils/Logger.js';
+export { escapeHtml } from './utils/Html.js';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -3,3 +3,4 @@ export * from './SSRHydration';
 export * from './SSRRender';
 
 export type { ServerLogs } from './utils/Logger';
+export { escapeHtml } from './utils/Html';

--- a/packages/react/src/internal.ts
+++ b/packages/react/src/internal.ts
@@ -1,0 +1,16 @@
+// Package-internal only. NOT re-exported from `index.ts`, so nothing here reaches the public API.
+//
+// R1-01 (design 1 / decisions item 10): the streaming end-gate needs to know when route data has
+// settled, WITHOUT adding a public `ready` surface to `SSRStore` (that decision belongs to R3-03).
+// `createSSRStore` attaches its internal `serverDataPromise` under this symbol; the renderer reads
+// it via `getStoreReadiness`. The symbol is not part of the `SSRStore<T>` type, so consumers never
+// see it.
+export const STORE_READINESS: unique symbol = Symbol('taujs.storeReadiness');
+
+/**
+ * The store's readiness: a `Promise<void>` that RESOLVES when the route data settles — on success
+ * AND on error alike (the store swallows the fetch error into `status: 'error'`). Callers race this
+ * against a data-timeout watchdog and then read `store.status` to decide deliver-vs-fail.
+ */
+export const getStoreReadiness = (store: unknown): Promise<void> | undefined =>
+  (store as Record<symbol, unknown>)?.[STORE_READINESS] as Promise<void> | undefined;

--- a/packages/react/src/test/ClientBundle.test.ts
+++ b/packages/react/src/test/ClientBundle.test.ts
@@ -31,14 +31,36 @@ describe('R3-05 client bundle excludes the SSR renderer', () => {
       const entry = path.join(dir, 'entry.js');
       writeFileSync(entry, `import { hydrateApp } from '@taujs/react';\nconsole.log(hydrateApp);\n`);
 
+      // Gate-review fix: assert on the FULL RESOLVED GRAPH, not only the final bytes. Resolving a
+      // Node-only module into the browser graph is a defect even when tree-shaking drops it from
+      // the output (vite merely warns; stricter bundlers hard-fail on bare node builtins). NB the
+      // warning channel itself is NOT a reliable guard: vite suppresses the "externalized for
+      // browser compatibility" warnings whenever NODE_ENV is pre-set (vitest sets NODE_ENV=test)
+      // — discovered empirically. `moduleParsed` fires for every loaded module, including ones
+      // later tree-shaken and vite's `__vite-browser-external` builtin stubs, in any environment.
+      const loadedModules: string[] = [];
+      const graphRecorder = {
+        name: 'taujs-guard-graph-recorder',
+        moduleParsed(info: { id: string }) {
+          loadedModules.push(info.id);
+        },
+      };
+
       const result = (await build({
         logLevel: 'silent',
         configFile: false,
         envFile: false,
         root: dir,
+        plugins: [graphRecorder],
         resolve: { alias: { '@taujs/react': DIST_ENTRY } },
         build: { outDir: path.join(dir, 'out'), emptyOutDir: true, rollupOptions: { input: entry } },
       })) as Rollup.RollupOutput | Rollup.RollupOutput[];
+
+      // Node-only server modules and browser-externalized node builtins must not even be LOADED.
+      // (Browser-safe react-dom server modules being loaded then shaken is the accepted mechanism
+      // — the OUTPUT assertions below cover those.)
+      const nodeOnlyLoaded = loadedModules.filter((id) => /react-dom-server\.node|static\.node\.js|__vite-browser-external/.test(id));
+      expect(nodeOnlyLoaded, `Node-only modules were resolved into the browser build graph:\n${nodeOnlyLoaded.join('\n')}`).toEqual([]);
 
       const outputs = Array.isArray(result) ? result : [result];
       const chunks = outputs.flatMap((r) => r.output).filter((o): o is Rollup.OutputChunk => o.type === 'chunk');
@@ -47,9 +69,11 @@ describe('R3-05 client bundle excludes the SSR renderer', () => {
       // Sanity: the graph really was built and includes the client renderer.
       expect(moduleIds.some((id) => id.includes('react-dom'))).toBe(true);
 
-      // 'static.node' covers R3-06's prerenderToNodeStream entry (react-dom/static.node) — Node-only,
-      // must never join a browser graph.
-      const serverModules = moduleIds.filter((id) => id.includes('react-dom-server') || id.includes('server.browser') || id.includes('static.node'));
+      // 'static.node' would mean the Node prerender build joined the graph; 'static.browser' in
+      // the OUTPUT would mean tree-shaking of the conditional static entry failed.
+      const serverModules = moduleIds.filter(
+        (id) => id.includes('react-dom-server') || id.includes('server.browser') || id.includes('static.node') || id.includes('static.browser'),
+      );
       expect(serverModules, `react-dom server renderer reached the client bundle:\n${serverModules.join('\n')}`).toEqual([]);
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/packages/react/src/test/ClientBundle.test.ts
+++ b/packages/react/src/test/ClientBundle.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment node
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { build, type Rollup } from 'vite';
+import { describe, expect, it } from 'vitest';
+
+// R3-05 (Q6, signed 2026-07-12) — the durable half of the entry-point fix: a production BROWSER
+// bundle of the scaffolded client entry (`import { hydrateApp } from '@taujs/react'`) must not
+// contain react-dom's server renderer. The defect mechanism: react-dom/server's browser condition
+// is CJS and cannot be proven pure, so a bundler retains it once it is REACHABLE; the pre-R3-05
+// single-module dist made it reachable from `hydrateApp` (+519 KB in the module graph, -49% raw /
+// -48% gzip once split). The assertion is on rollup MODULE IDS — authoritative, not a string grep.
+// If React ever ships an ESM browser server build, the config that makes this pass could become
+// unnecessary — but this guard stays valid either way (absence is the contract).
+//
+// Runs against the BUILT dist (the shipped artifact — the property lives in tsup's `bundle: false`
+// output, not in src). CI builds before testing (`pnpm run check` likewise).
+const DIST_ENTRY = fileURLToPath(new URL('../../dist/index.js', import.meta.url));
+
+describe('R3-05 client bundle excludes the SSR renderer', () => {
+  it('a production browser bundle importing only hydrateApp contains no react-dom server module', { timeout: 120_000 }, async () => {
+    expect(existsSync(DIST_ENTRY), `dist missing at ${DIST_ENTRY} — run \`pnpm build\` first (CI builds before tests)`).toBe(true);
+    // Belt: the dist must be the multi-module (bundle:false) shape, or reachability is meaningless.
+    expect(readFileSync(DIST_ENTRY, 'utf8')).toMatch(/from ["']\.\/SSRHydration\.js["']/);
+
+    const dir = mkdtempSync(path.join(tmpdir(), 'taujs-react-bundle-guard-'));
+    try {
+      const entry = path.join(dir, 'entry.js');
+      writeFileSync(entry, `import { hydrateApp } from '@taujs/react';\nconsole.log(hydrateApp);\n`);
+
+      const result = (await build({
+        logLevel: 'silent',
+        configFile: false,
+        envFile: false,
+        root: dir,
+        resolve: { alias: { '@taujs/react': DIST_ENTRY } },
+        build: { outDir: path.join(dir, 'out'), emptyOutDir: true, rollupOptions: { input: entry } },
+      })) as Rollup.RollupOutput | Rollup.RollupOutput[];
+
+      const outputs = Array.isArray(result) ? result : [result];
+      const chunks = outputs.flatMap((r) => r.output).filter((o): o is Rollup.OutputChunk => o.type === 'chunk');
+      const moduleIds = chunks.flatMap((c) => Object.keys(c.modules));
+
+      // Sanity: the graph really was built and includes the client renderer.
+      expect(moduleIds.some((id) => id.includes('react-dom'))).toBe(true);
+
+      const serverModules = moduleIds.filter((id) => id.includes('react-dom-server') || id.includes('server.browser'));
+      expect(serverModules, `react-dom server renderer reached the client bundle:\n${serverModules.join('\n')}`).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/react/src/test/ClientBundle.test.ts
+++ b/packages/react/src/test/ClientBundle.test.ts
@@ -47,7 +47,9 @@ describe('R3-05 client bundle excludes the SSR renderer', () => {
       // Sanity: the graph really was built and includes the client renderer.
       expect(moduleIds.some((id) => id.includes('react-dom'))).toBe(true);
 
-      const serverModules = moduleIds.filter((id) => id.includes('react-dom-server') || id.includes('server.browser'));
+      // 'static.node' covers R3-06's prerenderToNodeStream entry (react-dom/static.node) — Node-only,
+      // must never join a browser graph.
+      const serverModules = moduleIds.filter((id) => id.includes('react-dom-server') || id.includes('server.browser') || id.includes('static.node'));
       expect(serverModules, `react-dom server renderer reached the client bundle:\n${serverModules.join('\n')}`).toEqual([]);
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/packages/react/src/test/HydrationBeacon.test.tsx
+++ b/packages/react/src/test/HydrationBeacon.test.tsx
@@ -25,18 +25,22 @@ beforeEach(() => {
 });
 
 describe('hydrateApp dev-hook emission (P0B-04, spec 03 §7)', () => {
-  it('emits start/success around user callbacks — internal first, user second', () => {
+  it('emits hydration:start internal-first (beacon before user callback); success is DEFERRED to first commit', () => {
     const order: string[] = [];
     (window as any).__TAUJS_DEVTOOLS_HOOK__ = { emit: (ev: string) => order.push(`hook:${ev}`) };
     setup({ a: 1 });
 
+    const onSuccess = vi.fn(() => order.push('user:success'));
     hydrateApp({
       appComponent: App,
       onStart: () => order.push('user:start'),
-      onSuccess: () => order.push('user:success'),
+      onSuccess,
     });
 
-    expect(order).toEqual(['hook:hydration:start', 'user:start', 'hook:hydration:success', 'user:success']);
+    // start is internal-first; success is a first-COMMIT signal, so with a no-op mock it has NOT
+    // fired synchronously (the success internal-first ordering is proven in the integration suite).
+    expect(order).toEqual(['hook:hydration:start', 'user:start']);
+    expect(onSuccess).not.toHaveBeenCalled();
     expect(RDC.hydrateRoot).toHaveBeenCalledTimes(1);
   });
 
@@ -55,7 +59,7 @@ describe('hydrateApp dev-hook emission (P0B-04, spec 03 §7)', () => {
     expect(onHydrationError).toHaveBeenCalledTimes(1);
   });
 
-  it('user callbacks fire identically when the hook is absent (regression)', () => {
+  it('onStart fires when the hook is absent (regression); onSuccess is deferred to commit', () => {
     setup({ a: 1 });
     const onStart = vi.fn();
     const onSuccess = vi.fn();
@@ -63,20 +67,20 @@ describe('hydrateApp dev-hook emission (P0B-04, spec 03 §7)', () => {
     hydrateApp({ appComponent: App, onStart, onSuccess });
 
     expect(onStart).toHaveBeenCalledTimes(1);
-    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess).not.toHaveBeenCalled(); // first-commit signal; no-op mock never commits
   });
 
-  it('a throwing hook never affects hydration or user callbacks', () => {
+  it('a throwing hook never affects hydration or the start callback', () => {
     (window as any).__TAUJS_DEVTOOLS_HOOK__ = {
       emit: () => {
         throw new Error('hostile hook');
       },
     };
     setup({ a: 1 });
-    const onSuccess = vi.fn();
+    const onStart = vi.fn();
 
-    expect(() => hydrateApp({ appComponent: App, onSuccess })).not.toThrow();
-    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(() => hydrateApp({ appComponent: App, onStart })).not.toThrow();
+    expect(onStart).toHaveBeenCalledTimes(1);
     expect(RDC.hydrateRoot).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/react/src/test/SSRDataStore.supersede.test.tsx
+++ b/packages/react/src/test/SSRDataStore.supersede.test.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { act } from '@testing-library/react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createSSRStore, SSRStoreProvider, useSSRStore } from '..';
+import { getStoreReadiness } from '../internal.js';
+
+// R3-08 (S2) — an explicit `setData` supersedes the in-flight initial promise. Reproduced pre-fix
+// (probe 07): a LATE loader rejection flipped status to 'error', `getSnapshot` started throwing,
+// and React tore the committed tree down (DOM wiped to "", onUncaughtError "SSR data fetch
+// failed: loader failed late"); a LATE resolution silently overwrote the explicit value.
+
+const Comp = () => {
+  const d = useSSRStore<{ v: string }>();
+  return <span>{d.v}</span>;
+};
+
+let consoleError: ReturnType<typeof vi.spyOn>;
+beforeEach(() => {
+  consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  consoleError.mockRestore();
+});
+
+describe('R3-08 setData supersedes the in-flight initial promise', () => {
+  it('a late loader REJECTION does not tear down a tree committed via setData', async () => {
+    let rejectLoader!: (e: Error) => void;
+    const store = createSSRStore<{ v: string }>(
+      new Promise((_, rej) => {
+        rejectLoader = rej;
+      }),
+    );
+    store.setData({ v: 'from-setData' });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const uncaught: unknown[] = [];
+    const root = createRoot(container, { onUncaughtError: (e) => uncaught.push(e) });
+
+    await act(async () => {
+      root.render(
+        <SSRStoreProvider store={store}>
+          <Comp />
+        </SSRStoreProvider>,
+      );
+    });
+    expect(container.innerHTML).toBe('<span>from-setData</span>');
+
+    await act(async () => {
+      rejectLoader(new Error('loader failed late'));
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    expect(container.innerHTML).toBe('<span>from-setData</span>');
+    expect(uncaught).toEqual([]);
+    expect(store.status).toBe('success');
+    expect(store.lastError).toBeUndefined();
+
+    root.unmount();
+    container.remove();
+  });
+
+  it('a late loader RESOLUTION does not overwrite an explicit setData', async () => {
+    let resolveLoader!: (v: { v: string }) => void;
+    const store = createSSRStore<{ v: string }>(
+      new Promise((res) => {
+        resolveLoader = res;
+      }),
+    );
+    store.setData({ v: 'from-setData' });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <SSRStoreProvider store={store}>
+          <Comp />
+        </SSRStoreProvider>,
+      );
+    });
+
+    await act(async () => {
+      resolveLoader({ v: 'from-loader' });
+      await new Promise((r) => setTimeout(r, 10));
+    });
+
+    expect(container.innerHTML).toBe('<span>from-setData</span>');
+    expect(store.getSnapshot()).toEqual({ v: 'from-setData' });
+
+    root.unmount();
+    container.remove();
+  });
+
+  it('control: without setData the loader still settles the store normally (success and error)', async () => {
+    const success = createSSRStore<{ v: string }>(Promise.resolve({ v: 'from-loader' }));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(success.getSnapshot()).toEqual({ v: 'from-loader' });
+
+    const failure = createSSRStore<{ v: string }>(Promise.reject(new Error('loader boom')));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(failure.status).toBe('error');
+    expect(() => failure.getSnapshot()).toThrow('SSR data fetch failed: loader boom');
+  });
+
+  it('the internal readiness promise still settles when the loader is superseded (both settlement kinds)', async () => {
+    let resolveLoader!: (v: { v: string }) => void;
+    const resolved = createSSRStore<{ v: string }>(
+      new Promise((res) => {
+        resolveLoader = res;
+      }),
+    );
+    resolved.setData({ v: 'x' });
+
+    let rejectLoader!: (e: Error) => void;
+    const rejected = createSSRStore<{ v: string }>(
+      new Promise((_, rej) => {
+        rejectLoader = rej;
+      }),
+    );
+    rejected.setData({ v: 'x' });
+
+    const settled: string[] = [];
+    void getStoreReadiness(resolved)!.then(() => settled.push('resolved-loader'));
+    void getStoreReadiness(rejected)!.then(() => settled.push('rejected-loader'));
+
+    resolveLoader({ v: 'y' });
+    rejectLoader(new Error('late boom'));
+    await new Promise((r) => setTimeout(r, 10));
+
+    // The streaming end-gate awaits this promise — supersession must never create a hang class.
+    expect(settled.sort()).toEqual(['rejected-loader', 'resolved-loader']);
+  });
+});

--- a/packages/react/src/test/SSRDataStore.test.tsx
+++ b/packages/react/src/test/SSRDataStore.test.tsx
@@ -103,7 +103,7 @@ describe('createSSRStore', () => {
     console.error = consoleError;
   });
 
-  it('should allow setting data before initialDataPromise resolves', async () => {
+  it('should allow setting data before initialDataPromise resolves (setData supersedes the loader - R3-08)', async () => {
     let resolvePromise: (value: Record<string, unknown>) => void;
     const initialDataPromise = new Promise<any>((resolve) => {
       resolvePromise = resolve;
@@ -122,7 +122,10 @@ describe('createSSRStore', () => {
       await initialDataPromise;
     });
 
-    expect(store.getSnapshot()).toEqual({ foo: 'bar' });
+    // R3-08: the previous assertion here ({ foo: 'bar' }) had FROZEN the defect - the loader's
+    // late settlement silently overwrote the explicit setData. Signed ruling S2: setData
+    // supersedes the in-flight initial promise.
+    expect(store.getSnapshot()).toEqual({ foo: 'early' });
   });
 
   it('should remove subscriber after unsubscribe', async () => {

--- a/packages/react/src/test/SSRDataStore.test.tsx
+++ b/packages/react/src/test/SSRDataStore.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import React from 'react';
 import { act, render } from '@testing-library/react';
 import { screen } from '@testing-library/dom';
@@ -252,6 +252,8 @@ describe('SSRStoreProvider and useSSRStore', () => {
     console.error = consoleError;
   });
 
+  // R3-02 (C2): a thrown STRING keeps its message unquoted. This test previously froze the old
+  // behaviour, where `new Error(String(JSON.stringify(error)))` quoted it as '"not an error object"'.
   it('should handle non-Error thrown values', async () => {
     const errorPromise = Promise.reject('not an error object');
     const store = createSSRStore(errorPromise);
@@ -265,7 +267,7 @@ describe('SSRStoreProvider and useSSRStore', () => {
 
     await new Promise((r) => setImmediate(r));
 
-    expect(() => store.getSnapshot()).toThrow('SSR data fetch failed: "not an error object"');
+    expect(() => store.getSnapshot()).toThrow('SSR data fetch failed: not an error object');
 
     console.error = consoleError;
   });
@@ -427,5 +429,72 @@ describe('SSRStoreProvider and useSSRStore', () => {
     await p;
 
     expect(() => store.getServerSnapshot()).toThrow('Server data not available - check SSR configuration');
+  });
+});
+
+describe('R3-02 C2: error normalisation (pattern parity with @taujs/vue)', () => {
+  const settle = () => new Promise<void>((r) => setTimeout(r, 0));
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => errSpy.mockRestore());
+
+  it('a thrown STRING keeps its message unquoted (was \'"boom"\')', async () => {
+    const store = createSSRStore<any>(() => Promise.reject('boom'));
+    await settle();
+    expect(store.status).toBe('error');
+    expect(store.lastError).toBeInstanceOf(Error);
+    expect(store.lastError!.message).toBe('boom');
+  });
+
+  it('a thrown OBJECT is JSON-stringified', async () => {
+    const store = createSSRStore<any>(() => Promise.reject({ code: 500, msg: 'nope' }));
+    await settle();
+    expect(store.lastError!.message).toBe('{"code":500,"msg":"nope"}');
+  });
+
+  it('a thrown ERROR is preserved as the same instance', async () => {
+    const original = new Error('original');
+    const store = createSSRStore<any>(() => Promise.reject(original));
+    await settle();
+    expect(store.lastError).toBe(original);
+  });
+
+  it('a CIRCULAR object falls back to String(error) and does NOT throw (previously an unhandled rejection)', async () => {
+    const circular: any = { a: 1 };
+    circular.self = circular; // JSON.stringify throws on this
+    const store = createSSRStore<any>(() => Promise.reject(circular));
+    await settle();
+    expect(store.status).toBe('error');
+    expect(store.lastError).toBeInstanceOf(Error);
+    expect(store.lastError!.message).toBe('[object Object]');
+  });
+});
+
+describe('R3-02 C3: useSSRStore reads the store directly (no deferred value, no identity memo)', () => {
+  it('setData is observed by the consumer without an extra deferred render pass', async () => {
+    const store = createSSRStore<{ n: number }>({ n: 1 });
+    const seen: number[] = [];
+    const Consumer = () => {
+      const d = useSSRStore<{ n: number }>();
+      seen.push(d.n);
+      return <span data-testid="v">{d.n}</span>;
+    };
+
+    render(
+      <SSRStoreProvider store={store}>
+        <Consumer />
+      </SSRStoreProvider>,
+    );
+    expect(screen.getByTestId('v').textContent).toBe('1');
+
+    await act(async () => {
+      store.setData({ n: 2 });
+    });
+
+    expect(screen.getByTestId('v').textContent).toBe('2');
+    // Previously useDeferredValue produced [1, 1, 2] - an extra render serving one-render-stale data.
+    expect(seen).toEqual([1, 2]);
   });
 });

--- a/packages/react/src/test/SSRHydration.integration.test.tsx
+++ b/packages/react/src/test/SSRHydration.integration.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { hydrateApp } from '../SSRHydration';
+import { createRenderer } from '../SSRRender';
 
 // R2-01 / T1b — REAL react-dom/client in jsdom. Mocked-React tests cannot catch the R2-01 class:
 // hydration render failures are ASYNC (they arrive via the root's onUncaughtError, verified against
@@ -195,6 +196,27 @@ describe('R2-01 hydration observability (real react-dom/client)', () => {
     } finally {
       (globalThis as { reportError?: unknown }).reportError = prevReportError;
     }
+  });
+
+  // R2-04 regression: the internal commit reporter WRAPS the app (adds depth only). If it ever regresses
+  // to a SIBLING, it shifts every useId in the app and the client tree's ids diverge from the SSR
+  // markup -> a hydration mismatch. Guard the mismatch-free hydration of a useId app end-to-end.
+  it('useId app: taujs SSR markup hydrates with NO mismatch (reporter wraps, does not shift useId)', async () => {
+    const IdApp = () => {
+      const id = React.useId();
+      return <span data-id={id}>{id}</span>;
+    };
+    const { appHtml } = await createRenderer({ appComponent: () => <IdApp />, headContent: () => '' }).renderSSR({}, '/id-app');
+    setRoot('root', appHtml);
+    (window as unknown as Record<string, unknown>).__INITIAL_DATA__ = { a: 1 };
+    const warn = vi.fn();
+
+    hydrateApp({ appComponent: <IdApp />, logger: { warn } });
+
+    await flush();
+
+    // No recoverable hydration mismatch: the app's useId is identical on server and client.
+    expect(warn.mock.calls.filter((c) => String(c[0]).includes('Recoverable'))).toHaveLength(0);
   });
 
   it('CSR SUCCESS + settled-guard: onSuccess fires once on commit (createRoot DOUBLE-invokes the reporter effect under StrictMode), NO beacon, NO onStart', async () => {

--- a/packages/react/src/test/SSRHydration.integration.test.tsx
+++ b/packages/react/src/test/SSRHydration.integration.test.tsx
@@ -219,6 +219,27 @@ describe('R2-01 hydration observability (real react-dom/client)', () => {
     expect(warn.mock.calls.filter((c) => String(c[0]).includes('Recoverable'))).toHaveLength(0);
   });
 
+  // R2-04: identifierPrefix must be plumbed through hydrateApp so prefixed SSR markup hydrates cleanly.
+  it('identifierPrefix: prefixed SSR markup hydrates with the matching prefix and NO mismatch', async () => {
+    const IdApp = () => {
+      const id = React.useId();
+      return <span data-id={id}>{id}</span>;
+    };
+    const { appHtml } = await createRenderer({ appComponent: () => <IdApp />, headContent: () => '', identifierPrefix: 'app1-' }).renderSSR({}, '/id');
+    expect(appHtml).toContain('app1-'); // sanity: the SSR markup carries the prefix
+    setRoot('root', appHtml);
+    (window as unknown as Record<string, unknown>).__INITIAL_DATA__ = { a: 1 };
+    const warn = vi.fn();
+
+    hydrateApp({ appComponent: <IdApp />, identifierPrefix: 'app1-', logger: { warn } });
+
+    await flush();
+
+    // Client used the matching prefix -> ids equal the server render -> no recoverable mismatch.
+    expect(warn.mock.calls.filter((c) => String(c[0]).includes('Recoverable'))).toHaveLength(0);
+    expect(document.getElementById('root')?.innerHTML ?? '').toContain('app1-');
+  });
+
   it('CSR SUCCESS + settled-guard: onSuccess fires once on commit (createRoot DOUBLE-invokes the reporter effect under StrictMode), NO beacon, NO onStart', async () => {
     setRoot('root'); // no SSR html
     // no __INITIAL_DATA__ → CSR path. NB: unlike hydrateRoot, createRoot double-invokes the reporter

--- a/packages/react/src/test/SSRHydration.integration.test.tsx
+++ b/packages/react/src/test/SSRHydration.integration.test.tsx
@@ -41,10 +41,15 @@ beforeEach(() => {
   document.body.innerHTML = '';
   delete (window as unknown as Record<string, unknown>).__INITIAL_DATA__;
   delete (window as unknown as Record<string, unknown>).__TAUJS_DEVTOOLS_HOOK__;
+  // Real browsers expose globalThis.reportError; jsdom does NOT. Stub it present by default so the
+  // renderer's global-surfacing takes the reportError branch (no unhandled window 'error' event that
+  // would fail the run). The two dedicated global-surfacing tests override this locally.
+  (globalThis as { reportError?: unknown }).reportError = vi.fn();
 });
 
 afterEach(() => {
   document.body.innerHTML = '';
+  delete (globalThis as { reportError?: unknown }).reportError;
 });
 
 describe('R2-01 hydration observability (real react-dom/client)', () => {
@@ -250,6 +255,37 @@ describe('R2-01 hydration observability (real react-dom/client)', () => {
     expect(beacons.filter((b) => b === 'hydration:success')).toHaveLength(1);
     expect(document.getElementById('root')?.innerHTML ?? '').toContain('app'); // root NOT torn down
     expect(errorLog).toHaveBeenCalled(); // the throw was logged
+  });
+
+  // Recheck MEDIUM: global surfacing must work even when globalThis.reportError is ABSENT (older
+  // browsers / runtimes) — React's default falls back to dispatching a window 'error' event, so a
+  // plain reportError?.() would silently lose window.onerror monitoring. Complements POST-SETTLEMENT
+  // (which stubs reportError present) so BOTH branches are covered.
+  it('GLOBAL SURFACING FALLBACK: with no globalThis.reportError, an uncaught error still reaches window.onerror via ErrorEvent', async () => {
+    setRoot('root', '<div>app</div>');
+    (window as unknown as Record<string, unknown>).__INITIAL_DATA__ = { a: 1 };
+    const prevReportError = (globalThis as { reportError?: unknown }).reportError;
+    (globalThis as { reportError?: unknown }).reportError = undefined; // runtime without reportError
+
+    const globalErrors: unknown[] = [];
+    const handler = (e: Event) => {
+      e.preventDefault(); // suppress jsdom's default noisy logging
+      globalErrors.push((e as ErrorEvent).error);
+    };
+    window.addEventListener('error', handler);
+
+    try {
+      hydrateApp({ appComponent: <Boom />, logger: { error: vi.fn() }, onHydrationError: vi.fn() });
+
+      await flush();
+
+      expect(globalErrors.length).toBeGreaterThanOrEqual(1);
+      expect(globalErrors[0]).toBeInstanceOf(Error);
+      expect((globalErrors[0] as Error).message).toBe('render-boom');
+    } finally {
+      window.removeEventListener('error', handler);
+      (globalThis as { reportError?: unknown }).reportError = prevReportError;
+    }
   });
 
   // Gate-review HIGH (companion): onHydrationError runs inside our onUncaughtError handler. A throw

--- a/packages/react/src/test/SSRHydration.integration.test.tsx
+++ b/packages/react/src/test/SSRHydration.integration.test.tsx
@@ -1,0 +1,275 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { hydrateApp } from '../SSRHydration';
+
+// R2-01 / T1b — REAL react-dom/client in jsdom. Mocked-React tests cannot catch the R2-01 class:
+// hydration render failures are ASYNC (they arrive via the root's onUncaughtError, verified against
+// react-dom 19.2), and provable success is a component effect firing after FIRST COMMIT. A sync
+// try/catch around hydrateRoot/createRoot never observes either (review #4). These repros are
+// FAILING-FIRST against the pre-R2-01 renderer (which emits success synchronously and routes no
+// client render error); they go green once the single root-error adapter + reporter land.
+
+const flush = (ms = 40) => new Promise<void>((r) => setTimeout(r, ms));
+
+type Beacon = 'hydration:start' | 'hydration:success' | 'hydration:error';
+
+// Capture dev-hook beacon emissions AND their interleave with user callbacks (internal-first proof).
+function harness() {
+  const order: string[] = [];
+  const beacons: Beacon[] = [];
+  (window as unknown as { __TAUJS_DEVTOOLS_HOOK__?: unknown }).__TAUJS_DEVTOOLS_HOOK__ = {
+    emit: (ev: Beacon) => {
+      beacons.push(ev);
+      order.push(`hook:${ev}`);
+    },
+  };
+  return { order, beacons };
+}
+
+function setRoot(id = 'root', html = '') {
+  document.body.innerHTML = `<div id="${id}">${html}</div>`;
+  return document.getElementById(id)!;
+}
+
+const Boom = (): React.ReactElement => {
+  throw new Error('render-boom');
+};
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  delete (window as unknown as Record<string, unknown>).__INITIAL_DATA__;
+  delete (window as unknown as Record<string, unknown>).__TAUJS_DEVTOOLS_HOOK__;
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('R2-01 hydration observability (real react-dom/client)', () => {
+  it('SUCCESS TIMING: hydration:success/onSuccess fire only AFTER first commit, not synchronously (fails today: sync)', async () => {
+    setRoot('root', '<div>app</div>');
+    (window as unknown as Record<string, unknown>).__INITIAL_DATA__ = { a: 1 };
+    const { order, beacons } = harness();
+    const onSuccess = vi.fn(() => order.push('user:success'));
+    const onStart = vi.fn(() => order.push('user:start'));
+
+    hydrateApp({ appComponent: <div>app</div>, onStart, onSuccess });
+
+    // Synchronously after the call, START has fired but SUCCESS has NOT (it awaits first commit).
+    expect(beacons).toContain('hydration:start');
+    expect(beacons).not.toContain('hydration:success');
+    expect(onSuccess).not.toHaveBeenCalled();
+
+    await flush();
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(beacons.filter((b) => b === 'hydration:success')).toHaveLength(1);
+    // internal-first: the success beacon precedes the user success callback
+    expect(order.indexOf('hook:hydration:success')).toBeLessThan(order.indexOf('user:success'));
+  });
+
+  it('HYDRATE THROW (no boundary): onHydrationError + hydration:error fire (async); success does NOT (fails today)', async () => {
+    setRoot('root', '<div>app</div>');
+    (window as unknown as Record<string, unknown>).__INITIAL_DATA__ = { a: 1 };
+    const { beacons } = harness();
+    const onHydrationError = vi.fn();
+    const onSuccess = vi.fn();
+
+    hydrateApp({ appComponent: <Boom />, logger: { error: vi.fn() }, onHydrationError, onSuccess });
+
+    await flush();
+
+    expect(onHydrationError).toHaveBeenCalledTimes(1);
+    expect(onHydrationError.mock.calls[0]![0]).toBeInstanceOf(Error);
+    expect(beacons).toContain('hydration:error');
+    expect(beacons).not.toContain('hydration:success');
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('CSR THROW (no data → createRoot): onHydrationError fires (async), NO beacon (CSR is not a hydration) (fails today)', async () => {
+    setRoot('root'); // no SSR html
+    // no __INITIAL_DATA__ → CSR path
+    const { beacons } = harness();
+    const onHydrationError = vi.fn();
+
+    hydrateApp({ appComponent: <Boom />, logger: { error: vi.fn(), warn: vi.fn() }, onHydrationError });
+
+    await flush();
+
+    expect(onHydrationError).toHaveBeenCalledTimes(1);
+    expect(beacons).toHaveLength(0); // CSR emits NO beacon events (vue parity)
+  });
+
+  it('MISMATCH → recoverable: success still fires on commit, NO failure report, warn logged', async () => {
+    setRoot('root', '<div>SERVER</div>'); // server html differs from client
+    (window as unknown as Record<string, unknown>).__INITIAL_DATA__ = { a: 1 };
+    const { beacons } = harness();
+    const warn = vi.fn();
+    const onSuccess = vi.fn();
+    const onHydrationError = vi.fn();
+
+    hydrateApp({ appComponent: <div>CLIENT</div>, logger: { warn }, onSuccess, onHydrationError });
+
+    await flush();
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(beacons).toContain('hydration:success');
+    expect(onHydrationError).not.toHaveBeenCalled();
+    expect(beacons).not.toContain('hydration:error');
+    expect(warn).toHaveBeenCalled(); // recoverable mismatch is a warning
+  });
+
+  it('MISSING ROOT: routes to onHydrationError + hydration:error (fails today: log + return only)', async () => {
+    document.body.innerHTML = ''; // no #root
+    (window as unknown as Record<string, unknown>).__INITIAL_DATA__ = { a: 1 };
+    const { beacons } = harness();
+    const onHydrationError = vi.fn();
+
+    hydrateApp({ appComponent: <div>app</div>, logger: { error: vi.fn() }, onHydrationError });
+
+    await flush();
+
+    expect(onHydrationError).toHaveBeenCalledTimes(1);
+    expect((onHydrationError.mock.calls[0]![0] as Error).message).toContain('not found');
+    expect(beacons).toContain('hydration:error');
+  });
+
+  it('SINGLE SETTLEMENT: a hydrate throw settles failure exactly once — one hydration:error, no success', async () => {
+    setRoot('root', '<div>app</div>');
+    (window as unknown as Record<string, unknown>).__INITIAL_DATA__ = { a: 1 };
+    const { beacons } = harness();
+    const onHydrationError = vi.fn();
+    const onSuccess = vi.fn();
+
+    hydrateApp({ appComponent: <Boom />, logger: { error: vi.fn() }, onHydrationError, onSuccess });
+
+    await flush(80); // give StrictMode's double-invoke + any late ticks time
+
+    expect(onHydrationError).toHaveBeenCalledTimes(1);
+    expect(beacons.filter((b) => b === 'hydration:error')).toHaveLength(1);
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(beacons).not.toContain('hydration:success');
+  });
+
+  it('POST-SETTLEMENT: success survives a LATER uncaught error — onHydrationError NOT re-fired, no 2nd beacon, but it still surfaces globally', async () => {
+    setRoot('root', '<div>ok</div>');
+    (window as unknown as Record<string, unknown>).__INITIAL_DATA__ = { a: 1 };
+    const { beacons } = harness();
+    const onSuccess = vi.fn();
+    const onHydrationError = vi.fn();
+    const reportErrorSpy = vi.fn();
+    const prevReportError = (globalThis as { reportError?: unknown }).reportError;
+    (globalThis as { reportError?: unknown }).reportError = reportErrorSpy;
+
+    // Commits cleanly (settles success), then a delayed state update makes it throw with no boundary.
+    const Later = (): React.ReactElement => {
+      const [boom, setBoom] = React.useState(false);
+      React.useEffect(() => {
+        const t = setTimeout(() => setBoom(true), 10);
+        return () => clearTimeout(t);
+      }, []);
+      if (boom) throw new Error('post-commit-boom');
+
+      return <div>ok</div>;
+    };
+
+    try {
+      hydrateApp({ appComponent: <Later />, logger: { error: vi.fn() }, onSuccess, onHydrationError });
+
+      await flush(90); // first commit (success) + the 10ms delayed throw
+
+      expect(onSuccess).toHaveBeenCalledTimes(1); // settled on first commit
+      expect(onHydrationError).not.toHaveBeenCalled(); // NOT re-fired post-settlement (log-only)
+      expect(beacons.filter((b) => b === 'hydration:error')).toHaveLength(0); // no 2nd beacon
+      expect(beacons.filter((b) => b === 'hydration:success')).toHaveLength(1);
+      // The later error still reaches the global channel (window.onerror / monitoring) — the
+      // observability the custom onUncaughtError would otherwise suppress.
+      expect(reportErrorSpy).toHaveBeenCalled();
+    } finally {
+      (globalThis as { reportError?: unknown }).reportError = prevReportError;
+    }
+  });
+
+  it('CSR SUCCESS + settled-guard: onSuccess fires once on commit (createRoot DOUBLE-invokes the reporter effect under StrictMode), NO beacon, NO onStart', async () => {
+    setRoot('root'); // no SSR html
+    // no __INITIAL_DATA__ → CSR path. NB: unlike hydrateRoot, createRoot double-invokes the reporter
+    // effect under <StrictMode>, so this is the case where the single-settlement guard is genuinely
+    // exercised — onSuccess-once proves the `settled` flag collapses the double fire.
+    const { beacons } = harness();
+    const onStart = vi.fn();
+    const onSuccess = vi.fn();
+
+    hydrateApp({ appComponent: <div>csr</div>, onStart, onSuccess });
+
+    await flush(80);
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onStart).not.toHaveBeenCalled();
+    expect(beacons).toHaveLength(0);
+  });
+
+  it('HYDRATE SUCCESS settles onSuccess exactly once (hydrateRoot does not double-invoke the effect)', async () => {
+    setRoot('root', '<div>app</div>');
+    (window as unknown as Record<string, unknown>).__INITIAL_DATA__ = { a: 1 };
+    const { beacons } = harness();
+    const onSuccess = vi.fn();
+
+    hydrateApp({ appComponent: <div>app</div>, onSuccess });
+
+    await flush(80);
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(beacons.filter((b) => b === 'hydration:success')).toHaveLength(1);
+  });
+
+  // Gate-review HIGH: onSuccess runs INSIDE the reporter's React effect. An un-isolated throw would
+  // become an uncaught ROOT error → our own onUncaughtError → mis-classified as post-settlement
+  // telemetry WHILE React tears the committed root down. Isolation must keep the throw out of React's
+  // error domain: the DOM stays mounted, success fires once, and NO failure is manufactured.
+  it('CALLBACK ISOLATION: a throwing onSuccess is logged; root stays mounted, one success, NO failure', async () => {
+    setRoot('root', '<div>app</div>');
+    (window as unknown as Record<string, unknown>).__INITIAL_DATA__ = { a: 1 };
+    const { beacons } = harness();
+    const errorLog = vi.fn();
+    const onHydrationError = vi.fn();
+    let successCalls = 0;
+    const onSuccess = () => {
+      successCalls += 1;
+      throw new Error('onSuccess-boom');
+    };
+
+    hydrateApp({ appComponent: <div>app</div>, logger: { error: errorLog }, onSuccess, onHydrationError });
+
+    await flush(90);
+
+    expect(successCalls).toBe(1); // fired once
+    expect(onHydrationError).not.toHaveBeenCalled(); // the throw did NOT become a failure
+    expect(beacons.filter((b) => b === 'hydration:error')).toHaveLength(0);
+    expect(beacons.filter((b) => b === 'hydration:success')).toHaveLength(1);
+    expect(document.getElementById('root')?.innerHTML ?? '').toContain('app'); // root NOT torn down
+    expect(errorLog).toHaveBeenCalled(); // the throw was logged
+  });
+
+  // Gate-review HIGH (companion): onHydrationError runs inside our onUncaughtError handler. A throw
+  // must be logged, not escape the root adapter, and not create a second settlement.
+  it('CALLBACK ISOLATION: a throwing onHydrationError is logged and does not escape or double-settle', async () => {
+    setRoot('root', '<div>app</div>');
+    (window as unknown as Record<string, unknown>).__INITIAL_DATA__ = { a: 1 };
+    const { beacons } = harness();
+    let errCalls = 0;
+    const onHydrationError = () => {
+      errCalls += 1;
+      throw new Error('onHydrationError-boom');
+    };
+
+    hydrateApp({ appComponent: <Boom />, logger: { error: vi.fn() }, onHydrationError });
+
+    await flush(90);
+
+    expect(errCalls).toBe(1); // called once, its throw swallowed
+    expect(beacons.filter((b) => b === 'hydration:error')).toHaveLength(1); // single settlement
+    expect(beacons.filter((b) => b === 'hydration:success')).toHaveLength(0);
+  });
+});

--- a/packages/react/src/test/SSRHydration.test.tsx
+++ b/packages/react/src/test/SSRHydration.test.tsx
@@ -140,6 +140,26 @@ describe('hydrateApp (lean bootstrap: hydrate if data, else CSR)', () => {
     delete (window as any).__TAUJS_DEVTOOLS_HOOK__;
   });
 
+  it('R2-04: identifierPrefix reaches BOTH roots - hydrateRoot (data present) and createRoot (CSR fallback)', () => {
+    // hydrate path
+    addRoot('root');
+    (window as any).__INITIAL_DATA__ = { a: 1 };
+    hydrateApp({ appComponent: <div>App</div>, identifierPrefix: 'hyd-' });
+    expect((RDC as any).__getHydrateOpts()).toEqual(expect.objectContaining({ identifierPrefix: 'hyd-' }));
+    expect(RDC.createRoot).not.toHaveBeenCalled();
+
+    // CSR fallback path (no SSR data) - the option must reach createRoot too, else two CSR roots on
+    // one page collide on useId. Removing it from only this call would otherwise leave tests green.
+    vi.clearAllMocks();
+    resetDom();
+    addRoot('root');
+    (window as any).__INITIAL_DATA__ = undefined;
+    hydrateApp({ appComponent: <div>App</div>, identifierPrefix: 'csr-' });
+    expect(RDC.hydrateRoot).not.toHaveBeenCalled();
+    expect((RDC as any).__getCreateOpts()).toEqual(expect.objectContaining({ identifierPrefix: 'csr-' }));
+    expect(RDC.createRoot).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ identifierPrefix: 'csr-' }));
+  });
+
   it('logs error and aborts when root element is missing', () => {
     (window as any).__INITIAL_DATA__ = { a: 1 };
     const error = vi.fn();

--- a/packages/react/src/test/SSRHydration.test.tsx
+++ b/packages/react/src/test/SSRHydration.test.tsx
@@ -3,21 +3,24 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import React from 'react';
 
 vi.mock('react-dom/client', () => {
-  let capturedRecoverable: ((err: any, info: any) => void) | undefined;
+  let hydrateOpts: any;
+  let createOpts: any;
 
-  const hydrateRoot = vi.fn((el: any, node: any, opts?: { onRecoverableError?: (e: any, info?: any) => void }) => {
-    capturedRecoverable = opts?.onRecoverableError;
+  const hydrateRoot = vi.fn((el: any, node: any, opts?: any) => {
+    hydrateOpts = opts;
     return {}; // ReactRoot-ish
   });
 
-  const createRoot = vi.fn((el: any) => {
+  const createRoot = vi.fn((el: any, opts?: any) => {
+    createOpts = opts;
     return { render: vi.fn() };
   });
 
   return {
     hydrateRoot,
     createRoot,
-    __getCapturedRecoverable: () => capturedRecoverable,
+    __getHydrateOpts: () => hydrateOpts,
+    __getCreateOpts: () => createOpts,
   };
 });
 
@@ -56,7 +59,7 @@ describe('hydrateApp (lean bootstrap: hydrate if data, else CSR)', () => {
 
   afterEach(() => vi.restoreAllMocks());
 
-  it('hydrates successfully; calls onStart/onSuccess and wires recoverable handler', () => {
+  it('hydrates: onStart fires, root-error adapter wired to hydrateRoot; success is DEFERRED to first commit (not sync)', () => {
     const root = addRoot('root');
     (window as any).__INITIAL_DATA__ = { hello: 'world' };
 
@@ -80,21 +83,55 @@ describe('hydrateApp (lean bootstrap: hydrate if data, else CSR)', () => {
     expect(RDC.hydrateRoot).toHaveBeenCalledTimes(1);
     expect((RDC.hydrateRoot as any).mock.calls[0]![0]).toBe(root);
 
-    // recoverable error path
-    const getRec = (RDC as any).__getCapturedRecoverable as () => ((e: any, info: any) => void) | undefined;
-    const rec = getRec();
-    expect(typeof rec).toBe('function');
-    rec?.(new Error('rec'), { digest: 'x' });
+    // R2-01: the single root-error adapter is wired — all three handlers present.
+    const opts = (RDC as any).__getHydrateOpts();
+    expect(typeof opts.onUncaughtError).toBe('function');
+    expect(typeof opts.onCaughtError).toBe('function');
+    expect(typeof opts.onRecoverableError).toBe('function');
+    // recoverable → warn (log-only, never a failure)
+    opts.onRecoverableError(new Error('rec'), { digest: 'x' });
     expect(warn).toHaveBeenCalledWith('Recoverable hydration error:', expect.any(Error), expect.objectContaining({ digest: 'x' }));
 
-    // finished
-    expect(log).toHaveBeenCalledWith('Hydration completed');
     expect(onStart).toHaveBeenCalledTimes(1);
-    expect(onSuccess).toHaveBeenCalledTimes(1);
+    // Success is now a first-COMMIT signal (reporter effect). The no-op mock never commits, so
+    // onSuccess has NOT fired synchronously — the real commit path is covered in the integration suite.
+    expect(onSuccess).not.toHaveBeenCalled();
 
     // no CSR here
     expect(RDC.createRoot).not.toHaveBeenCalled();
     expect(error).not.toHaveBeenCalled();
+  });
+
+  it('a throwing onStart is isolated — hydration still proceeds to hydrateRoot (single-settlement intact)', () => {
+    addRoot('root');
+    (window as any).__INITIAL_DATA__ = { a: 1 };
+    const onStart = () => {
+      throw new Error('onStart-boom');
+    };
+
+    expect(() => hydrateApp({ appComponent: <div>App</div>, logger: { error: vi.fn() }, onStart })).not.toThrow();
+    expect(RDC.hydrateRoot).toHaveBeenCalledTimes(1); // reached despite the throw
+  });
+
+  it('failure-then-late-failure: a second uncaught error is telemetry only (one onHydrationError, one beacon)', () => {
+    addRoot('root');
+    (window as any).__INITIAL_DATA__ = { a: 1 };
+    const emit = vi.fn();
+    (window as any).__TAUJS_DEVTOOLS_HOOK__ = { emit };
+    const onHydrationError = vi.fn();
+
+    hydrateApp({ appComponent: <div>App</div>, logger: { error: vi.fn() }, onHydrationError });
+
+    // Drive the captured root adapter twice — React can surface more than one root error.
+    const opts = (RDC as any).__getHydrateOpts();
+    opts.onUncaughtError(new Error('first'), {});
+    opts.onUncaughtError(new Error('second'), {});
+
+    expect(onHydrationError).toHaveBeenCalledTimes(1); // settled once
+    expect((onHydrationError.mock.calls[0]![0] as Error).message).toBe('first');
+    expect(emit.mock.calls.filter((c: any[]) => c[0] === 'hydration:error')).toHaveLength(1);
+
+    delete (window as any).__TAUJS_DEVTOOLS_HOOK__;
   });
 
   it('logs error and aborts when root element is missing', () => {
@@ -151,9 +188,9 @@ describe('hydrateApp (lean bootstrap: hydrate if data, else CSR)', () => {
     expect(warn).toHaveBeenCalledWith('No initial SSR data at window["__INITIAL_DATA__"]. Mounting CSR.');
     expect(RDC.hydrateRoot).not.toHaveBeenCalled();
 
-    // CSR render path
+    // CSR render path — createRoot receives the root-error adapter (R2-01)
     expect(root.innerHTML).toBe('');
-    expect(RDC.createRoot).toHaveBeenCalledWith(root);
+    expect(RDC.createRoot).toHaveBeenCalledWith(root, expect.objectContaining({ onUncaughtError: expect.any(Function) }));
     const rootInstance = (RDC.createRoot as any).mock.results[0]!.value;
     expect(rootInstance.render).toHaveBeenCalledTimes(1);
 
@@ -206,12 +243,14 @@ describe('hydrateApp (lean bootstrap: hydrate if data, else CSR)', () => {
     expect(error).not.toHaveBeenCalled();
   });
 
-  it('does NOT call onStart/onSuccess in CSR mode (no SSR data)', () => {
+  it('CSR mode: onStart never fires; onSuccess is deferred to first commit (not synchronous)', () => {
     addRoot();
     const onStart = vi.fn(),
       onSuccess = vi.fn();
     hydrateApp({ appComponent: <div>App</div>, onStart, onSuccess });
 
+    // onStart is a hydration-only signal (CSR is not a hydration). onSuccess IS emitted on the CSR
+    // path — but on first commit, so the no-op mock never fires it (real commit tested in integration).
     expect(onStart).not.toHaveBeenCalled();
     expect(onSuccess).not.toHaveBeenCalled();
     expect(RDC.createRoot).toHaveBeenCalledTimes(1);
@@ -231,6 +270,6 @@ describe('hydrateApp (lean bootstrap: hydrate if data, else CSR)', () => {
     expect(Store.createSSRStore).toHaveBeenCalledWith({}); // the {} as T path
 
     expect(RDC.hydrateRoot).not.toHaveBeenCalled();
-    expect(RDC.createRoot).toHaveBeenCalledWith(root);
+    expect(RDC.createRoot).toHaveBeenCalledWith(root, expect.objectContaining({ onUncaughtError: expect.any(Function) }));
   });
 });

--- a/packages/react/src/test/SSRHydration.test.tsx
+++ b/packages/react/src/test/SSRHydration.test.tsx
@@ -55,9 +55,15 @@ describe('hydrateApp (lean bootstrap: hydrate if data, else CSR)', () => {
     vi.clearAllMocks();
     resetDom();
     setReadyState('complete');
+    // jsdom lacks globalThis.reportError; stub it present so the renderer's global-surfacing takes the
+    // reportError branch instead of dispatching an unhandled window 'error' event (which fails the run).
+    (globalThis as { reportError?: unknown }).reportError = vi.fn();
   });
 
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (globalThis as { reportError?: unknown }).reportError;
+  });
 
   it('hydrates: onStart fires, root-error adapter wired to hydrateRoot; success is DEFERRED to first commit (not sync)', () => {
     const root = addRoot('root');

--- a/packages/react/src/test/SSRRender.integration.test.tsx
+++ b/packages/react/src/test/SSRRender.integration.test.tsx
@@ -481,6 +481,54 @@ describe('R1-01 integration (real react-dom/server)', () => {
     expect(onError).toHaveBeenCalledTimes(1);
   });
 
+  // Recheck finding (MEDIUM): the data deadline must be torn down by CONTROLLER cleanup, not by the
+  // writable's 'close' event — a writable created with `emitClose: false` is destroyed WITHOUT emitting
+  // 'close'. On abort with pending data, the deadline's timer + 'close' listener must be released
+  // promptly (without waiting out dataTimeoutMs), not retained. (React keeps its OWN 'close' listener
+  // on the piped destination, so we isolate the DEADLINE's listener via an once() spy rather than a
+  // raw count.)
+  it("emitClose:false writable: controller cleanup disarms the data deadline (its 'close' listener is removed without a 'close' event)", async () => {
+    const writable = new PassThrough({ emitClose: false }); // destroy() will NOT emit 'close'
+    const onError = vi.fn();
+    const onAllReady = vi.fn();
+
+    // Both the writable guards and the deadline register `once('close', …)`; the deadline's is LAST
+    // (armed at shell commit, after guards). Capture the last close-once handler = the deadline disarm.
+    let deadlineClose: ((...a: unknown[]) => void) | undefined;
+    const realOnce = writable.once.bind(writable);
+    vi.spyOn(writable, 'once').mockImplementation(((event: string, handler: (...a: unknown[]) => void) => {
+      if (event === 'close') deadlineClose = handler;
+      return realOnce(event as never, handler);
+    }) as never);
+
+    const AppNoConsumer = () => <div>no consumer</div>;
+    const { done, abort } = createRenderer<Data>({ appComponent: () => <AppNoConsumer />, headContent: () => '<title>x</title>' }).renderStream(
+      writable,
+      { onHead: () => {}, onError, onAllReady },
+      () => new Promise<Data>(() => {}), // never settles → deadline armed at shell commit
+      '/emit-close-false',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { dataTimeoutMs: 5_000 }, // long — the point is PROMPT disarm on abort, not waiting it out
+    );
+
+    await settle(40); // shell commits → deadline armed; deadlineClose captured
+    expect(deadlineClose).toBeDefined();
+    expect(writable.listeners('close')).toContain(deadlineClose); // armed
+
+    abort(); // manual benign abort → controller cleanup → stopDataDeadline (authoritative, no 'close')
+    await expect(done).resolves.toBeUndefined();
+    await settle(20); // brief — nowhere near the 5s deadline; no 'close' event fires (emitClose:false)
+
+    // The deadline's specific 'close' listener was removed by CONTROLLER cleanup, not by a 'close'
+    // event. (Before the fix it relied on 'close' and would linger here until dataTimeoutMs.)
+    expect(writable.listeners('close')).not.toContain(deadlineClose);
+    expect(onError).not.toHaveBeenCalled();
+    expect(onAllReady).not.toHaveBeenCalled();
+  });
+
   // Review finding (HIGH + #10): abort DURING the deferred-end data wait must not leak the
   // dataTimeout timer, must not fire a spurious/late fatal onError, and must not deliver data or
   // end() a torn-down writable.

--- a/packages/react/src/test/SSRRender.integration.test.tsx
+++ b/packages/react/src/test/SSRRender.integration.test.tsx
@@ -409,6 +409,78 @@ describe('R1-01 integration (real react-dom/server)', () => {
     expect(chunks.join('')).not.toContain('app-body');
   });
 
+  // Gate-review finding 1 (HIGH): a <Suspense> store consumer whose data NEVER settles keeps React's
+  // stream open, so React never calls the sink's end(). The route-data deadline must fire ANYWAY —
+  // it is armed at shell commit, independent of end(). (Before the fix, the timer lived only in the
+  // end path, so this leaked the request/render/writable/loader indefinitely.)
+  it('bounded liveness: a suspending store consumer whose data NEVER settles → fallback shell ships, done REJECTS with the data-timeout error, writable torn down', async () => {
+    const { writable, chunks, state } = driveServerSide();
+    const onAllReady = vi.fn();
+
+    const Consumer = () => {
+      const data = useSSRStore<Data>();
+      return <div>value:{String(data.value)}</div>;
+    };
+    const App = () => (
+      <div>
+        <p>shell</p>
+        <Suspense fallback={<span>loading-fallback</span>}>
+          <Consumer />
+        </Suspense>
+      </div>
+    );
+
+    const { done } = createRenderer<Data>({ appComponent: () => <App />, headContent: () => '<title>x</title>' }).renderStream(
+      writable,
+      { onHead: () => {}, onAllReady },
+      () => new Promise<Data>(() => {}), // NEVER settles; the consumer suspends on it forever
+      '/never-settles-consumer',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { dataTimeoutMs: 80 },
+    );
+
+    await expect(done).rejects.toThrow(/Route data not ready/); // bounded despite React never ending
+    // The fallback shell WAS streamed before the deadline fired (React committed the shell).
+    expect(chunks.join('')).toContain('loading-fallback');
+    expect(onAllReady).not.toHaveBeenCalled();
+    await settle(40);
+    expect(writable.destroyed).toBe(true); // React + writable torn down, not leaked
+    expect(state.finished).toBe(false);
+  });
+
+  // Gate-review finding 2 (HIGH): the host onError may synchronously abort the SAME AbortSignal wired
+  // to the renderer's benign-cancel path (the server calls ac.abort() inside onError). A fatal must
+  // still REJECT done — the re-entrant benign abort must not win the one-shot controller and downgrade
+  // it to a benign resolve. (Before the fix, failFatal called onError before claiming fatal, so the
+  // re-entrant benignAbort resolved done and the contract-mandated rejection was lost.)
+  it('re-entrant abort: a fatal whose onError aborts the passed signal still REJECTS done (no benign downgrade), onError once', async () => {
+    const { writable } = driveServerSide();
+    const ac = new AbortController();
+    const original = new Error('reentrant-fatal-original');
+    const onError = vi.fn(() => ac.abort()); // aborts the very signal wired to controller.benignAbort
+
+    const FatalNoBoundary = () => {
+      throw original; // synchronous throw OUTSIDE any boundary → onShellError → failFatal(original)
+    };
+
+    const { done } = createRenderer<Data>({ appComponent: () => <FatalNoBoundary />, headContent: () => '<title>x</title>' }).renderStream(
+      writable,
+      { onHead: () => {}, onError },
+      { value: 1 },
+      '/reentrant-abort',
+      undefined,
+      undefined,
+      undefined,
+      ac.signal, // the signal onError will abort re-entrantly
+    );
+
+    await expect(done).rejects.toThrow('reentrant-fatal-original'); // rejected, NOT benign-resolved
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
   // Review finding (HIGH + #10): abort DURING the deferred-end data wait must not leak the
   // dataTimeout timer, must not fire a spurious/late fatal onError, and must not deliver data or
   // end() a torn-down writable.

--- a/packages/react/src/test/SSRRender.integration.test.tsx
+++ b/packages/react/src/test/SSRRender.integration.test.tsx
@@ -608,3 +608,42 @@ describe('R1-01 integration (real react-dom/server)', () => {
     expect(chunks.join('')).toContain('backpressure-body');
   });
 });
+
+describe('R2-04 identifierPrefix (real react-dom/server)', () => {
+  const IdApp = () => {
+    const id = React.useId();
+    return <span data-id={id}>{id}</span>;
+  };
+
+  it('renderSSR embeds identifierPrefix in useId output', async () => {
+    const { appHtml } = await createRenderer<Data>({ appComponent: () => <IdApp />, headContent: () => '', identifierPrefix: 'app1-' }).renderSSR(
+      { value: 1 },
+      '/id',
+    );
+    expect(appHtml).toContain('app1-');
+  });
+
+  it('two roots with distinct prefixes produce disjoint useId sets', async () => {
+    const render = (prefix: string) =>
+      createRenderer<Data>({ appComponent: () => <IdApp />, headContent: () => '', identifierPrefix: prefix }).renderSSR({ value: 1 }, '/id');
+    const [a, b] = await Promise.all([render('app1-'), render('app2-')]);
+    expect(a.appHtml).toContain('app1-');
+    expect(b.appHtml).toContain('app2-');
+    expect(a.appHtml).not.toContain('app2-');
+    expect(b.appHtml).not.toContain('app1-');
+  });
+
+  it('renderStream embeds identifierPrefix in the streamed output', async () => {
+    const { writable, chunks } = driveServerSide();
+    const { done } = createRenderer<Data>({
+      appComponent: () => <IdApp />,
+      headContent: () => '<title>x</title>',
+      identifierPrefix: 'stream1-',
+    }).renderStream(writable, { onHead: () => {} }, { value: 1 }, '/id');
+
+    await done.catch(() => {});
+    await settle();
+
+    expect(chunks.join('')).toContain('stream1-');
+  });
+});

--- a/packages/react/src/test/SSRRender.integration.test.tsx
+++ b/packages/react/src/test/SSRRender.integration.test.tsx
@@ -1,0 +1,490 @@
+// @vitest-environment node
+import { PassThrough } from 'node:stream';
+
+import React, { Suspense } from 'react';
+import { renderToPipeableStream } from 'react-dom/server';
+import { describe, it, expect, vi } from 'vitest';
+
+import { createRenderer } from '../SSRRender';
+import type { RenderErrorInfo } from '../SSRRender';
+import { useSSRStore } from '../SSRDataStore';
+
+// R1-01 / T1a — REAL react-dom/server, REAL PassThrough. Mocked-React tests cannot catch the
+// R2/R3 class because those live in the interaction with React's actual stream-end + error timing.
+//
+// These repros are FAILING-FIRST against the pre-rework renderer (documented in the report); they
+// go green once the bounded end-gate + onRenderError policy land.
+
+type Data = { value?: number };
+
+// Collect the streamed bytes AND simulate the server's `finish` handler: it appends
+// `window.__INITIAL_DATA__ = finalData ?? {}` when the writable finishes (HandleRender.ts).
+function driveServerSide() {
+  const writable = new PassThrough();
+  const chunks: string[] = [];
+  writable.on('data', (c) => chunks.push(c.toString()));
+
+  const state: { finalData: unknown; finishData: unknown; finished: boolean } = {
+    finalData: undefined,
+    finishData: undefined,
+    finished: false,
+  };
+
+  writable.on('finish', () => {
+    state.finishData = state.finalData ?? {};
+    state.finished = true;
+  });
+
+  return { writable, chunks, state };
+}
+
+const settle = (ms = 120) => new Promise<void>((r) => setTimeout(r, ms));
+
+// ── React behaviour FACTS (pure react-dom/server) ────────────────────────────────────────────
+// The R3 policy (post-shell errors are recoverable; timing does not prove recoverability) rests on
+// how React's own `renderToPipeableStream` sequences onShellReady / onShellError / onError / finish.
+// These probes drive React DIRECTLY (no τjs renderer) and record the observed order — if any
+// contradicts the R1-01 ground truth, that's an escalation, not an implementation detail.
+describe('React behaviour facts (pure react-dom/server)', () => {
+  const driveReact = (element: React.ReactElement) =>
+    new Promise<{ events: string[]; errors: string[]; finished: boolean }>((resolve) => {
+      const writable = new PassThrough();
+      const events: string[] = [];
+      const errors: string[] = [];
+      let finished = false;
+      writable.on('finish', () => {
+        finished = true;
+      });
+
+      const done = () => resolve({ events, errors, finished });
+
+      const { pipe } = renderToPipeableStream(element, {
+        onShellReady() {
+          events.push('shellReady');
+          pipe(writable);
+        },
+        onShellError() {
+          events.push('shellError');
+          done();
+        },
+        onAllReady() {
+          events.push('allReady');
+        },
+        onError(err) {
+          events.push('error');
+          errors.push(String((err as Error)?.message ?? err));
+        },
+      });
+
+      writable.on('finish', done);
+      setTimeout(done, 1500); // safety net
+    });
+
+  it('POST-SHELL boundary error → onError fires, NOT onShellError; shell commits and the stream still COMPLETES', async () => {
+    let resolved = false;
+    const gate = new Promise<void>((r) =>
+      setTimeout(() => {
+        resolved = true;
+        r();
+      }, 30),
+    );
+    const PostShellThrower = () => {
+      if (!resolved) throw gate; // suspend past the shell
+      throw new Error('post-shell boom'); // then throw (post-shell)
+    };
+
+    const { events, errors, finished } = await driveReact(
+      <div>
+        <p>shell</p>
+        <Suspense fallback={<span>loading</span>}>
+          <PostShellThrower />
+        </Suspense>
+      </div>,
+    );
+
+    expect(events).toContain('shellReady');
+    expect(events).toContain('error');
+    expect(events).not.toContain('shellError');
+    expect(finished).toBe(true); // React completed the stream despite the post-shell error
+    expect(errors).toContain('post-shell boom');
+  });
+
+  it('PRE-SHELL error inside a boundary whose fallback ships in the shell → onError (pre-shell), shell still commits', async () => {
+    const PreShellThrower = () => {
+      throw new Error('pre-shell recoverable'); // synchronous throw during shell render
+    };
+
+    const { events, errors, finished } = await driveReact(
+      <div>
+        <p>shell</p>
+        <Suspense fallback={<span>fallback</span>}>
+          <PreShellThrower />
+        </Suspense>
+      </div>,
+    );
+
+    // error observed; shell still commits (fallback in shell); no shellError; stream completes.
+    expect(events).toContain('error');
+    expect(events).toContain('shellReady');
+    expect(events).not.toContain('shellError');
+    expect(finished).toBe(true);
+    expect(errors).toContain('pre-shell recoverable');
+  });
+
+  it('PRE-SHELL error OUTSIDE any boundary → onShellError (fatal), shell does NOT commit', async () => {
+    const FatalNoBoundary = () => {
+      throw new Error('pre-shell fatal');
+    };
+
+    const { events, errors } = await driveReact(
+      <div>
+        <FatalNoBoundary />
+      </div>,
+    );
+
+    expect(events).toContain('shellError');
+    expect(events).not.toContain('shellReady');
+    // React reports the error via BOTH onError and onShellError.
+    expect(errors).toContain('pre-shell fatal');
+  });
+});
+
+describe('R1-01 integration (real react-dom/server)', () => {
+  it('R2: late-resolving data with NO store consumer — finish must serialize the RESOLVED data, not {}', async () => {
+    const { writable, state } = driveServerSide();
+
+    // App that never reads the store, so nothing suspends → React ends the shell immediately.
+    const AppNoConsumer = () => <div>no consumer</div>;
+
+    const { renderStream } = createRenderer<Data>({
+      appComponent: () => <AppNoConsumer />,
+      headContent: () => '<title>x</title>',
+    });
+
+    const { done } = renderStream(
+      writable,
+      { onAllReady: (d) => (state.finalData = d) },
+      () => new Promise<Data>((r) => setTimeout(() => r({ value: 42 }), 40)), // resolves AFTER the shell
+      '/no-consumer',
+    );
+
+    await done.catch(() => {});
+    await settle();
+
+    // Pre-rework: the pipe ends before the thunk resolves → finishData === {} (silent data loss).
+    // Post-rework (bounded end-gate): end is deferred until readiness → the resolved data is present.
+    expect(state.finished).toBe(true);
+    expect(state.finishData).toEqual({ value: 42 });
+  });
+
+  it('control: a suspending consumer already serializes resolved data today (should pass pre- and post-rework)', async () => {
+    const { writable, state } = driveServerSide();
+
+    // App that READS the store → suspends until data resolves → React defers stream end already.
+    const AppConsumer = () => {
+      const data = useSSRStore<Data>();
+      return <div>{String(data.value)}</div>;
+    };
+
+    const { renderStream } = createRenderer<Data>({
+      appComponent: () => (
+        <Suspense fallback={<div>loading</div>}>
+          <AppConsumer />
+        </Suspense>
+      ),
+      headContent: () => '<title>x</title>',
+    });
+
+    const { done } = renderStream(
+      writable,
+      { onAllReady: (d) => (state.finalData = d) },
+      () => new Promise<Data>((r) => setTimeout(() => r({ value: 42 }), 40)),
+      '/consumer',
+    );
+
+    await done.catch(() => {});
+    await settle();
+
+    expect(state.finishData).toEqual({ value: 42 });
+  });
+
+  it('THROW/SUSPENSE INTACT: a component reading the store SUSPENDS (fallback in the shell), then the resolved content streams out-of-order', async () => {
+    const { writable, chunks, state } = driveServerSide();
+
+    // getServerSnapshot throws serverDataPromise while pending → this component SUSPENDS. The
+    // refactor left that throw untouched and the end-gate waits on the SAME serverDataPromise.
+    const Consumer = () => {
+      const data = useSSRStore<Data>();
+      return <div>value:{String(data.value)}</div>;
+    };
+    const App = () => (
+      <div>
+        <p>shell</p>
+        <Suspense fallback={<span>loading-fallback</span>}>
+          <Consumer />
+        </Suspense>
+      </div>
+    );
+
+    const { done } = createRenderer<Data>({ appComponent: () => <App />, headContent: () => '<title>x</title>' }).renderStream(
+      writable,
+      { onHead: () => {}, onAllReady: (d) => (state.finalData = d) },
+      () => new Promise<Data>((r) => setTimeout(() => r({ value: 42 }), 40)),
+      '/suspends',
+    );
+
+    await done.catch(() => {});
+    await settle();
+
+    // React splits adjacent text with a `<!-- -->` marker (`value:<!-- -->42`), so strip HTML
+    // comments before matching the resolved text.
+    const html = chunks.join('');
+    const text = html.replace(/<!--.*?-->/g, '');
+    // React suspended on the store's throw (`<!--$?-->` pending boundary, NOT `<!--$!-->` error) →
+    // the shell carried the FALLBACK, and the resolved content streamed out-of-order once the data
+    // settled. The throw-a-promise + Suspense + streaming path is intact and the data serialized.
+    expect(html).toContain('<!--$?-->'); // React suspended (pending), did NOT error the boundary
+    expect(html).not.toContain('server rendering errored'); // no client-render fallback
+    expect(html).toContain('loading-fallback'); // fallback shipped in the shell (component suspended)
+    expect(text).toContain('value:42'); // resolved content streamed after the suspension resolved
+    expect(state.finishData).toEqual({ value: 42 });
+  });
+
+  it('R3 post-shell: a boundary error AFTER the shell → done RESOLVES, onRenderError {post-shell, recoverable:true}, NO fatal onError', async () => {
+    const { writable, state } = driveServerSide();
+    const onError = vi.fn();
+    const renderErrors: RenderErrorInfo[] = [];
+
+    let resolved = false;
+    const gate = new Promise<void>((r) =>
+      setTimeout(() => {
+        resolved = true;
+        r();
+      }, 30),
+    );
+    const PostShellThrower = () => {
+      if (!resolved) throw gate; // suspend past the shell
+      throw new Error('post-shell boom'); // then throw (post-shell)
+    };
+    const App = () => (
+      <div>
+        <p>shell</p>
+        <Suspense fallback={<span>loading</span>}>
+          <PostShellThrower />
+        </Suspense>
+      </div>
+    );
+
+    const { done } = createRenderer<Data>({ appComponent: () => <App />, headContent: () => '<title>x</title>' }).renderStream(
+      writable,
+      { onAllReady: (d) => (state.finalData = d), onError, onRenderError: (i) => renderErrors.push(i) },
+      { value: 1 }, // resolved data → the end-gate is immediate; isolates the R3 behaviour
+      '/post-shell',
+    );
+
+    // Pre-rework: the renderer fatal-aborts on the post-shell onError → done REJECTS (over-abort).
+    // Post-rework: React recovers the boundary client-side; done RESOLVES, no fatal, onRenderError fired.
+    await expect(done).resolves.toBeUndefined();
+    expect(onError).not.toHaveBeenCalled();
+    expect(renderErrors).toContainEqual(expect.objectContaining({ phase: 'post-shell', recoverable: true }));
+  });
+
+  it('R3 pre-shell recoverable: fallback-in-shell boundary error → onRenderError {pre-shell, unknown}, shell commits, done RESOLVES', async () => {
+    const { writable, state } = driveServerSide();
+    const onError = vi.fn();
+    const renderErrors: RenderErrorInfo[] = [];
+
+    const PreShellThrower = () => {
+      throw new Error('pre-shell recoverable'); // synchronous throw; boundary fallback is in the shell
+    };
+    const App = () => (
+      <div>
+        <p>shell</p>
+        <Suspense fallback={<span>fallback</span>}>
+          <PreShellThrower />
+        </Suspense>
+      </div>
+    );
+
+    const { done } = createRenderer<Data>({ appComponent: () => <App />, headContent: () => '<title>x</title>' }).renderStream(
+      writable,
+      { onAllReady: (d) => (state.finalData = d), onError, onRenderError: (i) => renderErrors.push(i) },
+      { value: 1 },
+      '/pre-shell-recoverable',
+    );
+
+    await expect(done).resolves.toBeUndefined();
+    expect(onError).not.toHaveBeenCalled();
+    expect(renderErrors).toContainEqual(expect.objectContaining({ phase: 'pre-shell', recoverable: 'unknown' }));
+  });
+
+  it('R3 pre-shell fatal: error OUTSIDE any boundary → done REJECTS from onShellError; onRenderError fired {pre-shell} but was NOT the fatal source', async () => {
+    const { writable } = driveServerSide();
+    const onError = vi.fn();
+    const renderErrors: RenderErrorInfo[] = [];
+
+    const FatalNoBoundary = () => {
+      throw new Error('pre-shell fatal');
+    };
+
+    const { done } = createRenderer<Data>({
+      appComponent: () => (
+        <div>
+          <FatalNoBoundary />
+        </div>
+      ),
+      headContent: () => '<title>x</title>',
+    }).renderStream(writable, { onError, onRenderError: (i) => renderErrors.push(i) }, { value: 1 }, '/pre-shell-fatal');
+
+    await expect(done).rejects.toThrow('pre-shell fatal');
+    // the advisory channel still observed it as pre-shell (fails today: onRenderError not wired)
+    expect(renderErrors).toContainEqual(expect.objectContaining({ phase: 'pre-shell' }));
+    // fatal came via the fatal onError (onShellError → fail), exactly once
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it('bounded gate: no consumer + never-settling data + small dataTimeoutMs → done REJECTS, writable destroyed (fails today: ends early with data loss)', async () => {
+    const { writable } = driveServerSide();
+    const AppNoConsumer = () => <div>no consumer</div>;
+
+    const { done } = createRenderer<Data>({ appComponent: () => <AppNoConsumer />, headContent: () => '<title>x</title>' }).renderStream(
+      writable,
+      { onHead: () => {} },
+      () => new Promise<Data>(() => {}), // never resolves
+      '/never-settles',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { dataTimeoutMs: 60 }, // small → the end-gate must fail deterministically
+    );
+
+    await expect(done).rejects.toThrow();
+    await settle();
+    expect(writable.destroyed).toBe(true);
+  });
+
+  it('store data error: rejecting loader → end-gate observes store.status "error" → done REJECTS with the loader error, no silent empty finish', async () => {
+    const { writable, state } = driveServerSide();
+    const boom = new Error('loader exploded');
+    const AppNoConsumer = () => <div>no consumer</div>;
+
+    // No store consumer → React finishes immediately and ends the gate; the gate then races the
+    // (rejecting) data promise. The store swallows the rejection into status:'error', so readiness
+    // RESOLVES and the gate must read the error status and fatal-abort — rather than end() the
+    // response with empty data (the R2 silent-data-loss class).
+    const { done } = createRenderer<Data>({ appComponent: () => <AppNoConsumer />, headContent: () => '<title>x</title>' }).renderStream(
+      writable,
+      { onHead: () => {} },
+      () => Promise.reject(boom),
+      '/store-error',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { dataTimeoutMs: 5_000 },
+    );
+
+    await expect(done).rejects.toThrow('loader exploded');
+    await settle();
+    // The gate fatal-aborted; it did NOT let the writable finish with `{}` serialized as data.
+    expect(state.finished).toBe(false);
+  });
+
+  it('onHead throws → done REJECTS (fatal, required callback) and NOTHING is piped (fails today: warns and continues)', async () => {
+    const { writable, chunks } = driveServerSide();
+
+    const { done } = createRenderer<Data>({ appComponent: () => <div>app-body</div>, headContent: () => '<title>x</title>' }).renderStream(
+      writable,
+      {
+        onHead: () => {
+          throw new Error('onHead boom');
+        },
+      },
+      { value: 1 },
+      '/onhead-throws',
+    );
+
+    await expect(done).rejects.toThrow('onHead boom');
+    expect(chunks.join('')).not.toContain('app-body');
+  });
+
+  // Review finding (HIGH + #10): abort DURING the deferred-end data wait must not leak the
+  // dataTimeout timer, must not fire a spurious/late fatal onError, and must not deliver data or
+  // end() a torn-down writable.
+  it('abort during the deferred-end wait: done RESOLVES benign, no onAllReady, no late/spurious onError even after data settles', async () => {
+    const { writable, state } = driveServerSide();
+    const onAllReady = vi.fn();
+    const onError = vi.fn();
+    let resolveData!: (d: Data) => void;
+    const dataP = new Promise<Data>((r) => (resolveData = r));
+    const AppNoConsumer = () => <div>no consumer</div>;
+
+    const { done, abort } = createRenderer<Data>({ appComponent: () => <AppNoConsumer />, headContent: () => '<title>x</title>' }).renderStream(
+      writable,
+      { onHead: () => {}, onAllReady, onError },
+      () => dataP, // still pending when React ends the shell → the gate arms its timer
+      '/abort-mid-wait',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { dataTimeoutMs: 5_000 }, // long — the test aborts long before it could fire
+    );
+
+    await settle(40); // let React commit the shell and arm the deferred-end timer
+    abort(); // benign abort mid-wait → controller destroys the writable
+    await expect(done).resolves.toBeUndefined();
+    expect(writable.destroyed).toBe(true);
+
+    resolveData({ value: 7 }); // data settles AFTER the abort
+    await settle(120);
+    expect(onAllReady).not.toHaveBeenCalled(); // delivery suppressed post-abort
+    expect(onError).not.toHaveBeenCalled(); // the leaked timer used to fire a spurious fatal here
+    expect(state.finished).toBe(false); // no end() on the torn-down writable
+  });
+
+  // Review finding #4: a loader that resolves to `undefined` settles status:'success' with no data;
+  // reading the snapshot at delivery throws — that must become a clean fatal, never a hung response.
+  it('loader resolves to undefined → done REJECTS (clean fatal), not a hang', async () => {
+    const { writable } = driveServerSide();
+    const onError = vi.fn();
+
+    const { done } = createRenderer<Data>({ appComponent: () => <div>x</div>, headContent: () => '<title>x</title>' }).renderStream(
+      writable,
+      { onHead: () => {}, onError },
+      () => Promise.resolve(undefined as unknown as Data),
+      '/undefined-data',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { dataTimeoutMs: 300 }, // small: if this were a hang, the test would only pass via the timeout
+    );
+
+    await expect(done).rejects.toThrow(/undefined/i);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  // Review finding #7: prove React's backpressure actually flows THROUGH the delegating sink. With a
+  // 1-byte highWaterMark and no consumer, write() returns false and React parks on a 'drain' listener
+  // it attaches via the sink's on(). If that forwarding were dropped, React would stall forever and
+  // done would never resolve; resuming the reader must let it complete with all bytes intact.
+  it('backpressure: a paused tiny-highWaterMark sink stalls React, then completes on resume (drain forwarded through the sink)', async () => {
+    const writable = new PassThrough({ highWaterMark: 1 });
+
+    const { done } = createRenderer<Data>({ appComponent: () => <div>backpressure-body</div>, headContent: () => '<title>x</title>' }).renderStream(
+      writable,
+      { onHead: () => {} },
+      { value: 1 },
+      '/backpressure',
+    );
+
+    await settle(60); // React writes, the tiny hwm returns false, React parks on 'drain'
+    const chunks: string[] = [];
+    writable.on('data', (c) => chunks.push(c.toString())); // resume flow → 'drain' fires → React continues
+
+    await expect(done).resolves.toBeUndefined();
+    expect(chunks.join('')).toContain('backpressure-body');
+  });
+});

--- a/packages/react/src/test/SSRRender.prerender.test.tsx
+++ b/packages/react/src/test/SSRRender.prerender.test.tsx
@@ -1,0 +1,218 @@
+// @vitest-environment jsdom
+import React, { Suspense, use } from 'react';
+import { hydrateRoot } from 'react-dom/client';
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createSSRStore, SSRStoreProvider, useSSRStore } from '../SSRDataStore.js';
+import { createRenderer } from '../SSRRender.js';
+
+// R3-06 (Q3, Policy A - signed 2026-07-12) - real react-dom, no mocks. Pins:
+// 1. the OUTPUT-EQUIVALENCE gate (decisions addendum): for non-suspending trees the prerender
+//    prelude is byte-identical to renderToString - the no-regression proof for every route that
+//    works today;
+// 2. the degrade matrix (probes 04/05): deadline + boundary => serve fallback-state HTML
+//    (<!--$?-->) + advisory warn; deadline + no boundary => throw (never a blank 200); caller
+//    abort => the existing { aborted: true } contract;
+// 3. the E2E degrade outcome: the served fallback-state page hydrates and the CLIENT completes
+//    the boundary (exactly one recoverable error, zero uncaught).
+
+const never = new Promise<string>(() => {});
+const delayed = (ms: number, v: string) => new Promise<string>((r) => setTimeout(() => r(v), ms));
+
+describe('R3-06 output equivalence with renderToString (non-suspending trees)', () => {
+  const cases: Array<{
+    name: string;
+    app: (props: { location: string; routeContext?: unknown }) => React.ReactElement;
+    identifierPrefix?: string;
+  }> = [
+    {
+      name: 'plain tree',
+      app: ({ location }) => (
+        <div>
+          <h1>Title</h1>
+          <p>{location}</p>
+        </div>
+      ),
+    },
+    {
+      name: 'Suspense boundary whose children never suspend (resolved store consumer)',
+      app: () => {
+        const Consumer = () => {
+          const d = useSSRStore<{ k: string }>();
+          return <em>{d.k}</em>;
+        };
+        return (
+          <div>
+            <Suspense fallback={<i>F</i>}>
+              <Consumer />
+            </Suspense>
+          </div>
+        );
+      },
+    },
+    {
+      name: 'useId tree with identifierPrefix',
+      identifierPrefix: 'tau1',
+      app: () => {
+        const IdComp = () => {
+          const id = React.useId();
+          return <span id={id}>x</span>;
+        };
+        return (
+          <form>
+            <IdComp />
+            <IdComp />
+          </form>
+        );
+      },
+    },
+  ];
+
+  for (const { name, app, identifierPrefix } of cases) {
+    it(`byte-identical: ${name}`, async () => {
+      const renderer = createRenderer<{ k: string }>({ appComponent: app, headContent: () => '<head/>', identifierPrefix });
+      const out = await renderer.renderSSR({ k: 'v' }, '/route', {});
+
+      const store = createSSRStore({ k: 'v' });
+      const expected = renderToString(<SSRStoreProvider store={store}>{app({ location: '/route' })}</SSRStoreProvider>, { identifierPrefix });
+
+      expect(out.aborted).toBe(false);
+      expect(out.appHtml).toBe(expected);
+    });
+  }
+});
+
+describe('R3-06 Policy A degrade matrix (real react-dom)', () => {
+  it('deadline with a suspending child INSIDE a boundary: serves fallback-state HTML + advisory warn, no throw', async () => {
+    const warn = vi.fn();
+    const Reader = () => <section>{use(never)}</section>;
+    const renderer = createRenderer<{ k: string }>({
+      appComponent: () => (
+        <div>
+          <h1>SHELL</h1>
+          <Suspense fallback={<i>FALLBACK</i>}>
+            <Reader />
+          </Suspense>
+        </div>
+      ),
+      headContent: () => '<head/>',
+      ssrOptions: { prerenderTimeoutMs: 100 },
+      logger: { warn },
+    });
+
+    const out = await renderer.renderSSR({ k: 'v' }, '/degrade', {});
+
+    expect(out.aborted).toBe(false);
+    expect(out.appHtml).toContain('SHELL');
+    expect(out.appHtml).toContain('FALLBACK');
+    expect(out.appHtml).toContain('<!--$?-->'); // pending marker - the client completes it
+    expect(out.headContent).toBe('<head/>');
+    const degradeWarn = warn.mock.calls.find(([msg]) => String(msg).includes('prerenderTimeoutMs'));
+    expect(degradeWarn?.[1]).toMatchObject({ location: '/degrade', prerenderTimeoutMs: 100 });
+  });
+
+  it('deadline with suspension OUTSIDE any boundary: throws (never a blank 200)', async () => {
+    const Reader = () => <section>{use(never)}</section>;
+    const renderer = createRenderer<{ k: string }>({
+      appComponent: () => (
+        <div>
+          <Reader />
+        </div>
+      ),
+      headContent: () => '<head/>',
+      ssrOptions: { prerenderTimeoutMs: 100 },
+      logger: { warn: vi.fn() },
+    });
+
+    await expect(renderer.renderSSR({ k: 'v' }, '/blank', {})).rejects.toThrow(/prerenderTimeoutMs \(100ms\) before the shell completed/);
+  });
+
+  it('caller abort mid-render preserves the existing { aborted: true } contract', async () => {
+    const warn = vi.fn();
+    const slow = delayed(300, 'CONTENT');
+    const Reader = () => <section>{use(slow)}</section>;
+    const renderer = createRenderer<{ k: string }>({
+      appComponent: () => (
+        <div>
+          <Suspense fallback={<i>F</i>}>
+            <Reader />
+          </Suspense>
+        </div>
+      ),
+      headContent: () => '<head/>',
+      logger: { warn },
+    });
+
+    const ac = new AbortController();
+    setTimeout(() => ac.abort(new Error('client disconnected')), 30);
+    const out = await renderer.renderSSR({ k: 'v' }, '/gone', {}, ac.signal);
+
+    expect(out).toEqual({ headContent: '', appHtml: '', aborted: true });
+    expect(warn).toHaveBeenCalledWith('SSR completed after client abort', { location: '/gone' });
+  });
+
+  it('the deadline timer is cleared on completion (no spurious deadline warn after the render)', async () => {
+    const warn = vi.fn();
+    const renderer = createRenderer<{ k: string }>({
+      appComponent: () => <div>fast</div>,
+      headContent: () => '<head/>',
+      ssrOptions: { prerenderTimeoutMs: 120 },
+      logger: { warn },
+    });
+
+    const out = await renderer.renderSSR({ k: 'v' }, '/fast', {});
+    expect(out.appHtml).toBe('<div>fast</div>');
+
+    await new Promise((r) => setTimeout(r, 200)); // well past the deadline
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('R3-06 E2E: the degraded page completes on the client', () => {
+  it('hydrateRoot on the served fallback-state HTML client-renders the boundary content', async () => {
+    // Server: deadline degrade (the boundary's promise never settles server-side).
+    const ServerReader = () => <section>{use(never)}</section>;
+    const shell = (reader: React.ReactElement) => (
+      <div>
+        <h1>SHELL</h1>
+        <Suspense fallback={<i>FALLBACK</i>}>{reader}</Suspense>
+      </div>
+    );
+    const renderer = createRenderer<{ k: string }>({
+      appComponent: () => shell(<ServerReader />),
+      headContent: () => '<head/>',
+      ssrOptions: { prerenderTimeoutMs: 100 },
+      logger: { warn: vi.fn() },
+    });
+    const out = await renderer.renderSSR({ k: 'v' }, '/e2e', {});
+    expect(out.appHtml).toContain('FALLBACK');
+
+    // Client: same tree shape; the promise resolves client-side ("render the rest on the client").
+    const clientPromise = delayed(30, 'CONTENT');
+    const ClientReader = () => <section>{use(clientPromise)}</section>;
+    const store = createSSRStore({ k: 'v' });
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    container.innerHTML = out.appHtml;
+
+    const recoverable: string[] = [];
+    const uncaught: unknown[] = [];
+    const root = hydrateRoot(container, <SSRStoreProvider store={store}>{shell(<ClientReader />)}</SSRStoreProvider>, {
+      onRecoverableError: (e) => recoverable.push(String((e as Error)?.message ?? e)),
+      onUncaughtError: (e) => uncaught.push(e),
+    });
+
+    await new Promise((r) => setTimeout(r, 300));
+
+    expect(container.textContent).toContain('CONTENT');
+    expect(container.textContent).not.toContain('FALLBACK');
+    expect(uncaught).toEqual([]);
+    expect(recoverable).toHaveLength(1);
+    expect(recoverable[0]).toMatch(/Suspense boundary.*Switched to client rendering/s);
+
+    root.unmount();
+    container.remove();
+  });
+});

--- a/packages/react/src/test/SSRRender.prerender.test.tsx
+++ b/packages/react/src/test/SSRRender.prerender.test.tsx
@@ -169,6 +169,27 @@ describe('R3-06 Policy A degrade matrix (real react-dom)', () => {
   });
 });
 
+describe('R3-06 prerenderTimeoutMs validation (gate-review fix)', () => {
+  const make = (v: unknown) => () =>
+    createRenderer<{ k: string }>({
+      appComponent: () => <div />,
+      headContent: () => '',
+      ssrOptions: { prerenderTimeoutMs: v as number },
+    });
+
+  it('rejects invalid values at the factory instead of silently waiting forever', () => {
+    for (const bad of [-1, Number.NaN, -Infinity, null, '5000']) {
+      expect(make(bad), `value: ${String(bad)}`).toThrow(TypeError);
+    }
+  });
+
+  it('accepts positive finite values and the documented sentinels 0 and Infinity', () => {
+    for (const ok of [1, 10_000, 0, Infinity]) {
+      expect(make(ok), `value: ${String(ok)}`).not.toThrow();
+    }
+  });
+});
+
 describe('R3-06 E2E: the degraded page completes on the client', () => {
   it('hydrateRoot on the served fallback-state HTML client-renders the boundary content', async () => {
     // Server: deadline degrade (the boundary's promise never settles server-side).

--- a/packages/react/src/test/SSRRender.test.tsx
+++ b/packages/react/src/test/SSRRender.test.tsx
@@ -2,9 +2,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import React from 'react';
 
-// R3-06: renderSSR renders via prerenderToNodeStream (react-dom/static.node). The mock resolves
-// with a one-chunk prelude, mirroring a completed prerender (postponed: null).
-vi.mock('react-dom/static.node', async () => {
+// R3-06: renderSSR renders via prerenderToNodeStream (conditional react-dom/static — Node build
+// at runtime). The mock resolves with a one-chunk prelude, mirroring a completed prerender.
+vi.mock('react-dom/static', async () => {
   const { Readable } = await import('node:stream');
   const prerenderToNodeStream = vi.fn(async (_el: any, _opts: any) => ({
     prelude: Readable.from(['<div>html</div>']),
@@ -101,7 +101,7 @@ import { Readable } from 'node:stream';
 
 import { createRenderer } from '../SSRRender';
 import * as RDS from 'react-dom/server';
-import * as RDStatic from 'react-dom/static.node';
+import * as RDStatic from 'react-dom/static';
 import * as Store from '../SSRDataStore';
 import * as Streaming from '../utils/Streaming';
 

--- a/packages/react/src/test/SSRRender.test.tsx
+++ b/packages/react/src/test/SSRRender.test.tsx
@@ -2,9 +2,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import React from 'react';
 
+// R3-06: renderSSR renders via prerenderToNodeStream (react-dom/static.node). The mock resolves
+// with a one-chunk prelude, mirroring a completed prerender (postponed: null).
+vi.mock('react-dom/static.node', async () => {
+  const { Readable } = await import('node:stream');
+  const prerenderToNodeStream = vi.fn(async (_el: any, _opts: any) => ({
+    prelude: Readable.from(['<div>html</div>']),
+    postponed: null,
+  }));
+  return { prerenderToNodeStream };
+});
+
 vi.mock('react-dom/server', () => {
   let lastOpts: any;
-  const renderToString = vi.fn(() => '<div>html</div>');
   const renderToPipeableStream = vi.fn((_el: any, opts: any) => {
     lastOpts = opts;
 
@@ -15,7 +25,6 @@ vi.mock('react-dom/server', () => {
     };
   });
   return {
-    renderToString,
     renderToPipeableStream,
     __getLastOpts: () => lastOpts,
   };
@@ -88,8 +97,11 @@ vi.mock('../utils/Streaming', () => {
   };
 });
 
+import { Readable } from 'node:stream';
+
 import { createRenderer } from '../SSRRender';
 import * as RDS from 'react-dom/server';
+import * as RDStatic from 'react-dom/static.node';
 import * as Store from '../SSRDataStore';
 import * as Streaming from '../utils/Streaming';
 
@@ -135,7 +147,7 @@ describe('createRenderer.renderSSR', () => {
     const out = await renderer.renderSSR({ title: 'T' } as any, '/home', { x: 1 });
 
     expect(Store.createSSRStore).toHaveBeenCalledWith({ title: 'T' });
-    expect(RDS.renderToString).toHaveBeenCalledTimes(1);
+    expect(RDStatic.prerenderToNodeStream).toHaveBeenCalledTimes(1);
     expect(out.headContent).toBe('<head>T-1</head>');
     expect(out.appHtml).toBe('<div>html</div>');
 
@@ -162,7 +174,7 @@ describe('createRenderer.renderSSR', () => {
 
     // No render attempts
     expect(Store.createSSRStore).not.toHaveBeenCalled();
-    expect(RDS.renderToString).not.toHaveBeenCalled();
+    expect(RDStatic.prerenderToNodeStream).not.toHaveBeenCalled();
 
     // Warn with prefix + message + context
     expect(warn).toHaveBeenCalledTimes(1);
@@ -183,20 +195,19 @@ describe('createRenderer.renderSSR', () => {
       logger: { warn },
     });
 
-    // We’ll abort *after* render kicks off but before completion
-    // Mock renderToString to let us flip the signal in-between
-    // const orig = RDS.renderToString as unknown as jest.Mock | vi.Mock;
-    (RDS.renderToString as any).mockImplementationOnce(() => {
-      // abort right before returning html to flip `aborted = true`
+    // We’ll abort *after* render kicks off but before completion:
+    // mock prerenderToNodeStream to flip the signal before resolving.
+    (RDStatic.prerenderToNodeStream as any).mockImplementationOnce(async () => {
+      // abort right before resolving to flip `aborted = true`
       ac.abort();
-      return '<div>html</div>';
+      return { prelude: Readable.from(['<div>html</div>']), postponed: null };
     });
 
     const out = await renderer.renderSSR({ title: 'Y' } as any, '/mid', {}, ac.signal);
 
     // Should have rendered, but then detected abort and returned aborted=true
     expect(Store.createSSRStore).toHaveBeenCalledTimes(1);
-    expect(RDS.renderToString).toHaveBeenCalledTimes(1);
+    expect(RDStatic.prerenderToNodeStream).toHaveBeenCalledTimes(1);
 
     expect(warn).toHaveBeenCalledTimes(1);
     const [msg, meta] = (warn as any).mock.calls[0]!;

--- a/packages/react/src/test/SSRRender.test.tsx
+++ b/packages/react/src/test/SSRRender.test.tsx
@@ -432,6 +432,28 @@ describe('createRenderer.renderStream', () => {
     expect(onError).toHaveBeenCalledWith(expect.any(Error));
   });
 
+  it('recheck: a throwing cb.onError does not veto fatal settlement — done rejects with the ORIGINAL error, single fire', async () => {
+    const { writable } = makeWritable();
+    const original = new Error('render boom');
+    const onError = vi.fn(() => {
+      throw new Error('onError boom');
+    });
+
+    const { renderStream } = createRenderer<any>({
+      appComponent: () => <div />,
+      headContent: () => '<head/>',
+    });
+
+    const r = renderStream(writable as any, { onError }, {}, '/fatal-throwing-cb');
+    const opts = (RDS as any).__getLastOpts();
+    opts.onError(original); // React surfaces a fatal render error
+
+    // failFatal runs controller.fatalAbort in `finally`, so `done` still rejects with the ORIGINAL
+    // error even though cb.onError threw (old code skipped fatalAbort → done never settled).
+    await expect(r.done).rejects.toBe(original);
+    expect(onError).toHaveBeenCalledTimes(1); // single fire (no double-fire, no skip)
+  });
+
   it('AbortSignal already aborted: benign abort & no stream render; manual abort works', async () => {
     const { writable } = makeWritable();
     const ac = new AbortController();

--- a/packages/react/src/test/SSRRender.test.tsx
+++ b/packages/react/src/test/SSRRender.test.tsx
@@ -448,10 +448,54 @@ describe('createRenderer.renderStream', () => {
     const opts = (RDS as any).__getLastOpts();
     opts.onError(original); // React surfaces a fatal render error
 
-    // failFatal runs controller.fatalAbort in `finally`, so `done` still rejects with the ORIGINAL
-    // error even though cb.onError threw (old code skipped fatalAbort → done never settled).
+    // failFatal runs controller.fatalAbort even though cb.onError threw (old code skipped it →
+    // done never settled). The original error is the reject reason.
     await expect(r.done).rejects.toBe(original);
     expect(onError).toHaveBeenCalledTimes(1); // single fire (no double-fire, no skip)
+  });
+
+  it("recheck-2: a hostile FRAMEWORK error (throwing message getter / Symbol.toPrimitive) doesn't throw before failFatal", async () => {
+    const hostiles: ReadonlyArray<() => unknown> = [
+      () => {
+        const o: Record<string, unknown> = {};
+        Object.defineProperty(o, 'message', {
+          get() {
+            throw new Error('getter boom');
+          },
+        });
+        return o;
+      },
+      () => ({
+        message: {
+          [Symbol.toPrimitive]() {
+            throw new Error('coercion boom');
+          },
+        },
+      }),
+    ];
+
+    for (const make of hostiles) {
+      const { writable } = makeWritable();
+      const onError = vi.fn();
+      const hostile = make();
+
+      const { renderStream } = createRenderer<any>({
+        appComponent: () => <div />,
+        headContent: () => '<head/>',
+      });
+
+      const r = renderStream(writable as any, { onError }, {}, '/hostile-framework-error');
+      const opts = (RDS as any).__getLastOpts();
+
+      // React surfaces a hostile error to onError — the handler must NOT coerce it before failFatal,
+      // so the call does not throw, and settlement/single-fire still happen with the ORIGINAL value.
+      expect(() => opts.onError(hostile)).not.toThrow();
+
+      await expect(r.done).rejects.toBe(hostile);
+      expect(onError).toHaveBeenCalledTimes(1);
+      // reference check (toHaveBeenCalledWith would deep-equal the arg and trip the throwing getter)
+      expect(onError.mock.calls[0]?.[0]).toBe(hostile);
+    }
   });
 
   it('AbortSignal already aborted: benign abort & no stream render; manual abort works', async () => {

--- a/packages/react/src/test/SSRRender.test.tsx
+++ b/packages/react/src/test/SSRRender.test.tsx
@@ -80,14 +80,10 @@ vi.mock('../utils/Streaming', () => {
   // wireWritableGuards: return no-op cleanup (we verify it’s set, not effects)
   const wireWritableGuards = vi.fn((_w: any, _cfg: any) => ({ cleanup: vi.fn() }));
 
-  // benign predicate configurable per test
-  const isBenignStreamErr = vi.fn(() => false);
-
   return {
     createStreamController,
     startShellTimer,
     wireWritableGuards,
-    isBenignStreamErr,
     __getLastTimeoutHandler: () => lastTimeoutHandler,
   };
 });
@@ -335,59 +331,10 @@ describe('createRenderer.renderStream', () => {
     expect(ctrl.fatalAbort).toHaveBeenCalled();
   });
 
-  it('onAllReady: getSnapshot throws a thenable first → resolves then re-delivers; non-thenable throws → fatal', async () => {
-    const { writable } = makeWritable();
-    let delivered = 0;
-    (Store as any).__setSnapshotImpl(() => {
-      if (delivered === 0) {
-        delivered++;
-        let resume!: () => void;
-        const p = new Promise<void>((r) => (resume = r));
-        Promise.resolve().then(() => resume());
-
-        throw p;
-      }
-      return { ok: true };
-    });
-
-    const onAllReady = vi.fn(),
-      onFinish = vi.fn(),
-      onError = vi.fn();
-    const { renderStream } = createRenderer<any>({
-      appComponent: () => <div />,
-      headContent: () => '<head/>',
-      enableDebug: true,
-    });
-
-    const { done } = renderStream(writable as any, { onAllReady, onFinish, onError }, {}, '/thenable');
-    const opts = (RDS as any).__getLastOpts();
-    opts.onShellReady();
-    opts.onAllReady();
-
-    const ctrl = (Streaming.createStreamController as any).mock.results.at(-1)!.value;
-    ctrl.benignAbort('test-complete');
-    await expect(done).resolves.toBeUndefined();
-
-    await expect(done).resolves.toBeUndefined();
-    expect(onAllReady).toHaveBeenCalledWith({ ok: true });
-    expect(onFinish).toHaveBeenCalledWith({ ok: true });
-    expect(onError).not.toHaveBeenCalled();
-
-    (Store as any).__setSnapshotImpl(() => {
-      throw new Error('bad');
-    });
-    const { done: done2 } = renderStream(writable as any, { onError }, {}, '/bad');
-    const opts2 = (RDS as any).__getLastOpts();
-    opts2.onShellReady();
-    opts2.onAllReady();
-
-    const ctrl1 = (Streaming.createStreamController as any).mock.results.at(-1)!.value;
-    ctrl1.benignAbort('test-complete');
-    await expect(done).resolves.toBeUndefined();
-
-    await expect(done2).rejects.toBeInstanceOf(Error);
-    expect(onError).toHaveBeenCalledWith(expect.any(Error));
-  });
+  // NOTE: the old thrown-thenable deliver-retry dance in `onAllReady` was removed in R1-01 — final
+  // data delivery is now owned by the bounded end-gate (deferred until store readiness settles).
+  // That path is covered end-to-end against real react-dom/server in SSRRender.integration.test.tsx
+  // (R2 data-loss + store-error → gate-fatal), which the mock (no-op pipe) cannot drive.
 
   it('onShellError → fatalAbort + done rejects', async () => {
     const { writable } = makeWritable();
@@ -406,35 +353,38 @@ describe('createRenderer.renderStream', () => {
     expect(onError).toHaveBeenCalledWith(expect.any(Error));
   });
 
-  it('onError benign → benignAbort resolves; onError fatal → fatalAbort rejects', async () => {
+  it("React's onError is NON-FATAL (R1-01): routes to onRenderError, does not settle done, never calls the fatal onError", async () => {
     const { writable } = makeWritable();
     const onError = vi.fn();
-
-    (Streaming.isBenignStreamErr as any).mockReturnValueOnce(true);
+    const onRenderError = vi.fn();
 
     const { renderStream } = createRenderer<any>({
       appComponent: () => <div />,
       headContent: () => '<head/>',
     });
 
-    const r1 = renderStream(writable as any, { onError }, {}, '/benign');
-    let opts = (RDS as any).__getLastOpts();
-    opts.onError(new Error('ECONNRESET'));
+    // No onShellReady() yet → shell not committed → phase is 'pre-shell', recoverable 'unknown'.
+    const r = renderStream(writable as any, { onError, onRenderError }, {}, '/render-error');
+    const opts = (RDS as any).__getLastOpts();
+    const err = new Error('boundary boom');
+    expect(() => opts.onError(err)).not.toThrow();
 
-    await expect(r1.done).resolves.toBeUndefined();
+    // Structured, non-fatal observation — NOT the fatal channel, NOT a settlement.
+    expect(onRenderError).toHaveBeenCalledTimes(1);
+    expect(onRenderError).toHaveBeenCalledWith({ error: err, phase: 'pre-shell', recoverable: 'unknown' });
+    expect(onError).not.toHaveBeenCalled();
 
-    // fatal case
-    const r2 = renderStream(writable as any, { onError }, {}, '/fatal');
-    opts = (RDS as any).__getLastOpts();
-    opts.onError(new Error('boom'));
+    const ctrl = (Streaming.createStreamController as any).mock.results.at(-1)!.value;
+    expect(ctrl.fatalAbort).not.toHaveBeenCalled();
 
-    await expect(r2.done).rejects.toBeInstanceOf(Error);
-    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    // done is settled by a separate channel, never by onError.
+    ctrl.benignAbort('test-complete');
+    await expect(r.done).resolves.toBeUndefined();
   });
 
   it('recheck: a throwing cb.onError does not veto fatal settlement — done rejects with the ORIGINAL error, single fire', async () => {
     const { writable } = makeWritable();
-    const original = new Error('render boom');
+    const original = new Error('shell boom');
     const onError = vi.fn(() => {
       throw new Error('onError boom');
     });
@@ -446,7 +396,7 @@ describe('createRenderer.renderStream', () => {
 
     const r = renderStream(writable as any, { onError }, {}, '/fatal-throwing-cb');
     const opts = (RDS as any).__getLastOpts();
-    opts.onError(original); // React surfaces a fatal render error
+    opts.onShellError(original); // React surfaces a fatal shell error → the failFatal path
 
     // failFatal runs controller.fatalAbort even though cb.onError threw (old code skipped it →
     // done never settled). The original error is the reject reason.
@@ -487,9 +437,10 @@ describe('createRenderer.renderStream', () => {
       const r = renderStream(writable as any, { onError }, {}, '/hostile-framework-error');
       const opts = (RDS as any).__getLastOpts();
 
-      // React surfaces a hostile error to onError — the handler must NOT coerce it before failFatal,
-      // so the call does not throw, and settlement/single-fire still happen with the ORIGINAL value.
-      expect(() => opts.onError(hostile)).not.toThrow();
+      // React surfaces a hostile error on a fatal channel — failFatal must NOT coerce it before
+      // aborting, so the call does not throw, and settlement/single-fire still happen with the
+      // ORIGINAL value.
+      expect(() => opts.onShellError(hostile)).not.toThrow();
 
       await expect(r.done).rejects.toBe(hostile);
       expect(onError).toHaveBeenCalledTimes(1);
@@ -707,15 +658,15 @@ describe('createRenderer.renderStream', () => {
     expect(ctrl.complete).toHaveBeenCalledWith('Stream finished (normal completion)');
   });
 
-  it('onShellReady callback throws → warns but does not fatal', async () => {
+  it('onShellReady callback throws → logs (advisory) but does not fatal', async () => {
     const { writable } = makeWritable();
-    const warn = vi.fn();
+    const errorLog = vi.fn();
 
     const { renderStream } = createRenderer<any>({
       appComponent: () => <div />,
       headContent: () => '<head/>',
       enableDebug: true,
-      logger: { warn },
+      logger: { error: errorLog },
     });
 
     const onShellReady = vi.fn(() => {
@@ -729,58 +680,27 @@ describe('createRenderer.renderStream', () => {
     );
 
     const opts = (RDS as any).__getLastOpts();
-    opts.onShellReady(); // triggers the throwing callback (wrapped)
+    opts.onShellReady(); // triggers the throwing callback (isolated)
 
-    // warned, and NOT fatal-aborted
-    expect(warn).toHaveBeenCalledTimes(1);
-    const [label, err] = (warn as any).mock.calls[0]!;
+    // logged (advisory), and NOT fatal-aborted
+    expect(errorLog).toHaveBeenCalledTimes(1);
+    const [label, err] = (errorLog as any).mock.calls[0]!;
     expect(label).toContain('onShellReady callback threw:');
     expect(err).toBeInstanceOf(Error);
     expect((err as Error).message).toBe('cb boom');
 
-    // finish the stream explicitly so `done` resolves
     const ctrl = (Streaming.createStreamController as any).mock.results.at(-1)!.value;
+    expect(ctrl.fatalAbort).not.toHaveBeenCalled();
+
+    // finish the stream explicitly so `done` resolves
     ctrl.benignAbort('test-complete');
     await expect(done).resolves.toBeUndefined();
   });
 
-  it('onAllReady → getSnapshot throws rejecting thenable → logs error, onError, fatalAbort (rejects)', async () => {
-    const { writable } = makeWritable();
-
-    // Throw a Promise that REJECTS later
-    (Store as any).__setSnapshotImpl(() => {
-      let reject!: (e: any) => void;
-      const p = new Promise((_res, rej) => {
-        reject = rej;
-      });
-      // reject in microtask
-      Promise.resolve().then(() => reject(new Error('nope')));
-      throw p; // Suspense-style thenable
-    });
-
-    const errorLog = vi.fn();
-    const onError = vi.fn();
-
-    const { renderStream } = createRenderer<any>({
-      appComponent: () => <div />,
-      headContent: () => '<head/>',
-      enableDebug: true,
-      logger: { error: errorLog },
-    });
-
-    const { done } = renderStream(writable as any, { onError }, {}, '/rejecting-thenable');
-    const opts = (RDS as any).__getLastOpts();
-    opts.onShellReady();
-    opts.onAllReady(); // deliver() runs; thenable rejects → catch path
-
-    await expect(done).rejects.toBeInstanceOf(Error);
-    expect(errorLog).toHaveBeenCalledTimes(1);
-    const [label, err] = (errorLog as any).mock.calls[0]!;
-    expect(label).toContain('Data promise rejected:');
-    expect(err).toBeInstanceOf(Error);
-    expect((err as Error).message).toBe('nope');
-    expect(onError).toHaveBeenCalledWith(expect.any(Error));
-  });
+  // NOTE: the store data-fetch-error path (store settles to status:'error') is now handled by the
+  // bounded end-gate, not by a deliver-retry inside onAllReady. It fatal-aborts the response after
+  // the gate observes readiness — covered against real react-dom/server in the integration suite
+  // ('store data error → gate fatal'), which the no-op-pipe mock cannot drive.
 
   it('renderToPipeableStream throws synchronously → onError + fatalAbort (rejects)', async () => {
     const { writable } = makeWritable();
@@ -860,28 +780,6 @@ describe('createRenderer.renderStream', () => {
     await expect(done).resolves.toBeUndefined();
   });
 
-  it("onError with object lacking message (err?.message ?? '') and non-benign → fatalAbort", async () => {
-    const { writable } = makeWritable();
-    const onErrorCb = vi.fn();
-
-    (Streaming.isBenignStreamErr as any).mockReturnValue(false);
-
-    const { renderStream } = createRenderer<any>({
-      appComponent: () => <div />,
-      headContent: () => '<head/>',
-    });
-
-    const { done } = renderStream(writable as any, { onError: onErrorCb }, {}, '/no-message');
-    const opts = (RDS as any).__getLastOpts();
-
-    // Pass exactly once: an object with no .message to hit (err?.message ?? '')
-    const errObj: any = {}; // no .message
-    opts.onError(errObj);
-
-    await expect(done).rejects.toBe(errObj); // rejects with the same object
-    expect(onErrorCb).toHaveBeenCalledWith(errObj);
-  });
-
   it('onShellError triggers stopShellTimer catch and fatalAbort', async () => {
     const { writable } = makeWritable();
     const onError = vi.fn();
@@ -935,87 +833,39 @@ describe('createRenderer.renderStream', () => {
     await expect(done).resolves.toBeUndefined();
   });
 
-  it('onShellReady: writable has no write() → fallback true path pipes immediately', async () => {
-    // writable without write() to hit the "?: true" branch
-    const w: any = {
-      once: vi.fn(),
-      // no write
-    };
-    const { renderStream } = createRenderer<any>({
-      appComponent: () => <div />,
-      headContent: () => '<head/>',
-    });
+  // NOTE: the old backpressure/onHead-return-value piping logic in onShellReady (write()-fallback,
+  // drain-waiting, onHead-returns-false) was removed in R1-01. React now always pipes into the
+  // delegating end-gate, and React ITSELF drives backpressure against the real writable (write()'s
+  // boolean return + a 'drain' listener it attaches through the sink). That real drain path — and
+  // the deferred end() / abort-mid-wait races — are covered against real react-dom/server in the
+  // integration suite ('backpressure: a paused tiny-highWaterMark sink …', 'abort during the
+  // deferred-end wait …'); the no-op-pipe mock here cannot exercise byte flow.
 
-    const { done } = renderStream(w as any, {}, {}, '/no-write');
-    const opts = (RDS as any).__getLastOpts();
-    opts.onShellReady(); // should not throw
-
-    // pipe was called immediately since wroteOk===true and onHead!==false
-    const streamInstance = (RDS.renderToPipeableStream as any).mock.results.at(-1)!.value;
-    expect(streamInstance.pipe).toHaveBeenCalledWith(w);
-    expect(w.once).not.toHaveBeenCalled(); // no drain waiting
-
-    const ctrl = (Streaming.createStreamController as any).mock.results.at(-1)!.value;
-    ctrl.benignAbort('done');
-    await expect(done).resolves.toBeUndefined();
-  });
-  it('onShellReady: onHead callback throws → warns and continues streaming', async () => {
+  it('onShellReady: a throwing onHead is FATAL (required callback) — onError + fatalAbort, nothing piped', async () => {
     const { writable } = makeWritable();
-    const warn = vi.fn();
+    const onError = vi.fn();
 
     const { renderStream } = createRenderer<any>({
       appComponent: () => <div />,
       headContent: () => '<head/>',
-      enableDebug: true,
-      logger: { warn },
     });
 
     const onHead = vi.fn(() => {
       throw new Error('head-cb boom');
     });
-    const { done } = renderStream(writable as any, { onHead }, {}, '/onhead-throws');
+    const { done } = renderStream(writable as any, { onHead, onError }, {}, '/onhead-throws');
 
     const opts = (RDS as any).__getLastOpts();
+    // onHead commits the response head + connects the sink; a throw enters the fatal path and must
+    // NOT leave the response half-committed — the renderer returns BEFORE piping.
     expect(() => opts.onShellReady()).not.toThrow();
 
-    expect(warn).toHaveBeenCalledTimes(1);
-    const [msg, errObj] = (warn as any).mock.calls[0]!;
-    expect(msg).toContain('onHead callback threw:');
-    expect(errObj).toBeInstanceOf(Error);
-    expect((errObj as Error).message).toBe('head-cb boom');
-
     const streamInstance = (RDS.renderToPipeableStream as any).mock.results.at(-1)!.value;
-    expect(streamInstance.pipe).toHaveBeenCalledWith(writable);
+    expect(streamInstance.pipe).not.toHaveBeenCalled();
 
     const ctrl = (Streaming.createStreamController as any).mock.results.at(-1)!.value;
-    ctrl.benignAbort('ok');
-    await expect(done).resolves.toBeUndefined();
-  });
-
-  // Also test the case where onHead returns false (forces wait) but no once() available
-  it('onShellReady: onHead returns false (force wait) + no once() → pipes immediately (best effort)', async () => {
-    const w: any = {
-      write: vi.fn(() => true), // no backpressure from write
-      // NO once() method
-    };
-
-    const { renderStream } = createRenderer<any>({
-      appComponent: () => <div />,
-      headContent: () => '<head/>',
-    });
-
-    const onHead = vi.fn(() => false); // explicitly request wait for drain
-    const { done } = renderStream(w as any, { onHead }, {}, '/onhead-force-no-once');
-    const opts = (RDS as any).__getLastOpts();
-    opts.onShellReady();
-
-    // onHead returned false (wants to wait) but there's no once() to attach a listener,
-    // so it falls through to best-effort startPipe()
-    const streamInstance = (RDS.renderToPipeableStream as any).mock.results.at(-1)!.value;
-    expect(streamInstance.pipe).toHaveBeenCalledWith(w);
-
-    const ctrl = (Streaming.createStreamController as any).mock.results.at(-1)!.value;
-    ctrl.benignAbort('done');
-    await expect(done).resolves.toBeUndefined();
+    expect(ctrl.fatalAbort).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    await expect(done).rejects.toThrow('head-cb boom');
   });
 });

--- a/packages/react/src/test/SSRRender.test.tsx
+++ b/packages/react/src/test/SSRRender.test.tsx
@@ -84,7 +84,6 @@ vi.mock('../utils/Streaming', () => {
   const isBenignStreamErr = vi.fn(() => false);
 
   return {
-    DEFAULT_BENIGN_ERRORS: /x/i,
     createStreamController,
     startShellTimer,
     wireWritableGuards,

--- a/packages/react/src/test/SpecifierExtensions.test.ts
+++ b/packages/react/src/test/SpecifierExtensions.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment node
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+// R3-05 (Q6) — every relative import/export specifier in emitted source must carry an explicit
+// `.js` extension. tsup builds with `bundle: false` and emits specifiers AS-IS; an extensionless
+// relative specifier ships a dist that fails Node ESM with ERR_MODULE_NOT_FOUND. Test files are
+// excluded (they run under vitest's resolver and are never emitted), as are `.d.ts` files.
+const SRC = fileURLToPath(new URL('..', import.meta.url));
+
+const RELATIVE_SPECIFIER = /(?:from\s+|import\s*\(\s*|import\s+)['"](\.\.?\/[^'"]+)['"]/g;
+
+function emittedSourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return entry.name === 'test' ? [] : emittedSourceFiles(full);
+    if (!/\.(ts|tsx)$/.test(entry.name) || entry.name.endsWith('.d.ts')) return [];
+    return [full];
+  });
+}
+
+describe('R3-05 relative specifier extensions (dist integrity guard)', () => {
+  it('every relative specifier in emitted source carries an explicit extension', () => {
+    const offenders: string[] = [];
+
+    for (const file of emittedSourceFiles(SRC)) {
+      const source = readFileSync(file, 'utf8');
+      for (const match of source.matchAll(RELATIVE_SPECIFIER)) {
+        const spec = match[1]!;
+        if (!/\.(js|json|css)$/.test(spec)) offenders.push(`${path.relative(SRC, file)} -> '${spec}'`);
+      }
+    }
+
+    expect(offenders, `extensionless relative specifiers break the bundle:false dist (Node ESM ERR_MODULE_NOT_FOUND):\n${offenders.join('\n')}`).toEqual([]);
+  });
+});

--- a/packages/react/src/test/contract.test-d.ts
+++ b/packages/react/src/test/contract.test-d.ts
@@ -1,0 +1,50 @@
+// Type-level conformance test (R3-01, mirroring @taujs/vue's V1-05 template). Proves
+// @taujs/react's `createRenderer(...)` output is assignable to @taujs/server's `RenderModule`
+// contract WITH ZERO CASTS — the drift guard against a renderer silently diverging from the host
+// contract. Enforced by `pnpm --filter @taujs/react typecheck` (tsc); the repo has no type-test
+// runner, and the `.test-d.ts` suffix is outside vitest's test glob so it never runs as a spec.
+// NOTE: requires @taujs/server to be built first (types resolve to its dist).
+import { createElement } from 'react';
+
+import type { RenderModule, RenderSSR, RenderStream, RenderStreamHandle } from '@taujs/server';
+
+import { createRenderer } from '../SSRRender';
+
+// The CONCRETE renderer output, deliberately un-annotated so tsc keeps its real inferred types.
+// (Annotating this as `RenderModule` would erase them, and every return-shape assertion below would
+// degrade into a tautology comparing the contract against itself - the exact width-subtyping
+// blindness critical review #3 warns about.)
+const _renderer = createRenderer({
+  appComponent: () => createElement('div'),
+  headContent: () => '',
+});
+
+// The load-bearing assertion: the whole renderer module conforms, cast-free.
+const _module: RenderModule = _renderer;
+void _module;
+
+// And each half individually, for a sharper error if one diverges.
+const _renderSSR: RenderSSR = _renderer.renderSSR;
+const _renderStream: RenderStream = _renderer.renderStream;
+void _renderSSR;
+void _renderStream;
+
+// R3-01 / critical review #3: assignability of the FUNCTION alone can hide a capability gap through
+// width-subtyping, so pin the RETURN shape explicitly and in BOTH directions - against the ACTUAL
+// renderer return type, not the contract alias.
+type ReactStreamHandle = ReturnType<typeof _renderer.renderStream>;
+
+// 1. What the renderer actually returns must satisfy the published handle contract (catches a
+//    missing/mistyped `done` — the crash-class channel R0-01 shipped).
+const _handleSatisfiesContract: RenderStreamHandle = null as unknown as ReactStreamHandle;
+void _handleSatisfiesContract;
+
+// 2. ...and every capability the contract REQUIRES must actually be present on it (catches a handle
+//    that only structurally passes because the contract is narrower than the capability it needs).
+const _contractSatisfiedByHandle: ReactStreamHandle = null as unknown as RenderStreamHandle;
+void _contractSatisfiedByHandle;
+
+// 3. `done` is the load-bearing member (R0-01: an unobserved rejection is the process-crash class).
+//    Pin it on the ACTUAL return type, not on the contract alias.
+const _done: Promise<void> = null as unknown as ReactStreamHandle['done'];
+void _done;

--- a/packages/react/src/utils/Html.ts
+++ b/packages/react/src/utils/Html.ts
@@ -1,5 +1,5 @@
 /**
- * Escape a string for safe interpolation into RAW HTML — both element text and attribute values,
+ * Escape a value for safe interpolation into RAW HTML — both element text and attribute values,
  * single- AND double-quoted. Escapes the five HTML-sensitive characters:
  *
  * - `&` → `&amp;`

--- a/packages/react/src/utils/Html.ts
+++ b/packages/react/src/utils/Html.ts
@@ -8,15 +8,21 @@
  * - `"` → `&quot;`
  * - `'` → `&#39;`
  *
+ * SCOPE — this makes a value safe ONLY for HTML text and QUOTED HTML attributes. It does NOT make a
+ * value safe for other contexts: JavaScript, `<script>` JSON / JSON-LD data (character references are
+ * NOT decoded in script raw text — there you must escape `<` as the JSON escape `\u003c`), CSS, or URL
+ * scheme validation. For URL-bearing attributes it prevents attribute breakout but does not validate the
+ * scheme or authorize the destination — construct or allow-list URLs separately.
+ *
  * Intended for `headContent` interpolations (see `HeadContext`): a renderer's `headContent` return
  * value is written into `<head>` as RAW HTML, so any value drawn from services or user input must be
  * escaped before interpolation. The framework-rendered application HTML does NOT need this — React and
  * Vue escape it for you.
  *
  * `&` is replaced FIRST so a freshly produced entity (e.g. `&lt;`) is not corrupted. This function is
- * therefore NOT idempotent — escape each value exactly once; do not double-escape. Non-string input is
- * coerced with `String(value)`.
+ * therefore NOT idempotent — escape each value exactly once; do not double-escape. Input is `unknown`
+ * and coerced with `String(value)`, so non-string values are supported.
  */
-export function escapeHtml(value: string): string {
+export function escapeHtml(value: unknown): string {
   return String(value).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }

--- a/packages/react/src/utils/Html.ts
+++ b/packages/react/src/utils/Html.ts
@@ -1,0 +1,22 @@
+/**
+ * Escape a string for safe interpolation into RAW HTML — both element text and attribute values,
+ * single- AND double-quoted. Escapes the five HTML-sensitive characters:
+ *
+ * - `&` → `&amp;`
+ * - `<` → `&lt;`
+ * - `>` → `&gt;`
+ * - `"` → `&quot;`
+ * - `'` → `&#39;`
+ *
+ * Intended for `headContent` interpolations (see `HeadContext`): a renderer's `headContent` return
+ * value is written into `<head>` as RAW HTML, so any value drawn from services or user input must be
+ * escaped before interpolation. The framework-rendered application HTML does NOT need this — React and
+ * Vue escape it for you.
+ *
+ * `&` is replaced FIRST so a freshly produced entity (e.g. `&lt;`) is not corrupted. This function is
+ * therefore NOT idempotent — escape each value exactly once; do not double-escape. Non-string input is
+ * coerced with `String(value)`.
+ */
+export function escapeHtml(value: string): string {
+  return String(value).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}

--- a/packages/react/src/utils/Logger.ts
+++ b/packages/react/src/utils/Logger.ts
@@ -22,7 +22,25 @@ type Opts = {
   enableDebug?: boolean;
 };
 
-const toJSONString = (v: unknown) => (typeof v === 'string' ? v : v instanceof Error ? (v.stack ?? v.message) : JSON.stringify(v));
+// R0-03/gate: NON-THROWING value formatting. Renderer errors are `unknown`, and this runs on
+// error paths that log BEFORE cleanup (see `createStreamController.fatalAbort`), so it must never
+// throw — `JSON.stringify` alone would on a `BigInt`, a circular object, or a throwing
+// `toJSON`/`Symbol.toPrimitive`. Falls back to a best-effort string that also cannot throw.
+const toJSONString = (v: unknown): string => {
+  if (typeof v === 'string') return v;
+  if (v instanceof Error) return v.stack ?? v.message;
+  try {
+    const json = JSON.stringify(v);
+    if (json !== undefined) return json;
+  } catch {
+    // fall through to String() best-effort
+  }
+  try {
+    return String(v);
+  } catch {
+    return '[unserializable]';
+  }
+};
 
 const splitMsgAndMeta = (args: unknown[]) => {
   const [first, ...rest] = args;
@@ -33,6 +51,18 @@ const splitMsgAndMeta = (args: unknown[]) => {
   const meta = only && typeof only === 'object' && !(only instanceof Error) ? only : { args: rest.map(toJSONString) };
 
   return { msg, meta };
+};
+
+// R0-03/gate: a diagnostic logger must never break the code path it observes (`fatalAbort` logs
+// BEFORE cleanup). `safe` isolates BOTH value formatting and the user-provided logger method — a
+// swallowed failure loses a log line, never settlement/cleanup. Documented policy: the UI logger
+// is best-effort and non-throwing.
+const safe = (fn: () => void): void => {
+  try {
+    fn();
+  } catch {
+    // best-effort: diagnostics must not throw
+  }
 };
 
 export function createUILogger(logger?: LoggerLike, opts: Opts = {}): UILogger {
@@ -72,36 +102,39 @@ export function createUILogger(logger?: LoggerLike, opts: Opts = {}): UILogger {
 
     return {
       log: enableDebug
-        ? (...args: unknown[]) => {
-            const { msg, meta } = splitMsgAndMeta(args);
+        ? (...args: unknown[]) =>
+            safe(() => {
+              const { msg, meta } = splitMsgAndMeta(args);
 
-            if (debug) {
-              const enabled = (isDebugEnabled ? isDebugEnabled(debugCategory) : false) || preferDebug;
+              if (debug) {
+                const enabled = (isDebugEnabled ? isDebugEnabled(debugCategory) : false) || preferDebug;
 
-              if (enabled) {
-                debug(debugCategory, msg, meta);
-                return;
+                if (enabled) {
+                  debug(debugCategory, msg, meta);
+                  return;
+                }
               }
-            }
 
-            info(msg, meta);
-          }
+              info(msg, meta);
+            })
         : () => {},
-      warn: (...args: unknown[]) => {
-        const { msg, meta } = splitMsgAndMeta(args);
-        warn(msg, meta);
-      },
-      error: (...args: unknown[]) => {
-        const { msg, meta } = splitMsgAndMeta(args);
-        error(msg, meta);
-      },
+      warn: (...args: unknown[]) =>
+        safe(() => {
+          const { msg, meta } = splitMsgAndMeta(args);
+          warn(msg, meta);
+        }),
+      error: (...args: unknown[]) =>
+        safe(() => {
+          const { msg, meta } = splitMsgAndMeta(args);
+          error(msg, meta);
+        }),
     };
   }
 
   const ui = (logger as Partial<UILogger>) || {};
   return {
-    log: enableDebug ? (...a) => (ui.log ?? console.log)(...a) : () => {},
-    warn: (...a) => (ui.warn ?? console.warn)(...a),
-    error: (...a) => (ui.error ?? console.error)(...a),
+    log: enableDebug ? (...a) => safe(() => (ui.log ?? console.log)(...a)) : () => {},
+    warn: (...a) => safe(() => (ui.warn ?? console.warn)(...a)),
+    error: (...a) => safe(() => (ui.error ?? console.error)(...a)),
   };
 }

--- a/packages/react/src/utils/Logger.ts
+++ b/packages/react/src/utils/Logger.ts
@@ -38,14 +38,9 @@ const splitMsgAndMeta = (args: unknown[]) => {
 export function createUILogger(logger?: LoggerLike, opts: Opts = {}): UILogger {
   const { debugCategory = 'ssr', context, preferDebug = false, enableDebug = false } = opts;
 
-  if (!enableDebug) {
-    return {
-      log: () => {},
-      warn: () => {},
-      error: () => {},
-    };
-  }
-
+  // R0-03: `enableDebug` gates VERBOSITY (the `log` channel), not error visibility. `warn` and
+  // `error` always route — to the provided logger if any, else `console`. Only `log` is gated,
+  // so production consumers still see renderer warnings/errors (RFC S2).
   const looksServer = !!logger && ('info' in logger || 'debug' in logger || 'child' in logger || 'isDebugEnabled' in logger);
 
   if (looksServer) {
@@ -76,20 +71,22 @@ export function createUILogger(logger?: LoggerLike, opts: Opts = {}): UILogger {
     const isDebugEnabled = s.isDebugEnabled ? (category: string) => s.isDebugEnabled!(category) : undefined;
 
     return {
-      log: (...args: unknown[]) => {
-        const { msg, meta } = splitMsgAndMeta(args);
+      log: enableDebug
+        ? (...args: unknown[]) => {
+            const { msg, meta } = splitMsgAndMeta(args);
 
-        if (debug) {
-          const enabled = (isDebugEnabled ? isDebugEnabled(debugCategory) : false) || preferDebug;
+            if (debug) {
+              const enabled = (isDebugEnabled ? isDebugEnabled(debugCategory) : false) || preferDebug;
 
-          if (enabled) {
-            debug(debugCategory, msg, meta);
-            return;
+              if (enabled) {
+                debug(debugCategory, msg, meta);
+                return;
+              }
+            }
+
+            info(msg, meta);
           }
-        }
-
-        info(msg, meta);
-      },
+        : () => {},
       warn: (...args: unknown[]) => {
         const { msg, meta } = splitMsgAndMeta(args);
         warn(msg, meta);
@@ -103,7 +100,7 @@ export function createUILogger(logger?: LoggerLike, opts: Opts = {}): UILogger {
 
   const ui = (logger as Partial<UILogger>) || {};
   return {
-    log: (...a) => (ui.log ?? console.log)(...a),
+    log: enableDebug ? (...a) => (ui.log ?? console.log)(...a) : () => {},
     warn: (...a) => (ui.warn ?? console.warn)(...a),
     error: (...a) => (ui.error ?? console.error)(...a),
   };

--- a/packages/react/src/utils/Streaming.ts
+++ b/packages/react/src/utils/Streaming.ts
@@ -6,12 +6,32 @@ export type StreamLogger = {
   error: (msg: string, extra?: unknown) => void;
 };
 
-export const DEFAULT_BENIGN_ERRORS = /ECONNRESET|EPIPE|socket hang up|aborted|premature/i;
+// R0-02: benignity is a property of an error's ORIGIN, never of its message/name/user-set
+// properties when it came from render/data code. Classify by origin AND shape.
+export type StreamErrSource = 'socket' | 'render';
 
-export function isBenignStreamErr(err: unknown): boolean {
-  const msg = String((err as any)?.message ?? '');
+// Disconnect signals worth trusting on a socket/writable-origin error.
+const BENIGN_SOCKET_CODES = new Set(['ECONNRESET', 'EPIPE', 'ERR_STREAM_PREMATURE_CLOSE', 'ERR_STREAM_DESTROYED']);
+// Exact (case-insensitive, trimmed) node/undici socket messages — NOT loose substrings, so an
+// app error whose message merely contains "aborted" is not mistaken for a disconnect.
+const BENIGN_SOCKET_MESSAGES = new Set(['aborted', 'socket hang up', 'premature close', 'request aborted']);
 
-  return DEFAULT_BENIGN_ERRORS.test(msg);
+export function isBenignStreamErr(err: unknown, source: StreamErrSource): boolean {
+  // Render/data-origin errors are never benign by shape: a component can throw
+  // `new Error('Payment aborted unexpectedly')` or `Object.assign(new Error(), { code: 'EPIPE' })`.
+  // The only benign render outcome is one the controller already knows about (callers check
+  // `controller.isAborted` before classifying).
+  if (source !== 'socket') return false;
+
+  const e = err as { code?: unknown; name?: unknown; message?: unknown } | null | undefined;
+  if (typeof e?.code === 'string' && BENIGN_SOCKET_CODES.has(e.code)) return true;
+  if (e?.name === 'AbortError') return true;
+
+  return BENIGN_SOCKET_MESSAGES.has(
+    String(e?.message ?? '')
+      .trim()
+      .toLowerCase(),
+  );
 }
 
 export type Settler = {
@@ -58,13 +78,11 @@ export function wireWritableGuards(
     fatalAbort,
     onError,
     onFinish,
-    benignErrorPattern = DEFAULT_BENIGN_ERRORS,
   }: {
     benignAbort: (why: string) => void;
     fatalAbort: (err: unknown) => void;
     onError?: (e: unknown) => void;
     onFinish?: () => void;
-    benignErrorPattern?: RegExp;
   },
 ): WritableGuards {
   const handlers: Array<() => void> = [];
@@ -74,8 +92,9 @@ export function wireWritableGuards(
   };
 
   add('error', (err) => {
-    const msg = String((err as any)?.message ?? '');
-    if (benignErrorPattern.test(msg)) {
+    // These are writable/socket-origin errors (the destination emitted 'error'): classify as
+    // 'socket' (R0-02).
+    if (isBenignStreamErr(err, 'socket')) {
       benignAbort('Client disconnected during stream');
     } else {
       onError?.(err);

--- a/packages/react/src/utils/Streaming.ts
+++ b/packages/react/src/utils/Streaming.ts
@@ -123,6 +123,12 @@ export function createStreamController(writable: Writable, logger: StreamLogger)
 
   let aborted = false;
   const settle = createSettler();
+  // R0-01: pre-attach a no-op rejection handler to `settle.done`. This marks the SAME promise
+  // as handled, so an unobserved `done` can never raise `unhandledRejection` (Node's default
+  // mode turns that into a process-terminating `uncaughtException`) — while consumers who await
+  // `done` still receive the fatal rejection on their own handler. Safe-by-default: the renderer
+  // must not hand out a footgun promise (see server call site + `RenderStreamHandle`).
+  settle.done.catch(() => {});
 
   let stopShellTimer: (() => void) | undefined;
   let removeAbortListener: (() => void) | undefined;

--- a/packages/react/src/utils/Streaming.ts
+++ b/packages/react/src/utils/Streaming.ts
@@ -202,21 +202,30 @@ export function createStreamController(writable: Writable, logger: StreamLogger)
     complete(message?: string) {
       if (aborted) return;
 
-      if (message) (log ?? warn)(message);
+      // Gate: a throwing logger must never prevent cleanup/settlement — the diagnostic must not
+      // break the control-flow path it observes. (createUILogger is already non-throwing; this is
+      // defence in depth for any StreamLogger, including a `fatalAbort(<BigInt>)`.)
+      try {
+        if (message) (log ?? warn)(message);
+      } catch {}
       cleanup(true);
     },
 
     benignAbort(why) {
       if (aborted) return;
 
-      warn(why);
+      try {
+        warn(why);
+      } catch {}
       cleanup(true);
     },
 
     fatalAbort(err) {
       if (aborted) return;
 
-      error('Stream aborted with error:', err);
+      try {
+        error('Stream aborted with error:', err);
+      } catch {}
       cleanup(false, err);
     },
 

--- a/packages/react/src/utils/index.ts
+++ b/packages/react/src/utils/index.ts
@@ -1,1 +1,0 @@
-export * from './';

--- a/packages/react/src/utils/test/Html.test.ts
+++ b/packages/react/src/utils/test/Html.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+
+import { escapeHtml } from '../Html';
+
+describe('escapeHtml', () => {
+  it('escapes all five HTML-sensitive characters (text- AND attribute-safe, both quote styles)', () => {
+    expect(escapeHtml('&')).toBe('&amp;');
+    expect(escapeHtml('<')).toBe('&lt;');
+    expect(escapeHtml('>')).toBe('&gt;');
+    expect(escapeHtml('"')).toBe('&quot;');
+    expect(escapeHtml("'")).toBe('&#39;');
+  });
+
+  it('escapes & FIRST so freshly produced entities are not corrupted', () => {
+    expect(escapeHtml('a & b < c')).toBe('a &amp; b &lt; c');
+    // an existing entity has its `&` escaped — double-escaping is the caller's concern (below)
+    expect(escapeHtml('&amp;')).toBe('&amp;amp;');
+  });
+
+  it('escapes a mixed attribute-breakout payload', () => {
+    const raw = `" onload='alert(1)' <img src=x>`;
+    expect(escapeHtml(raw)).toBe('&quot; onload=&#39;alert(1)&#39; &lt;img src=x&gt;');
+  });
+
+  it('coerces non-string input via String()', () => {
+    expect(escapeHtml(42 as unknown as string)).toBe('42');
+    expect(escapeHtml(null as unknown as string)).toBe('null');
+    expect(escapeHtml(undefined as unknown as string)).toBe('undefined');
+    expect(escapeHtml({ toString: () => '<x>' } as unknown as string)).toBe('&lt;x&gt;');
+  });
+
+  it('leaves safe text unchanged', () => {
+    expect(escapeHtml('hello world 123')).toBe('hello world 123');
+    expect(escapeHtml('')).toBe('');
+  });
+
+  it('is NOT idempotent — the caller must not double-escape (documented)', () => {
+    expect(escapeHtml(escapeHtml('<'))).toBe('&amp;lt;');
+  });
+});

--- a/packages/react/src/utils/test/Html.test.ts
+++ b/packages/react/src/utils/test/Html.test.ts
@@ -22,11 +22,11 @@ describe('escapeHtml', () => {
     expect(escapeHtml(raw)).toBe('&quot; onload=&#39;alert(1)&#39; &lt;img src=x&gt;');
   });
 
-  it('coerces non-string input via String()', () => {
-    expect(escapeHtml(42 as unknown as string)).toBe('42');
-    expect(escapeHtml(null as unknown as string)).toBe('null');
-    expect(escapeHtml(undefined as unknown as string)).toBe('undefined');
-    expect(escapeHtml({ toString: () => '<x>' } as unknown as string)).toBe('&lt;x&gt;');
+  it('coerces non-string input via String() (public signature accepts unknown)', () => {
+    expect(escapeHtml(42)).toBe('42');
+    expect(escapeHtml(null)).toBe('null');
+    expect(escapeHtml(undefined)).toBe('undefined');
+    expect(escapeHtml({ toString: () => '<x>' })).toBe('&lt;x&gt;');
   });
 
   it('leaves safe text unchanged', () => {

--- a/packages/react/src/utils/test/Logger.test.ts
+++ b/packages/react/src/utils/test/Logger.test.ts
@@ -21,36 +21,36 @@ afterEach(() => {
 });
 
 describe('createUILogger - enableDebug gate', () => {
-  it('returns no-op functions when enableDebug is false (default)', () => {
+  it('R0-03: with enableDebug false (default), only `log` is silent — warn/error route to console', () => {
     const { logSpy, warnSpy, errSpy } = mkSpies();
     const ui = createUILogger(undefined); // enableDebug defaults to false
 
-    ui.log('should not appear');
-    ui.warn('should not appear');
-    ui.error('should not appear');
+    ui.log('debug only');
+    ui.warn('a warning');
+    ui.error('an error');
 
-    expect(logSpy).not.toHaveBeenCalled();
-    expect(warnSpy).not.toHaveBeenCalled();
-    expect(errSpy).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled(); // verbosity gated
+    expect(warnSpy).toHaveBeenCalled(); // error visibility is NOT gated (RFC S2)
+    expect(errSpy).toHaveBeenCalled();
   });
 
-  it('returns no-op functions when enableDebug is explicitly false', () => {
+  it('R0-03: with enableDebug false, `log` is gated but warn/error still route (console fallback)', () => {
     const { logSpy, warnSpy, errSpy } = mkSpies();
     const customLog = vi.fn();
 
     const ui = createUILogger({ log: customLog }, { enableDebug: false });
 
-    ui.log('nope');
-    ui.warn('nope');
-    ui.error('nope');
+    ui.log('debug only');
+    ui.warn('a warning');
+    ui.error('an error');
 
     expect(customLog).not.toHaveBeenCalled();
     expect(logSpy).not.toHaveBeenCalled();
-    expect(warnSpy).not.toHaveBeenCalled();
-    expect(errSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled(); // ui logger has no warn -> console.warn
+    expect(errSpy).toHaveBeenCalled(); // ui logger has no error -> console.error
   });
 
-  it('returns no-op functions even when server logger is provided and enableDebug is false', () => {
+  it('R0-03: with a server logger and enableDebug false, warn/error reach the server logger; log stays silent', () => {
     const info = vi.fn();
     const warn = vi.fn();
     const error = vi.fn();
@@ -58,13 +58,13 @@ describe('createUILogger - enableDebug gate', () => {
     const server: ServerLogs = { info, warn, error };
     const ui = createUILogger(server, { enableDebug: false });
 
-    ui.log('hidden');
-    ui.warn('hidden');
-    ui.error('hidden');
+    ui.log('debug only');
+    ui.warn('a warning');
+    ui.error('an error');
 
-    expect(info).not.toHaveBeenCalled();
-    expect(warn).not.toHaveBeenCalled();
-    expect(error).not.toHaveBeenCalled();
+    expect(info).not.toHaveBeenCalled(); // `log` channel gated
+    expect(warn).toHaveBeenCalled(); // warn routes to the provided logger
+    expect(error).toHaveBeenCalled(); // error routes to the provided logger
   });
 
   it('enables logging when enableDebug is true', () => {

--- a/packages/react/src/utils/test/Logger.test.ts
+++ b/packages/react/src/utils/test/Logger.test.ts
@@ -77,6 +77,69 @@ describe('createUILogger - enableDebug gate', () => {
   });
 });
 
+describe('createUILogger — non-throwing on hostile values (gate finding 2)', () => {
+  const circular: Record<string, unknown> = {};
+  circular.self = circular;
+
+  const hostileToJSON = {
+    toJSON() {
+      throw new Error('toJSON boom');
+    },
+  };
+  const hostileCoercion = {
+    [Symbol.toPrimitive]() {
+      throw new Error('coercion boom');
+    },
+    toString() {
+      throw new Error('coercion boom');
+    },
+  };
+
+  const values: ReadonlyArray<readonly [string, unknown]> = [
+    ['BigInt', 1n],
+    ['circular', circular],
+    ['symbol', Symbol('s')],
+    ['throwing toJSON', hostileToJSON],
+    ['throwing Symbol.toPrimitive', hostileCoercion],
+  ];
+
+  for (const [name, v] of values) {
+    it(`server-shaped logger: error(${name}) does not throw (formatting is isolated)`, () => {
+      const server: ServerLogs = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      const ui = createUILogger(server, { enableDebug: false });
+
+      expect(() => ui.error('boom', v)).not.toThrow();
+      expect(() => ui.warn('boom', v)).not.toThrow();
+    });
+  }
+
+  it('isolates a server logger method that itself throws', () => {
+    const server: ServerLogs = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(() => {
+        throw new Error('logger.error boom');
+      }),
+    };
+    const ui = createUILogger(server, { enableDebug: false });
+
+    expect(() => ui.error('anything')).not.toThrow();
+  });
+
+  it('isolates a UI-shaped logger method that itself throws', () => {
+    const ui = createUILogger(
+      {
+        error: () => {
+          throw new Error('ui.error boom');
+        },
+      },
+      { enableDebug: false },
+    );
+
+    expect(() => ui.error('anything')).not.toThrow();
+  });
+});
+
 describe('createUILogger - UI-logger-shaped input', () => {
   it('uses provided UI methods and falls back to console for missing ones; forwards raw args', () => {
     const { warnSpy, errSpy } = mkSpies();

--- a/packages/react/src/utils/test/Streaming.crash.test.ts
+++ b/packages/react/src/utils/test/Streaming.crash.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { PassThrough } from 'node:stream';
+import { fileURLToPath } from 'node:url';
+
+import ts from 'typescript';
+import { describe, it, expect } from 'vitest';
+
+import { createStreamController } from '../Streaming';
+
+// R0-01 — crash-safe `done`.
+//
+// Every in-process streaming test AWAITS `done`, which is exactly why the unobserved-rejection
+// crash was invisible to the suite. An in-process `process.on('unhandledRejection')` listener
+// would itself change Node's default behaviour (and vitest may install its own listeners), so
+// the crash is proven in a real CHILD process under DEFAULT flags — no `--unhandled-rejections`
+// override, so Node's default (crash) mode applies.
+//
+// The child runs the REAL `Streaming.ts`, transpiled to plain JS at test time (via the
+// TypeScript compiler, a devDependency) and executed with `node --input-type=module -e` (the
+// brief's "inline node -e" option). Transpiling keeps the guard portable to EVERY supported
+// Node (`engines.node` is `>=20.11`, `.nvmrc` is `22.17.0`) instead of relying on native `.ts`
+// execution (Node >= 22.18 only) — while still exercising the actual source, so reverting the
+// `settle.done.catch(...)` fix makes this test fail.
+function buildChildScript(): string {
+  const streamingTs = fileURLToPath(new URL('../Streaming.ts', import.meta.url));
+  const transpiled = ts.transpileModule(readFileSync(streamingTs, 'utf8'), {
+    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 },
+  }).outputText;
+
+  return [
+    `import { PassThrough } from 'node:stream';`,
+    transpiled,
+    `const noop = () => {};`,
+    `const controller = createStreamController(new PassThrough(), { log: noop, warn: noop, error: noop });`,
+    // Stands in for any fatal stream error (a non-benign writable error, `onShellError`, or the
+    // first-content watchdog) — all route through `fatalAbort` -> `settle.reject`. `done` is
+    // never observed here, exactly as the server call site did before R0-01.
+    `controller.fatalAbort(new Error('R0-01 fatal-boom'));`,
+    `setTimeout(() => { console.log('SURVIVED'); process.exit(0); }, 150);`,
+  ].join('\n');
+}
+
+describe('R0-01 crash-safe done', () => {
+  it('does not crash the process when a fatal abort rejects an unobserved `done` (child process, default rejection mode)', () => {
+    let status = 0;
+    let stdout = '';
+    try {
+      stdout = execFileSync(process.execPath, ['--input-type=module', '-e', buildChildScript()], { encoding: 'utf8' });
+    } catch (err) {
+      status = (err as { status?: number | null }).status ?? 1;
+      stdout = String((err as { stdout?: unknown }).stdout ?? '');
+    }
+
+    expect(status).toBe(0);
+    expect(stdout).toContain('SURVIVED');
+  });
+
+  it('still rejects `done` for consumers who await it', async () => {
+    const noop = () => {};
+    const controller = createStreamController(new PassThrough(), { log: noop, warn: noop, error: noop });
+
+    controller.fatalAbort(new Error('R0-01 fatal-boom'));
+
+    await expect(controller.done).rejects.toThrow('R0-01 fatal-boom');
+  });
+});

--- a/packages/react/src/utils/test/Streaming.test.ts
+++ b/packages/react/src/utils/test/Streaming.test.ts
@@ -1,14 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import {
-  DEFAULT_BENIGN_ERRORS,
-  isBenignStreamErr,
-  createSettler,
-  startShellTimer,
-  wireWritableGuards,
-  createStreamController,
-  type StreamLogger,
-} from '../Streaming';
+import { isBenignStreamErr, createSettler, startShellTimer, wireWritableGuards, createStreamController, type StreamLogger } from '../Streaming';
 
 function makeWritableMock() {
   const events = new Map<string, Set<Function>>();
@@ -92,19 +84,46 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe('isBenignStreamErr / DEFAULT_BENIGN_ERRORS', () => {
-  it('matches known benign patterns', () => {
-    const msgs = ['ECONNRESET', 'EPIPE', 'socket hang up', 'aborted', 'premature close'];
-    for (const m of msgs) {
-      expect(DEFAULT_BENIGN_ERRORS.test(m)).toBe(true);
-      expect(isBenignStreamErr(new Error(m))).toBe(true);
+describe('isBenignStreamErr (origin-aware, R0-02)', () => {
+  it('render-origin errors are NEVER benign, whatever their shape', () => {
+    expect(isBenignStreamErr(new Error('Payment aborted unexpectedly'), 'render')).toBe(false);
+    expect(isBenignStreamErr(Object.assign(new Error('x'), { code: 'EPIPE' }), 'render')).toBe(false);
+    expect(isBenignStreamErr(Object.assign(new Error('x'), { name: 'AbortError' }), 'render')).toBe(false);
+    expect(isBenignStreamErr(new Error('aborted'), 'render')).toBe(false);
+  });
+
+  it('socket-origin: benign by exact (case-insensitive, trimmed) message', () => {
+    for (const m of ['aborted', 'socket hang up', 'premature close', 'request aborted', '  ABORTED  ']) {
+      expect(isBenignStreamErr(new Error(m), 'socket')).toBe(true);
     }
   });
 
-  it('non-matching errors are not benign', () => {
-    expect(isBenignStreamErr(new Error('boom'))).toBe(false);
-    expect(isBenignStreamErr({ message: 'other' })).toBe(false);
-    expect(isBenignStreamErr({})).toBe(false);
+  it('socket-origin: a message that merely CONTAINS a benign word is not benign', () => {
+    expect(isBenignStreamErr(new Error('Payment aborted unexpectedly'), 'socket')).toBe(false);
+    expect(isBenignStreamErr(new Error('stream premature something'), 'socket')).toBe(false);
+    // legacy substrings that used to match the retired regex now do not
+    expect(isBenignStreamErr(new Error('ECONNRESET'), 'socket')).toBe(false);
+    expect(isBenignStreamErr(new Error('EPIPE'), 'socket')).toBe(false);
+  });
+
+  it('socket-origin: benign by disconnect code', () => {
+    for (const code of ['ECONNRESET', 'EPIPE', 'ERR_STREAM_PREMATURE_CLOSE', 'ERR_STREAM_DESTROYED']) {
+      expect(isBenignStreamErr(Object.assign(new Error('whatever'), { code }), 'socket')).toBe(true);
+    }
+    expect(isBenignStreamErr(Object.assign(new Error('x'), { code: 'ENOENT' }), 'socket')).toBe(false);
+  });
+
+  it('socket-origin: benign by AbortError name', () => {
+    expect(isBenignStreamErr(Object.assign(new Error('x'), { name: 'AbortError' }), 'socket')).toBe(true);
+    expect(isBenignStreamErr(new DOMException('', 'AbortError'), 'socket')).toBe(true);
+  });
+
+  it('non-Error values are not benign and do not throw', () => {
+    expect(isBenignStreamErr(undefined, 'socket')).toBe(false);
+    expect(isBenignStreamErr(null, 'socket')).toBe(false);
+    expect(isBenignStreamErr({}, 'socket')).toBe(false);
+    expect(isBenignStreamErr('aborted', 'socket')).toBe(false); // raw string has no `.message`
+    expect(isBenignStreamErr(undefined, 'render')).toBe(false);
   });
 });
 

--- a/packages/react/src/utils/test/Streaming.test.ts
+++ b/packages/react/src/utils/test/Streaming.test.ts
@@ -496,4 +496,36 @@ describe('createStreamController', () => {
     expect(warn).not.toHaveBeenCalled();
     expect(error).not.toHaveBeenCalled();
   });
+
+  it('gate finding 2: fatalAbort still cleans up and rejects done when the logger throws', async () => {
+    const w = makeWritableMock();
+    const throwingLogger: StreamLogger = {
+      warn: vi.fn(),
+      error: () => {
+        throw new Error('logger boom');
+      },
+    };
+    const c = createStreamController(w, throwingLogger);
+
+    c.fatalAbort(new Error('fatal'));
+
+    await expect(c.done).rejects.toThrow('fatal');
+    expect(w.destroyed).toBe(true); // cleanup ran despite the logger throwing
+  });
+
+  it('gate finding 2: benignAbort still cleans up and resolves done when the logger throws', async () => {
+    const w = makeWritableMock();
+    const throwingLogger: StreamLogger = {
+      warn: () => {
+        throw new Error('logger boom');
+      },
+      error: vi.fn(),
+    };
+    const c = createStreamController(w, throwingLogger);
+
+    c.benignAbort('client gone');
+
+    await expect(c.done).resolves.toBeUndefined();
+    expect(w.destroyed).toBe(true);
+  });
 });

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -2,9 +2,20 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
+  // R3-05 (Q6, signed 2026-07-12): `bundle: false` preserves the source module graph in dist so a
+  // browser bundler can prove `react-dom/server` unreachable from the client entry (`hydrateApp`).
+  // The single-module barrel forced every client bundle to retain the CJS browser build of
+  // react-dom/server (-49% raw / -48% gzip once split). Two load-bearing details:
+  // 1. `bundle: false` does NOT follow the import graph — every source module must be an entry
+  //    (the glob below), or its output is silently missing from dist.
+  // 2. Source files must use explicit `.js` relative specifiers — tsup emits specifiers as-is,
+  //    and extensionless relative imports fail Node ESM with ERR_MODULE_NOT_FOUND. A lint guard
+  //    (`SpecifierExtensions.test.ts`) and a client-bundle absence guard (`ClientBundle.test.ts`)
+  //    keep both properties from regressing.
+  bundle: false,
   clean: true,
   dts: true,
-  entryPoints: ['src/index.ts', 'src/plugin.ts'],
+  entryPoints: ['src/**/*.ts', 'src/**/*.tsx', '!src/**/test/**', '!src/**/*.d.ts'],
   external: ['node:fs/promises', 'node:path', 'node:url', 'node:stream', 'react', 'react-dom', 'vite', '@vitejs/plugin-react'],
   format: ['esm'],
   outDir: 'dist',

--- a/packages/server/src/constants.ts
+++ b/packages/server/src/constants.ts
@@ -37,7 +37,3 @@ export const DEBUG = {
   trx: { label: 'trx', colour: pc.magenta },
   vite: { label: 'vite', colour: pc.yellow },
 } as const;
-
-export const REGEX = {
-  BENIGN_NET_ERR: /\b(?:ECONNRESET|EPIPE|ECONNABORTED)\b|socket hang up|aborted|premature(?: close)?/i,
-} as const satisfies Readonly<Record<string, RegExp>>;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5,6 +5,6 @@ export { AppError } from './core/errors/AppError';
 export { createRequestGraph } from './core/introspection/RequestGraph';
 
 export type { InitialRouteParams } from './types';
-export type { RenderCallbacks, RenderSSR, RenderStream, RenderModule, RendererLogger } from './types';
+export type { RenderCallbacks, RenderSSR, RenderStream, RenderStreamHandle, RenderModule, RendererLogger } from './types';
 export type { BaseLogger } from './logging/Logger';
 export type { CreateRequestGraphOptions, GraphWarning, RequestGraph } from './core/introspection/RequestGraph';

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -84,6 +84,25 @@ export type RenderSSR = (
   appHtml: string;
 }>;
 
+/**
+ * The lifecycle handle a renderer's `renderStream` returns (R0-01).
+ *
+ * - `abort()` requests a benign cancel of an in-flight stream.
+ * - `done` resolves on normal completion or benign cancel, and REJECTS on a fatal stream error.
+ *
+ * The rejection is pre-observed inside the renderer: a no-op handler is attached to the same
+ * promise at creation (see each framework's `createStreamController`), so an unobserved `done`
+ * can never raise `unhandledRejection` — which Node's default mode turns into a
+ * process-terminating `uncaughtException`. Consumers who `await done` still receive the fatal
+ * error on their own handler; consumers who ignore `done` are safe. The server observes `done`
+ * as acknowledgement (fatal errors are already handled via the `onError` callback) and as
+ * defence in depth against a third-party renderer that omits the pre-attached handler.
+ */
+export type RenderStreamHandle = {
+  abort(): void;
+  done: Promise<void>;
+};
+
 export type RenderStream = (
   // The server always passes a node Writable (a PassThrough); both framework renderers have
   // always consumed node-Writable APIs. The contract states that truth (V1-05).
@@ -96,7 +115,7 @@ export type RenderStream = (
   cspNonce?: string,
   signal?: AbortSignal,
   opts?: { logger?: RendererLogger; routeContext?: unknown },
-) => { abort(): void };
+) => RenderStreamHandle;
 
 export type RenderModule = {
   renderSSR: RenderSSR;

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -30,11 +30,33 @@ export interface InitialRouteParams extends Record<string, unknown> {
   serviceMethod?: string;
 }
 
+/**
+ * Structured, NON-FATAL render-error observation (R1-01). `phase` is the OBSERVED timing (had the
+ * shell committed when the renderer surfaced the error) — descriptive only, never a fatality
+ * signal. `recoverable` is `true` only for `post-shell` errors (React recovers them client-side)
+ * and `'unknown'` for `pre-shell` (outcome resolved by the fatal channels).
+ */
+export type RenderErrorInfo = {
+  error: unknown;
+  phase: 'pre-shell' | 'post-shell';
+  recoverable: boolean | 'unknown';
+};
+
 export type RenderCallbacks<T = unknown> = {
+  /** REQUIRED (operationally): commits the head + connects the sink. A throwing `onHead` is fatal. */
   onHead?: (headContent: string) => void;
+  /** Advisory (isolated — a throw is logged, not fatal). */
   onShellReady?: () => void;
+  /** Advisory. Fires once with the resolved route data. */
   onAllReady?: (initialData: T) => void;
+  /** FATAL error channel (shell error / timeout / guard / non-recoverable). */
   onError?: (error: unknown) => void;
+  /**
+   * Advisory, NON-FATAL structured render-error channel (R1-01) — fires for render errors that do
+   * not fail the response (notably post-shell boundary errors React recovers client-side). The
+   * server wires this to the request logger. Never a fatality signal.
+   */
+  onRenderError?: (info: RenderErrorInfo) => void;
 };
 
 export type SSRManifest = { [key: string]: string[] };

--- a/packages/server/src/utils/HandleRender.ts
+++ b/packages/server/src/utils/HandleRender.ts
@@ -407,7 +407,12 @@ export const handleRender = async (
             recorder?.streamPhase({ traceId, phase: 'allReady' });
           },
           onError: (err: unknown) => {
-            if (abortedState.aborted || isBenignSocketError(err)) {
+            // Gate finding 1: `onError` is the renderer's FATAL channel — the renderer already
+            // established origin (benign socket disconnects are handled by the writable guards via
+            // `benignAbort`, never routed here). Trust it: the only benign condition is ACTUAL
+            // request-abort state, never the shape of an app-controlled error (re-classifying by
+            // `code`/`name`/message would re-introduce the R0-02 spoofing at the cross-package join).
+            if (abortedState.aborted) {
               logger.warn({}, 'Client disconnected before stream finished');
               recorder?.aborted({ traceId, phase: 'stream' });
               try {

--- a/packages/server/src/utils/HandleRender.ts
+++ b/packages/server/src/utils/HandleRender.ts
@@ -51,6 +51,51 @@ const isBenignSocketError = (err: unknown): boolean => {
   );
 };
 
+// Recheck: the streaming render `onError` callback runs on a stream tick with a possibly-HOSTILE
+// `unknown` — a component may throw an object with a throwing `message` getter / `Symbol.toPrimitive`,
+// or a proxy with a throwing brand getter. These helpers extract telemetry WITHOUT ever throwing so
+// that formatting a fatal error can never veto the response teardown (500 / socket destroy).
+const safeStringify = (value: unknown): string => {
+  try {
+    return String(value);
+  } catch {
+    return '[unstringifiable]';
+  }
+};
+
+const safeErrorMessage = (err: unknown): string => {
+  try {
+    const message = (err as { message?: unknown } | null | undefined)?.message;
+    return safeStringify(message ?? err ?? '');
+  } catch {
+    return '[unstringifiable]';
+  }
+};
+
+const safeErrorKind = (err: unknown): string => {
+  try {
+    return AppError.isAppError(err) ? safeStringify((err as { kind?: unknown }).kind) : 'stream';
+  } catch {
+    return 'stream';
+  }
+};
+
+const safeNormaliseError = (err: unknown): ReturnType<typeof normaliseError> => {
+  try {
+    return normaliseError(err);
+  } catch {
+    return { name: 'Error', message: '[unstringifiable]' };
+  }
+};
+
+const safeToReason = (err: unknown): Error => {
+  try {
+    return toReason(err);
+  } catch {
+    return new Error('[unstringifiable render error]');
+  }
+};
+
 export const handleRender = async (
   req: FastifyRequest,
   reply: FastifyReply,
@@ -263,7 +308,7 @@ export const handleRender = async (
         logger.error(
           {
             url: req.url,
-            error: normaliseError(err),
+            error: safeNormaliseError(err),
           },
           'SSR render failed',
         );
@@ -302,7 +347,7 @@ export const handleRender = async (
         const benign = isBenignSocketError(err);
 
         if (!benign) {
-          logger.error({ url: req.url, error: normaliseError(err) }, 'SSR send failed');
+          logger.error({ url: req.url, error: safeNormaliseError(err) }, 'SSR send failed');
           recorder?.failed({ traceId, error: { kind: 'send', message: msg } });
         } else {
           logger.warn({ url: req.url, reason: msg }, 'SSR send aborted (benign)');
@@ -418,30 +463,27 @@ export const handleRender = async (
               try {
                 if (!reply.raw.writableEnded && !reply.raw.destroyed) reply.raw.destroy();
               } catch (e) {
-                logger.debug?.('ssr', { error: normaliseError(e) }, 'stream teardown: destroy() failed');
+                logger.debug?.('ssr', { error: safeNormaliseError(e) }, 'stream teardown: destroy() failed');
               }
               return;
             }
 
             abortedState.aborted = true;
-            recorder?.failed({
-              traceId,
-              error: { kind: AppError.isAppError(err) ? (err as any).kind : 'stream', message: String((err as any)?.message ?? err ?? '') },
-            });
 
-            logger.error(
-              {
-                error: normaliseError(err),
-                clientRoot,
-                url: req.url,
-              },
-              'Critical rendering error during stream',
-            );
+            // Recheck: this callback must NEVER throw — a throw here (e.g. formatting a hostile
+            // error for telemetry) would skip the response teardown below and hang the request.
+            // Format defensively and belt the telemetry so teardown always runs.
+            try {
+              recorder?.failed({ traceId, error: { kind: safeErrorKind(err), message: safeErrorMessage(err) } });
+              logger.error({ error: safeNormaliseError(err), clientRoot, url: req.url }, 'Critical rendering error during stream');
+            } catch {
+              // telemetry formatting must not veto teardown
+            }
 
             try {
               ac?.abort?.();
             } catch (e) {
-              logger.debug?.('ssr', { error: normaliseError(e) }, 'stream teardown: abort() failed');
+              logger.debug?.('ssr', { error: safeNormaliseError(e) }, 'stream teardown: abort() failed');
             }
 
             if (!reply.raw.headersSent) {
@@ -451,17 +493,17 @@ export const handleRender = async (
                 reply.raw.writeHead(500, { 'Content-Type': 'text/html; charset=utf-8' });
                 reply.raw.end('Internal Server Error');
               } catch (e) {
-                logger.debug?.('ssr', { error: normaliseError(e) }, 'stream teardown: error response failed');
+                logger.debug?.('ssr', { error: safeNormaliseError(e) }, 'stream teardown: error response failed');
               }
               return;
             }
 
-            const reason = toReason(err);
+            const reason = safeToReason(err);
 
             try {
               if (!reply.raw.writableEnded && !reply.raw.destroyed) reply.raw.destroy(reason);
             } catch (e) {
-              logger.debug?.('ssr', { error: normaliseError(e) }, 'stream teardown: destroy() failed');
+              logger.debug?.('ssr', { error: safeNormaliseError(e) }, 'stream teardown: destroy() failed');
             }
           },
         },
@@ -493,7 +535,7 @@ export const handleRender = async (
 
           if (!serialized.ok) {
             abortedState.aborted = true;
-            logger.error({ error: normaliseError(serialized.error), clientRoot, url: req.url }, 'Failed to serialize streaming initial data');
+            logger.error({ error: safeNormaliseError(serialized.error), clientRoot, url: req.url }, 'Failed to serialize streaming initial data');
             recorder?.failed({ traceId, error: { kind: 'serialize', message: String(serialized.error.message) } });
 
             // Deterministic termination — mirror the onError teardown idioms above.
@@ -502,14 +544,14 @@ export const handleRender = async (
                 reply.raw.writeHead(500, { 'Content-Type': 'text/html; charset=utf-8' });
                 reply.raw.end('Internal Server Error');
               } catch (e) {
-                logger.debug?.('ssr', { error: normaliseError(e) }, 'stream teardown: error response failed');
+                logger.debug?.('ssr', { error: safeNormaliseError(e) }, 'stream teardown: error response failed');
               }
             } else {
               // Shell already committed: end without the data script and destroy.
               try {
                 if (!reply.raw.writableEnded && !reply.raw.destroyed) reply.raw.destroy();
               } catch (e) {
-                logger.debug?.('ssr', { error: normaliseError(e) }, 'stream teardown: destroy() failed');
+                logger.debug?.('ssr', { error: safeNormaliseError(e) }, 'stream teardown: destroy() failed');
               }
             }
             return;
@@ -526,7 +568,7 @@ export const handleRender = async (
           recorder?.sent({ traceId, status: 200, mode: 'streaming' });
         } catch (e) {
           // Belt: never let this listener throw — an uncaughtException here would exit the process.
-          logger.error({ error: normaliseError(e), clientRoot, url: req.url }, 'Streaming finish listener failed');
+          logger.error({ error: safeNormaliseError(e), clientRoot, url: req.url }, 'Streaming finish listener failed');
           try {
             if (!reply.raw.writableEnded && !reply.raw.destroyed) reply.raw.destroy();
           } catch {}

--- a/packages/server/src/utils/HandleRender.ts
+++ b/packages/server/src/utils/HandleRender.ts
@@ -352,7 +352,7 @@ export const handleRender = async (
       let finalData: unknown = undefined;
       let pipedToReply = false;
 
-      renderStream(
+      const { done } = renderStream(
         writable,
         {
           onHead: (headContent: string) => {
@@ -445,6 +445,13 @@ export const handleRender = async (
         ac.signal,
         { logger: reqLogger, routeContext },
       );
+
+      // R0-01: observe the stream handle's `done`. Fatal stream errors are already fully handled
+      // via the `onError` callback above, so this catch is acknowledgement (it marks the
+      // rejection handled) and defence in depth if a renderer omits its own pre-attached handler
+      // — an unobserved rejected `done` would otherwise crash the process under Node's default
+      // unhandled-rejection mode.
+      void done.catch(() => {});
 
       writable.on('finish', () => {
         if (abortedState.aborted || reply.raw.writableEnded) return;

--- a/packages/server/src/utils/HandleRender.ts
+++ b/packages/server/src/utils/HandleRender.ts
@@ -6,7 +6,6 @@ import { AppError, normaliseError, toReason } from '../core/errors/AppError';
 import { fetchInitialData, matchRoute } from '../core/routes/DataRoutes';
 import { now } from '../core/telemetry/Telemetry';
 import { resolveEntryFile } from '../Build';
-import { REGEX } from '../constants';
 import { createLogger } from '../logging/Logger';
 import { isDevelopment } from '../System';
 import { createRequestContext, getRequestContext } from './Telemetry';
@@ -30,6 +29,26 @@ import type { RouteMatcher } from '../core/routes/DataRoutes';
 import type { ServiceRegistry } from '../core/services/DataServices';
 import type { Manifest, ProcessedConfig, RenderModule, SSRManifest } from '../types';
 import { handleNotFound } from './HandleNotFound';
+
+// R0-02: origin-aware benign classification, textually parallel to `isBenignStreamErr` in
+// packages/react/src/utils/Streaming.ts (the server does not import renderer utils). A
+// socket/writable-origin error is a benign client disconnect iff its code/name/exact message
+// says so; render/data-origin errors are never benign by shape — an app error whose message
+// merely contains "aborted" must not be swallowed as a disconnect.
+const BENIGN_SOCKET_CODES = new Set(['ECONNRESET', 'EPIPE', 'ECONNABORTED', 'ERR_STREAM_PREMATURE_CLOSE', 'ERR_STREAM_DESTROYED']);
+const BENIGN_SOCKET_MESSAGES = new Set(['aborted', 'socket hang up', 'premature close', 'request aborted']);
+
+const isBenignSocketError = (err: unknown): boolean => {
+  const e = err as { code?: unknown; name?: unknown; message?: unknown } | null | undefined;
+  if (typeof e?.code === 'string' && BENIGN_SOCKET_CODES.has(e.code)) return true;
+  if (e?.name === 'AbortError') return true;
+
+  return BENIGN_SOCKET_MESSAGES.has(
+    String(e?.message ?? '')
+      .trim()
+      .toLowerCase(),
+  );
+};
 
 export const handleRender = async (
   req: FastifyRequest,
@@ -224,16 +243,17 @@ export const handleRender = async (
           return;
         }
       } catch (err) {
-        const msg = String((err as any)?.message ?? err ?? '');
-        const benign = REGEX.BENIGN_NET_ERR.test(msg);
-
-        if (ac.signal.aborted || benign) {
+        // R0-02: a renderSSR failure is render/data-origin — never benign by shape. Only an
+        // actual client disconnect (signal aborted) is benign; anything else is an application
+        // error that must produce a real 500. Previously a disconnect-shaped message returned
+        // here WITHOUT sending a response, hanging the request.
+        if (ac.signal.aborted) {
           logger.warn(
             {
               url: req.url,
-              reason: msg,
+              reason: String((err as any)?.message ?? err ?? ''),
             },
-            'SSR aborted mid-render (benign)',
+            'SSR aborted mid-render (client disconnected)',
           );
           recorder?.aborted({ traceId, phase: 'render' });
           return;
@@ -271,7 +291,8 @@ export const handleRender = async (
         return sendResult;
       } catch (err) {
         const msg = String((err as any)?.message ?? err ?? '');
-        const benign = REGEX.BENIGN_NET_ERR.test(msg);
+        // R0-02: a send failure is socket/writable-origin — classify by socket taxonomy.
+        const benign = isBenignSocketError(err);
 
         if (!benign) {
           logger.error({ url: req.url, error: normaliseError(err) }, 'SSR send failed');
@@ -335,18 +356,13 @@ export const handleRender = async (
 
       const shouldHydrate = attr?.hydrate !== false;
 
-      const isBenignSocketAbort = (e: unknown) => {
-        const msg = String((e as any)?.message ?? e ?? '');
-        return REGEX.BENIGN_NET_ERR.test(msg);
-      };
-
       const writable = new PassThrough();
       writable.on('error', (err) => {
-        if (!isBenignSocketAbort(err)) logger.error({ error: err }, 'PassThrough error:');
+        if (!isBenignSocketError(err)) logger.error({ error: err }, 'PassThrough error:');
       });
 
       reply.raw.on('error', (err) => {
-        if (!isBenignSocketAbort(err)) logger.error({ error: err }, 'HTTP socket error:');
+        if (!isBenignSocketError(err)) logger.error({ error: err }, 'HTTP socket error:');
       });
 
       let finalData: unknown = undefined;
@@ -384,7 +400,7 @@ export const handleRender = async (
             recorder?.streamPhase({ traceId, phase: 'allReady' });
           },
           onError: (err: unknown) => {
-            if (abortedState.aborted || isBenignSocketAbort(err)) {
+            if (abortedState.aborted || isBenignSocketError(err)) {
               logger.warn({}, 'Client disconnected before stream finished');
               recorder?.aborted({ traceId, phase: 'stream' });
               try {

--- a/packages/server/src/utils/HandleRender.ts
+++ b/packages/server/src/utils/HandleRender.ts
@@ -230,7 +230,9 @@ export const handleRender = async (
     // exists solely on dev boots, so production HTML never carries it.
     const devtools = (req as { server?: { taujsIntrospection?: { token: string } } }).server?.taujsIntrospection;
     const devStamp = devtools ? buildTaujsDevStamp(traceId, devtools.token, cspNonce) : '';
-    const ctx = { traceId, logger: reqLogger, headers, recorder };
+    // R1-01 (design 4): each branch sets `ctx.signal` from its request AbortController BEFORE the
+    // data is fetched, so loaders that honour `ctx.signal` stop on client disconnect / deadline.
+    const ctx = { traceId, logger: reqLogger, headers, recorder, signal: undefined as AbortSignal | undefined };
     const initialDataInput = async () => {
       const dataT0 = now();
       try {
@@ -265,6 +267,8 @@ export const handleRender = async (
         if (!reply.raw.writableEnded) ac.abort('socket_closed');
       });
       reply.raw.on('finish', () => req.raw.off('aborted', onAborted));
+
+      ctx.signal = ac.signal; // R1-01: propagate into the data context before fetching
 
       if (ac.signal.aborted) {
         logger.warn({ url: req.url }, 'SSR skipped; already aborted');
@@ -406,6 +410,8 @@ export const handleRender = async (
         req.raw.off('aborted', onAborted);
       });
 
+      ctx.signal = ac.signal; // R1-01: propagate into the data context before renderStream fetches it
+
       const shouldHydrate = attr?.hydrate !== false;
 
       const writable = new PassThrough();
@@ -450,6 +456,24 @@ export const handleRender = async (
           onAllReady: (data: unknown) => {
             if (!abortedState.aborted) finalData = data;
             recorder?.streamPhase({ traceId, phase: 'allReady' });
+          },
+          onRenderError: (info) => {
+            // R1-01 (design 7): NON-FATAL structured render-error channel — wired to the request
+            // logger with structured fields. No new recorder methods (TraceRecorder integration is
+            // introspection-owned, conventions #3). Never fails the response.
+            //
+            // Log at `warn`, not `error`: this channel is advisory by contract. Only `post-shell`
+            // errors are provably recoverable (React retries the boundary client-side); a
+            // `pre-shell` error's fatality is resolved by the SEPARATE fatal channel
+            // (`onError`/`onShellError`), which logs the real failure at `error` if it fails the
+            // response. Keying the message on `recoverable` avoids claiming "Recoverable" for a
+            // pre-shell error that then turns fatal (which previously double-logged at `error` with
+            // contradictory framing).
+            const message =
+              info.recoverable === true
+                ? 'Recoverable render error (React retries the affected boundary client-side)'
+                : 'Render error observed (pre-shell); response outcome resolved by the fatal channel';
+            reqLogger.warn({ error: safeNormaliseError(info.error), phase: info.phase, recoverable: info.recoverable, clientRoot, url: req.url }, message);
           },
           onError: (err: unknown) => {
             // Gate finding 1: `onError` is the renderer's FATAL channel — the renderer already

--- a/packages/server/src/utils/HandleRender.ts
+++ b/packages/server/src/utils/HandleRender.ts
@@ -13,6 +13,7 @@ import {
   ensureNonNull,
   buildTaujsDevStamp,
   collectStyle,
+  escapeHtmlAttribute,
   processTemplate,
   rebuildTemplate,
   addNonceToInlineScripts,
@@ -334,7 +335,8 @@ export const handleRender = async (
       }
       const initialDataScript = `<script${nonceAttr}>window.__INITIAL_DATA__ = ${serialized.js};</script>`;
 
-      const bootstrapScriptTag = shouldHydrate && bootstrapModule ? `<script${nonceAttr} type="module" src="${bootstrapModule}" defer></script>` : '';
+      const bootstrapScriptTag =
+        shouldHydrate && bootstrapModule ? `<script${nonceAttr} type="module" src="${escapeHtmlAttribute(bootstrapModule)}" defer></script>` : '';
 
       const safeAppHtml = appHtml.trim();
       const fullHtml = rebuildTemplate(templateParts, aggregateHeadContent, `${safeAppHtml}${initialDataScript}${devStamp}${bootstrapScriptTag}`);

--- a/packages/server/src/utils/HandleRender.ts
+++ b/packages/server/src/utils/HandleRender.ts
@@ -20,6 +20,7 @@ import {
   stripDevClientAndStyles,
   applyViteTransform,
 } from './Templates';
+import { serializeInlineData } from './InlineData';
 
 import type { FastifyRequest, FastifyReply } from 'fastify';
 import type { ViteDevServer } from 'vite';
@@ -276,7 +277,13 @@ export const handleRender = async (
 
       const shouldHydrate = attr?.hydrate !== false;
       const nonceAttr = cspNonce ? ` nonce="${cspNonce}"` : '';
-      const initialDataScript = `<script${nonceAttr}>window.__INITIAL_DATA__ = ${JSON.stringify(initialDataResolved).replace(/</g, '\\u003c')};</script>`;
+      // R0-04: single serialization boundary. On the SSR path a failure is inside the request
+      // try/catch, so throw into the existing 500 machinery (valid-data output is unchanged).
+      const serialized = serializeInlineData(initialDataResolved);
+      if (!serialized.ok) {
+        throw AppError.internal('Failed to serialize initial data for inline injection', serialized.error, { clientRoot, url: req.url });
+      }
+      const initialDataScript = `<script${nonceAttr}>window.__INITIAL_DATA__ = ${serialized.js};</script>`;
 
       const bootstrapScriptTag = shouldHydrate && bootstrapModule ? `<script${nonceAttr} type="module" src="${bootstrapModule}" defer></script>` : '';
 
@@ -470,19 +477,55 @@ export const handleRender = async (
       void done.catch(() => {});
 
       writable.on('finish', () => {
-        if (abortedState.aborted || reply.raw.writableEnded) return;
+        // R0-04: this listener runs on a stream tick, OUTSIDE the request try/catch, so an
+        // uncaught throw here becomes an `uncaughtException` → process exit. `serializeInlineData`
+        // never throws; the outer try/catch is a belt so nothing else in the listener can either.
+        try {
+          if (abortedState.aborted || reply.raw.writableEnded) return;
 
-        const data = finalData ?? {};
-        const initialDataScript = `<script${cspNonce ? ` nonce="${cspNonce}"` : ''}>window.__INITIAL_DATA__ = ${JSON.stringify(data).replace(
-          /</g,
-          '\\u003c',
-        )}; window.dispatchEvent(new Event('taujs:data-ready'));</script>`;
+          const data = finalData ?? {};
+          const serialized = serializeInlineData(data);
 
-        commitHead();
-        reply.raw.write(initialDataScript);
-        reply.raw.write(templateParts.afterBody);
-        reply.raw.end();
-        recorder?.sent({ traceId, status: 200, mode: 'streaming' });
+          if (!serialized.ok) {
+            abortedState.aborted = true;
+            logger.error({ error: normaliseError(serialized.error), clientRoot, url: req.url }, 'Failed to serialize streaming initial data');
+            recorder?.failed({ traceId, error: { kind: 'serialize', message: String(serialized.error.message) } });
+
+            // Deterministic termination — mirror the onError teardown idioms above.
+            if (!reply.raw.headersSent) {
+              try {
+                reply.raw.writeHead(500, { 'Content-Type': 'text/html; charset=utf-8' });
+                reply.raw.end('Internal Server Error');
+              } catch (e) {
+                logger.debug?.('ssr', { error: normaliseError(e) }, 'stream teardown: error response failed');
+              }
+            } else {
+              // Shell already committed: end without the data script and destroy.
+              try {
+                if (!reply.raw.writableEnded && !reply.raw.destroyed) reply.raw.destroy();
+              } catch (e) {
+                logger.debug?.('ssr', { error: normaliseError(e) }, 'stream teardown: destroy() failed');
+              }
+            }
+            return;
+          }
+
+          const initialDataScript = `<script${
+            cspNonce ? ` nonce="${cspNonce}"` : ''
+          }>window.__INITIAL_DATA__ = ${serialized.js}; window.dispatchEvent(new Event('taujs:data-ready'));</script>`;
+
+          commitHead();
+          reply.raw.write(initialDataScript);
+          reply.raw.write(templateParts.afterBody);
+          reply.raw.end();
+          recorder?.sent({ traceId, status: 200, mode: 'streaming' });
+        } catch (e) {
+          // Belt: never let this listener throw — an uncaughtException here would exit the process.
+          logger.error({ error: normaliseError(e), clientRoot, url: req.url }, 'Streaming finish listener failed');
+          try {
+            if (!reply.raw.writableEnded && !reply.raw.destroyed) reply.raw.destroy();
+          } catch {}
+        }
       });
     }
   } catch (err) {

--- a/packages/server/src/utils/InlineData.ts
+++ b/packages/server/src/utils/InlineData.ts
@@ -15,12 +15,19 @@ const toError = (err: unknown): Error => {
 /**
  * Serialize route data for inline injection into `window.__INITIAL_DATA__`, SAFELY (R0-04).
  *
- * The single server-owned serialization boundary for BOTH render modes. Route data is the JSON
- * contract (`Record<string, unknown>`), but the service layer only validates that the result
- * ROOT is a plain object — never recursively — so circular references, `BigInt`, a throwing
- * `toJSON`, functions, or an `undefined` result all reach here. Any of these fails
- * DETERMINISTICALLY (returns `{ ok: false }`) and this function NEVER throws, so the caller can
- * terminate the response instead of crashing the process.
+ * The single server-owned serialization boundary for BOTH render modes. Route data is nominally
+ * the JSON contract (`Record<string, unknown>`), but the service layer only validates that the
+ * result ROOT is a plain object — never recursively. This function's guarantee is CRASH-SAFETY,
+ * not full contract enforcement:
+ *   - Values that make `JSON.stringify` THROW — circular references, `BigInt`, a throwing
+ *     `toJSON`/`valueOf` — ANYWHERE in the tree fail deterministically (`{ ok: false }`).
+ *   - A value whose top-level `JSON.stringify` result is `undefined` (the value itself is
+ *     `undefined`, a function, or a symbol) fails deterministically.
+ *   - NESTED `undefined`/functions/symbols follow STANDARD JSON semantics — omitted from objects,
+ *     `null` in arrays — and are NOT rejected (this matches `JSON.stringify`). Enforcing the full
+ *     JSON contract for nested values (recursive validation with a path) is deferred to a future
+ *     data-contract task (R3-03 / RFC-0004); R0-04 only removes the process-crash class.
+ * This function NEVER throws, so the caller can terminate the response instead of crashing.
  *
  * Why "never throws" matters: the streaming `finish` listener runs on a stream tick, OUTSIDE the
  * request `try/catch`, so an uncaught throw there becomes an `uncaughtException` → process exit
@@ -32,9 +39,14 @@ const toError = (err: unknown): Error => {
  * pages must not observe a diff). U+2028/U+2029 are legal in ES2019+ string literals and pass
  * through unescaped.
  *
- * `__proto__` fidelity (RFC SEC4): an object-literal `"__proto__"` key serializes as an ordinary
- * JSON string key and, on the client, re-parses as an OWN property of the initial-data object
- * (not a prototype mutation); it cannot pollute `Object.prototype`. Behaviour is unchanged.
+ * `__proto__` note (RFC SEC4): the inline script is emitted as a JS OBJECT LITERAL
+ * (`window.__INITIAL_DATA__ = { ... }`), and a quoted `"__proto__":` key in an object literal
+ * SETS THE CREATED OBJECT'S PROTOTYPE (ES Annex B.3.1), it does not add an own property. So a
+ * `__proto__` DATA key lands on the initial-data object's prototype (reachable via the prototype
+ * chain, with no own `__proto__` property) — it does NOT pollute the global `Object.prototype`,
+ * but its shape differs between server (own key) and client (prototype). Removing that drift
+ * (recursively rejecting `__proto__`, or emitting via `JSON.parse("…")`) is a data-contract
+ * change, deferred with the nested-value handling above. Behaviour is unchanged from before R0-04.
  */
 export const serializeInlineData = (value: unknown): SerializedInlineData => {
   try {

--- a/packages/server/src/utils/InlineData.ts
+++ b/packages/server/src/utils/InlineData.ts
@@ -1,0 +1,52 @@
+export type SerializedInlineData = { ok: true; js: string } | { ok: false; error: Error };
+
+// Coerce any thrown value to an Error without ever throwing — a hostile non-Error (e.g. an
+// object with a throwing `toString`/`Symbol.toPrimitive` thrown from a `toJSON`) must not defeat
+// the "never throws" guarantee below.
+const toError = (err: unknown): Error => {
+  if (err instanceof Error) return err;
+  try {
+    return new Error(String(err));
+  } catch {
+    return new Error('Value is not JSON-serializable (its thrown error could not be coerced to a string)');
+  }
+};
+
+/**
+ * Serialize route data for inline injection into `window.__INITIAL_DATA__`, SAFELY (R0-04).
+ *
+ * The single server-owned serialization boundary for BOTH render modes. Route data is the JSON
+ * contract (`Record<string, unknown>`), but the service layer only validates that the result
+ * ROOT is a plain object — never recursively — so circular references, `BigInt`, a throwing
+ * `toJSON`, functions, or an `undefined` result all reach here. Any of these fails
+ * DETERMINISTICALLY (returns `{ ok: false }`) and this function NEVER throws, so the caller can
+ * terminate the response instead of crashing the process.
+ *
+ * Why "never throws" matters: the streaming `finish` listener runs on a stream tick, OUTSIDE the
+ * request `try/catch`, so an uncaught throw there becomes an `uncaughtException` → process exit
+ * (the second crash class; the first was R0-01's unobserved `done` rejection).
+ *
+ * Security: every `<` is replaced by its JS unicode escape so `</script>` and `<!--` cannot
+ * break out of the inline script (RFC §4). Output is BYTE-IDENTICAL to the previous inline
+ * `JSON.stringify(v).replace(/</g, '\\u003c')` for every valid input (existing tests and cached
+ * pages must not observe a diff). U+2028/U+2029 are legal in ES2019+ string literals and pass
+ * through unescaped.
+ *
+ * `__proto__` fidelity (RFC SEC4): an object-literal `"__proto__"` key serializes as an ordinary
+ * JSON string key and, on the client, re-parses as an OWN property of the initial-data object
+ * (not a prototype mutation); it cannot pollute `Object.prototype`. Behaviour is unchanged.
+ */
+export const serializeInlineData = (value: unknown): SerializedInlineData => {
+  try {
+    const json = JSON.stringify(value);
+    // `JSON.stringify` returns `undefined` for `undefined`, functions, and symbols — not a
+    // representable value for inline injection.
+    if (json === undefined) {
+      return { ok: false, error: new Error('Value is not JSON-serializable (JSON.stringify returned undefined)') };
+    }
+
+    return { ok: true, js: json.replace(/</g, '\\u003c') };
+  } catch (err) {
+    return { ok: false, error: toError(err) };
+  }
+};

--- a/packages/server/src/utils/Templates.ts
+++ b/packages/server/src/utils/Templates.ts
@@ -182,11 +182,20 @@ export const applyViteTransform = async (template: string, url: string, viteDevS
   return viteDevServer.transformIndexHtml(url, template);
 };
 
+/**
+ * Attribute-escape a value for interpolation into a double-quoted HTML attribute (SEC2, R2-02).
+ * Defence-in-depth for the config-controlled bootstrap-module `src` — the server is renderer-agnostic
+ * and does NOT import the renderers' `escapeHtml`, so this is the server-local equivalent (same five
+ * characters). Escapes `&` first; not idempotent.
+ */
+export const escapeHtmlAttribute = (value: string): string =>
+  String(value).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+
 export const injectBootstrapModule = (template: string, bootstrapModule?: string, nonce?: string) => {
   if (!bootstrapModule) return template;
 
   const nonceAttr = nonce ? ` nonce="${nonce}"` : '';
-  return template.replace('</body>', `<script${nonceAttr} type="module" src="${bootstrapModule}" defer></script></body>`);
+  return template.replace('</body>', `<script${nonceAttr} type="module" src="${escapeHtmlAttribute(bootstrapModule)}" defer></script></body>`);
 };
 
 export const injectCssLink = (template: string, cssLink?: string) => {

--- a/packages/server/src/utils/Templates.ts
+++ b/packages/server/src/utils/Templates.ts
@@ -188,7 +188,7 @@ export const applyViteTransform = async (template: string, url: string, viteDevS
  * and does NOT import the renderers' `escapeHtml`, so this is the server-local equivalent (same five
  * characters). Escapes `&` first; not idempotent.
  */
-export const escapeHtmlAttribute = (value: string): string =>
+export const escapeHtmlAttribute = (value: unknown): string =>
   String(value).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 
 export const injectBootstrapModule = (template: string, bootstrapModule?: string, nonce?: string) => {

--- a/packages/server/src/utils/test/HandleRender.test.ts
+++ b/packages/server/src/utils/test/HandleRender.test.ts
@@ -1247,6 +1247,43 @@ describe('handleRender', () => {
       expect(mockReply.raw.write).toHaveBeenCalled();
     });
 
+    it('R1-01: streaming threads the request AbortSignal into the data context', async () => {
+      const mockRoute = createMockRouteMatch({ render: 'streaming', meta: {} });
+      vi.mocked(DataRoutes.matchRoute).mockReturnValue(mockRoute);
+      vi.mocked(Templates.ensureNonNull).mockReturnValue('<html></html>');
+      vi.mocked(Templates.processTemplate).mockReturnValue({
+        beforeHead: '<html><head>',
+        afterHead: '</head>',
+        beforeBody: '<body>',
+        afterBody: '</body></html>',
+      });
+
+      // Drive the initialData loader the way createSSRStore would, so fetchInitialData actually runs
+      // and we can assert the context it received. `ctx.signal = ac.signal` (streaming branch) runs
+      // BEFORE renderStream is called, so the shared ctx already carries the signal here. Regression
+      // guard: dropping that assignment must fail this.
+      const mockRenderStream = vi.fn((writable, callbacks, initialData) => {
+        writable.on = vi.fn((event: string, handler: any) => {
+          if (event === 'finish') handler();
+        });
+        void (initialData as () => Promise<unknown>)();
+        callbacks.onHead?.('<title>Stream</title>');
+        return { abort: vi.fn(), done: Promise.resolve() };
+      });
+
+      mockMaps.renderModules.set('/test/client', { renderStream: mockRenderStream });
+      vi.mocked(DataRoutes.fetchInitialData).mockResolvedValue({ ok: true });
+
+      await handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps);
+
+      expect(DataRoutes.fetchInitialData).toHaveBeenCalledWith(
+        mockRoute.route.attr,
+        expect.anything(),
+        mockServiceRegistry,
+        expect.objectContaining({ signal: expect.anything() }),
+      );
+    });
+
     it('should handle streaming without hydration', async () => {
       const mockRoute = createMockRouteMatch({ render: 'streaming', hydrate: false, meta: {} });
       vi.mocked(DataRoutes.matchRoute).mockReturnValue(mockRoute);
@@ -2526,6 +2563,12 @@ describe('handleRender', () => {
         expect.objectContaining({
           traceId: expect.any(String),
           headers: expect.objectContaining({ host: 'localhost' }),
+          // R1-01: the request AbortSignal is threaded into the data context BEFORE the fetch, so
+          // loaders can honour client disconnect / deadline. Regression guard for the SSR branch —
+          // dropping `ctx.signal = ac.signal` (HandleRender.ts) leaves `signal: undefined`, which
+          // `expect.anything()` rejects. (This suite mocks AbortController, so the signal is a mock
+          // object, not an `AbortSignal` instance — assert presence, not type.)
+          signal: expect.anything(),
           logger: expect.objectContaining({
             info: expect.any(Function),
             warn: expect.any(Function),

--- a/packages/server/src/utils/test/HandleRender.test.ts
+++ b/packages/server/src/utils/test/HandleRender.test.ts
@@ -1429,6 +1429,70 @@ describe('handleRender', () => {
       expect(mockReply.raw.write.mock.calls.some((args: any[]) => String(args[0]).includes('__INITIAL_DATA__'))).toBe(false);
     });
 
+    it('R0-04: streaming route with non-serializable (circular) final data terminates deterministically — no data script, no crash', async () => {
+      const mockRoute = createMockRouteMatch({ render: 'streaming', meta: {} });
+      vi.mocked(DataRoutes.matchRoute).mockReturnValue(mockRoute);
+      vi.mocked(Templates.ensureNonNull).mockReturnValue('<html></html>');
+      vi.mocked(Templates.processTemplate).mockReturnValue({
+        beforeHead: '<html><head>',
+        afterHead: '</head>',
+        beforeBody: '<body>',
+        afterBody: '</body></html>',
+      });
+
+      const circular: Record<string, unknown> = { name: 'x' };
+      circular.self = circular;
+
+      const mockRenderStream = vi.fn((writable, callbacks) => {
+        callbacks.onHead?.('<title>Stream</title>');
+        callbacks.onShellReady?.();
+        callbacks.onAllReady?.(circular); // finalData is non-serializable
+        writable.on = vi.fn((event: string, handler: any) => {
+          if (event === 'finish') handler();
+        });
+        return { abort: vi.fn(), done: Promise.resolve() };
+      });
+
+      mockMaps.renderModules.set('/test/client', { renderStream: mockRenderStream });
+      vi.mocked(DataRoutes.fetchInitialData).mockResolvedValue({});
+
+      // The finish listener must handle the serialization failure LOCALLY and never throw. (An
+      // uncaught throw from the real async listener would be an uncaughtException — the crash
+      // class itself is proven in InlineData.crash.test.ts; here we verify the handleRender wiring.)
+      await expect(handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps)).resolves.toBeUndefined();
+
+      expect(mockLogger.error).toHaveBeenCalledWith(expect.objectContaining({ url: mockReq.url }), 'Failed to serialize streaming initial data');
+      expect(mockReply.raw.write.mock.calls.some((args: any[]) => String(args[0]).includes('__INITIAL_DATA__'))).toBe(false);
+    });
+
+    it('R0-04: SSR route with non-serializable (circular) data → 500 via the request try/catch', async () => {
+      const mockRoute = createMockRouteMatch({ render: 'ssr' });
+      vi.mocked(DataRoutes.matchRoute).mockReturnValue(mockRoute);
+      vi.mocked(Templates.ensureNonNull).mockReturnValue('<html></html>');
+      vi.mocked(Templates.processTemplate).mockReturnValue({
+        beforeHead: '<html><head>',
+        afterHead: '</head>',
+        beforeBody: '<body>',
+        afterBody: '</body></html>',
+      });
+      vi.mocked(Templates.rebuildTemplate).mockReturnValue('<html>complete</html>');
+
+      const circular: Record<string, unknown> = { name: 'x' };
+      circular.self = circular;
+
+      mockMaps.renderModules.set('/test/client', {
+        renderSSR: vi.fn().mockResolvedValue({ headContent: '', appHtml: '<div/>' }),
+      });
+      vi.mocked(DataRoutes.fetchInitialData).mockResolvedValue(circular as any);
+
+      // On the SSR path the serialization failure throws an AppError.internal into the request
+      // try/catch → 500 machinery (the app HTML is never sent).
+      await expect(handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps)).rejects.toThrow(
+        'Failed to serialize initial data',
+      );
+      expect(mockReply.send).not.toHaveBeenCalled();
+    });
+
     it('should handle finish event when already aborted', async () => {
       const mockRoute = createMockRouteMatch({ render: 'streaming', meta: {} });
       vi.mocked(DataRoutes.matchRoute).mockReturnValue(mockRoute);

--- a/packages/server/src/utils/test/HandleRender.test.ts
+++ b/packages/server/src/utils/test/HandleRender.test.ts
@@ -1467,6 +1467,77 @@ describe('handleRender', () => {
       expect(mockReply.raw.write.mock.calls.some((args: any[]) => String(args[0]).includes('__INITIAL_DATA__'))).toBe(false);
     });
 
+    // Recheck: the fatal onError callback must never throw on a HOSTILE unknown (a component can
+    // legally throw an object whose `message` getter / `Symbol.toPrimitive` throws), otherwise the
+    // response teardown is skipped and the request hangs.
+    const hostileErrors: ReadonlyArray<readonly [string, () => unknown]> = [
+      [
+        'throwing message getter',
+        () => {
+          const o: Record<string, unknown> = {};
+          Object.defineProperty(o, 'message', {
+            get() {
+              throw new Error('getter boom');
+            },
+          });
+          return o;
+        },
+      ],
+      [
+        'throwing Symbol.toPrimitive',
+        () => ({
+          message: {
+            [Symbol.toPrimitive]() {
+              throw new Error('coercion boom');
+            },
+          },
+        }),
+      ],
+    ];
+
+    for (const [name, make] of hostileErrors) {
+      it(`recheck: onError with a hostile error (${name}) never throws and still terminates the response`, async () => {
+        setupStreamingRoute();
+
+        const mockRenderStream = vi.fn((writable, callbacks) => {
+          writable.on = vi.fn();
+          callbacks.onError?.(make()); // live request → fatal branch, with a hostile error
+          return { abort: vi.fn(), done: Promise.resolve() };
+        });
+        mockMaps.renderModules.set('/test/client', { renderStream: mockRenderStream });
+
+        // No uncaught escapes, and the response is torn down deterministically (headers not sent → 500).
+        await expect(handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps)).resolves.toBeUndefined();
+
+        expect(mockLogger.error).toHaveBeenCalledWith(expect.objectContaining({ url: mockReq.url }), 'Critical rendering error during stream');
+        expect(mockReply.raw.writeHead).toHaveBeenCalledWith(500, expect.any(Object));
+      });
+    }
+
+    it('recheck: onError with a hostile error AFTER headers are sent → socket destroy teardown, no throw', async () => {
+      setupStreamingRoute();
+
+      const hostile: Record<string, unknown> = {};
+      Object.defineProperty(hostile, 'message', {
+        get() {
+          throw new Error('getter boom');
+        },
+      });
+
+      const mockRenderStream = vi.fn((writable, callbacks) => {
+        writable.on = vi.fn();
+        callbacks.onHead?.('<title>S</title>'); // commits headers (headersSent = true)
+        callbacks.onError?.(hostile); // headers already sent → destroy(safeToReason(err)) branch
+        return { abort: vi.fn(), done: Promise.resolve() };
+      });
+      mockMaps.renderModules.set('/test/client', { renderStream: mockRenderStream });
+
+      await expect(handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps)).resolves.toBeUndefined();
+
+      expect(mockReply.raw.destroy).toHaveBeenCalled();
+      expect(mockReply.raw.writeHead).not.toHaveBeenCalledWith(500, expect.any(Object));
+    });
+
     it('R0-04: streaming route with non-serializable (circular) final data terminates deterministically — no data script, no crash', async () => {
       const mockRoute = createMockRouteMatch({ render: 'streaming', meta: {} });
       vi.mocked(DataRoutes.matchRoute).mockReturnValue(mockRoute);

--- a/packages/server/src/utils/test/HandleRender.test.ts
+++ b/packages/server/src/utils/test/HandleRender.test.ts
@@ -1247,7 +1247,26 @@ describe('handleRender', () => {
       expect(mockReply.raw.write).toHaveBeenCalled();
     });
 
-    it('R1-01: streaming threads the request AbortSignal into the data context', async () => {
+    it('R1-01: streaming threads the request AbortSignal into the data ctx, and a client disconnect CANCELS it', async () => {
+      // Faithful AbortController: the suite's default mock has a no-op abort(); here abort() must flip
+      // signal.aborted so we can prove the loader's signal actually cancels on disconnect (gate-review
+      // "Additional Observations": presence alone is not enough).
+      (globalThis as any).AbortController = vi.fn().mockImplementation(function () {
+        const signal: any = { aborted: false, addEventListener: vi.fn(), removeEventListener: vi.fn() };
+        return {
+          abort: vi.fn(() => {
+            signal.aborted = true;
+          }),
+          signal,
+        };
+      });
+
+      // Capture the req 'aborted' disconnect handler so we can fire it.
+      let abortHandler: (() => void) | undefined;
+      mockReq.raw.on = vi.fn((event: string, cb: any) => {
+        if (event === 'aborted') abortHandler = cb;
+      });
+
       const mockRoute = createMockRouteMatch({ render: 'streaming', meta: {} });
       vi.mocked(DataRoutes.matchRoute).mockReturnValue(mockRoute);
       vi.mocked(Templates.ensureNonNull).mockReturnValue('<html></html>');
@@ -1258,30 +1277,31 @@ describe('handleRender', () => {
         afterBody: '</body></html>',
       });
 
-      // Drive the initialData loader the way createSSRStore would, so fetchInitialData actually runs
-      // and we can assert the context it received. `ctx.signal = ac.signal` (streaming branch) runs
-      // BEFORE renderStream is called, so the shared ctx already carries the signal here. Regression
-      // guard: dropping that assignment must fail this.
+      // Capture the exact context the loader receives.
+      let loaderCtx: any;
+      vi.mocked(DataRoutes.fetchInitialData).mockImplementation(async (_attr, _params, _reg, ctx) => {
+        loaderCtx = ctx;
+        return { ok: true };
+      });
+
+      // Drive the initialData loader the way createSSRStore would (so fetchInitialData runs), but do
+      // NOT fire 'finish' — that would unregister the 'aborted' handler before we can trigger it.
       const mockRenderStream = vi.fn((writable, callbacks, initialData) => {
-        writable.on = vi.fn((event: string, handler: any) => {
-          if (event === 'finish') handler();
-        });
+        writable.on = vi.fn();
         void (initialData as () => Promise<unknown>)();
         callbacks.onHead?.('<title>Stream</title>');
         return { abort: vi.fn(), done: Promise.resolve() };
       });
-
       mockMaps.renderModules.set('/test/client', { renderStream: mockRenderStream });
-      vi.mocked(DataRoutes.fetchInitialData).mockResolvedValue({ ok: true });
 
       await handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps);
 
-      expect(DataRoutes.fetchInitialData).toHaveBeenCalledWith(
-        mockRoute.route.attr,
-        expect.anything(),
-        mockServiceRegistry,
-        expect.objectContaining({ signal: expect.anything() }),
-      );
+      // The loader received the signal (regression guard: dropping `ctx.signal = ac.signal` leaves it
+      // undefined) and it is the SAME signal the disconnect path aborts.
+      expect(loaderCtx?.signal).toBeDefined();
+      expect(loaderCtx.signal.aborted).toBe(false);
+      abortHandler?.(); // simulate the client disconnecting mid-stream
+      expect(loaderCtx.signal.aborted).toBe(true);
     });
 
     it('should handle streaming without hydration', async () => {

--- a/packages/server/src/utils/test/HandleRender.test.ts
+++ b/packages/server/src/utils/test/HandleRender.test.ts
@@ -970,7 +970,7 @@ describe('handleRender', () => {
         callbacks.onHead?.('<title>Stream</title>');
         callbacks.onShellReady?.();
         callbacks.onAllReady?.({ streamed: 'data' });
-        return { abort: vi.fn() };
+        return { abort: vi.fn(), done: Promise.resolve() };
       });
 
       const mockRenderModule = { renderStream: mockRenderStream };
@@ -1046,7 +1046,7 @@ describe('handleRender', () => {
           writable.emit('finish');
         }, 0);
 
-        return { abort: vi.fn() };
+        return { abort: vi.fn(), done: Promise.resolve() };
       });
 
       const mockRenderModule = { renderStream: mockRenderStream };
@@ -1217,7 +1217,7 @@ describe('handleRender', () => {
         callbacks.onShellReady?.();
         callbacks.onAllReady?.({ streamed: 'data' });
 
-        return { abort: vi.fn() };
+        return { abort: vi.fn(), done: Promise.resolve() };
       });
 
       const mockRenderModule = { renderStream: mockRenderStream };
@@ -1248,7 +1248,7 @@ describe('handleRender', () => {
         writable.on = vi.fn();
         callbacks.onHead?.('<title>Stream</title>');
 
-        return { abort: vi.fn() };
+        return { abort: vi.fn(), done: Promise.resolve() };
       });
 
       const mockRenderModule = { renderStream: mockRenderStream };
@@ -1279,7 +1279,7 @@ describe('handleRender', () => {
 
       const mockRenderStream = vi.fn((writable) => {
         writable.on = vi.fn();
-        return { abort: vi.fn() };
+        return { abort: vi.fn(), done: Promise.resolve() };
       });
 
       const mockRenderModule = { renderStream: mockRenderStream };
@@ -1311,7 +1311,7 @@ describe('handleRender', () => {
 
       const mockRenderStream = vi.fn((writable) => {
         writable.on = vi.fn();
-        return { abort: vi.fn() };
+        return { abort: vi.fn(), done: Promise.resolve() };
       });
 
       const mockRenderModule = { renderStream: mockRenderStream };
@@ -1345,7 +1345,7 @@ describe('handleRender', () => {
           }
         });
 
-        return { abort: vi.fn() };
+        return { abort: vi.fn(), done: Promise.resolve() };
       });
 
       const mockRenderModule = { renderStream: mockRenderStream };
@@ -1371,7 +1371,7 @@ describe('handleRender', () => {
 
       const mockRenderStream = vi.fn((writable) => {
         writable.emit('error', new Error('Unknown error'));
-        return { abort: vi.fn() };
+        return { abort: vi.fn(), done: Promise.resolve() };
       });
 
       const mockRenderModule = { renderStream: mockRenderStream };
@@ -1398,7 +1398,7 @@ describe('handleRender', () => {
       const mockRenderStream = vi.fn((writable, callbacks) => {
         writable.on = vi.fn();
         callbacks.onError?.(new Error('EPIPE'));
-        return { abort: vi.fn() };
+        return { abort: vi.fn(), done: Promise.resolve() };
       });
 
       const mockRenderModule = { renderStream: mockRenderStream };
@@ -1426,7 +1426,7 @@ describe('handleRender', () => {
       const mockRenderStream = vi.fn((writable, callbacks) => {
         callbacks.onError?.(new Error('EPIPE'));
         writable.emit('finish');
-        return { abort: vi.fn() };
+        return { abort: vi.fn(), done: Promise.resolve() };
       });
 
       const mockRenderModule = { renderStream: mockRenderStream };
@@ -1461,7 +1461,7 @@ describe('handleRender', () => {
           }
         });
 
-        return { abort: vi.fn() };
+        return { abort: vi.fn(), done: Promise.resolve() };
       });
 
       const mockRenderModule = { renderStream: mockRenderStream };
@@ -1517,7 +1517,7 @@ describe('handleRender', () => {
           }
         });
 
-        return { abort: vi.fn() };
+        return { abort: vi.fn(), done: Promise.resolve() };
       });
 
       const mockRenderModule = { renderStream: mockRenderStream };
@@ -1551,7 +1551,7 @@ describe('handleRender', () => {
           }
         });
 
-        return { abort: vi.fn() };
+        return { abort: vi.fn(), done: Promise.resolve() };
       });
 
       const mockRenderModule = { renderStream: mockRenderStream };
@@ -1586,7 +1586,7 @@ describe('handleRender', () => {
         writable.on = vi.fn();
         callbacks.onError?.(benign);
         writable.emit?.('finish');
-        return { abort: vi.fn() };
+        return { abort: vi.fn(), done: Promise.resolve() };
       });
 
       mockMaps.renderModules.set('/test/client', { renderStream: mockRenderStream });
@@ -1629,7 +1629,7 @@ describe('handleRender', () => {
         writable.on = vi.fn();
         callbacks.onError?.(new Error('boom'));
         writable.emit?.('finish');
-        return { abort: vi.fn() };
+        return { abort: vi.fn(), done: Promise.resolve() };
       });
 
       mockMaps.renderModules.set('/test/client', { renderStream: mockRenderStream });
@@ -1672,7 +1672,7 @@ describe('handleRender', () => {
         writable.on = vi.fn();
         callbacks.onError?.(new Error('boom'));
         writable.emit?.('finish');
-        return { abort: vi.fn() };
+        return { abort: vi.fn(), done: Promise.resolve() };
       });
 
       mockMaps.renderModules.set('/test/client', { renderStream: mockRenderStream });
@@ -1705,7 +1705,7 @@ describe('handleRender', () => {
       const mockRenderStream = vi.fn((writable, callbacks) => {
         writable.on = vi.fn();
         callbacks.onError?.(new Error('boom'));
-        return { abort: vi.fn() };
+        return { abort: vi.fn(), done: Promise.resolve() };
       });
 
       mockMaps.renderModules.set('/test/client', { renderStream: mockRenderStream });
@@ -1735,7 +1735,7 @@ describe('handleRender', () => {
       const mockRenderStream = vi.fn((writable, callbacks) => {
         writable.on = vi.fn();
         capturedCallbacks = callbacks;
-        return { abort: vi.fn() };
+        return { abort: vi.fn(), done: Promise.resolve() };
       });
 
       mockMaps.renderModules.set('/test/client', { renderStream: mockRenderStream });
@@ -1769,7 +1769,7 @@ describe('handleRender', () => {
         });
         callbacks.onHead?.('<title>Stream</title>');
         callbacks.onAllReady?.({ hello: 'world' });
-        return { abort: vi.fn() };
+        return { abort: vi.fn(), done: Promise.resolve() };
       });
 
       mockMaps.renderModules.set('/test/client', { renderStream: mockRenderStream });
@@ -1800,7 +1800,7 @@ describe('handleRender', () => {
         });
         callbacks.onHead?.('<title>Stream</title>');
         callbacks.onAllReady?.({ ok: true });
-        return { abort: vi.fn() };
+        return { abort: vi.fn(), done: Promise.resolve() };
       });
 
       mockMaps.renderModules.set('/test/client', { renderStream: mockRenderStream });
@@ -1834,7 +1834,7 @@ describe('handleRender', () => {
         renderStream: vi.fn((writable: any, callbacks: any) => {
           callbacks.onHead?.('<title>X</title>');
           writable.emit('finish');
-          return {};
+          return { abort: vi.fn(), done: Promise.resolve() };
         }),
       });
 
@@ -1872,7 +1872,7 @@ describe('handleRender', () => {
         renderStream: vi.fn((writable: any, callbacks: any) => {
           callbacks.onHead?.('<title>X</title>');
           writable.emit('finish');
-          return {};
+          return { abort: vi.fn(), done: Promise.resolve() };
         }),
       });
 
@@ -1914,7 +1914,7 @@ describe('handleRender', () => {
         closeHandler?.(); // sets abortedState.aborted=true in your implementation
         callbacks.onAllReady?.({ shouldNotBeUsed: true });
         writable.emit('finish');
-        return {};
+        return { abort: vi.fn(), done: Promise.resolve() };
       });
 
       mockMaps.renderModules.set('/test/client', { renderStream: mockRenderStream });
@@ -1945,7 +1945,7 @@ describe('handleRender', () => {
         renderStream: vi.fn((writable: any, callbacks: any) => {
           callbacks.onHead?.('<title>X</title>');
           writable.emit('finish');
-          return {};
+          return { abort: vi.fn(), done: Promise.resolve() };
         }),
       });
 
@@ -2220,7 +2220,7 @@ describe('handleRender', () => {
       const mockRenderStream = vi.fn((writable, callbacks) => {
         callbacks.onHead?.('<title>Dev Streaming</title>');
         writable.emit('finish');
-        return {};
+        return { abort: vi.fn(), done: Promise.resolve() };
       });
 
       mockViteDevServer.ssrLoadModule.mockResolvedValue({
@@ -2479,7 +2479,7 @@ describe('handleRender', () => {
           if (!writable.on) writable.on = vi.fn();
           callbacks.onError?.(errValue);
           writable.emit?.('finish');
-          return { abort: vi.fn() };
+          return { abort: vi.fn(), done: Promise.resolve() };
         });
 
         mockMaps.renderModules.set('/test/client', { renderStream: mockRenderStream });
@@ -2590,7 +2590,7 @@ describe('handleRender', () => {
 
       const mockRenderStream = vi.fn((writable) => {
         setTimeout(() => writable.emit('finish'), 0);
-        return { abort: vi.fn() };
+        return { abort: vi.fn(), done: Promise.resolve() };
       });
 
       const mockRenderModule = { renderStream: mockRenderStream };

--- a/packages/server/src/utils/test/HandleRender.test.ts
+++ b/packages/server/src/utils/test/HandleRender.test.ts
@@ -249,6 +249,8 @@ describe('handleRender', () => {
     vi.mocked(Templates.addNonceToInlineScripts).mockImplementation(actualTemplates.addNonceToInlineScripts);
     vi.mocked(Templates.stripDevClientAndStyles).mockImplementation(actualTemplates.stripDevClientAndStyles);
     vi.mocked(Templates.applyViteTransform).mockImplementation(actualTemplates.applyViteTransform);
+    // Use the REAL attribute-escape so the SSR bootstrap-tag sink is exercised end-to-end (R2-02 SEC2).
+    vi.mocked(Templates.escapeHtmlAttribute).mockImplementation(actualTemplates.escapeHtmlAttribute);
   });
 
   afterEach(() => {
@@ -357,6 +359,33 @@ describe('handleRender', () => {
 
       const bodyContent = vi.mocked(Templates.rebuildTemplate).mock.calls[0]?.[2]!;
       expect(bodyContent).not.toContain('nonce=');
+    });
+
+    it('R2-02 SEC2: an attribute-breakout bootstrapModule is escaped in the SSR bootstrap tag (no live onerror)', async () => {
+      const mockRoute = createMockRouteMatch({ render: 'ssr' }); // hydrate defaults to true
+      vi.mocked(DataRoutes.matchRoute).mockReturnValue(mockRoute);
+      vi.mocked(Templates.ensureNonNull).mockReturnValue('<html></html>');
+      vi.mocked(Templates.processTemplate).mockReturnValue({
+        beforeHead: '<html><head>',
+        afterHead: '</head>',
+        beforeBody: '<body>',
+        afterBody: '</body></html>',
+      });
+      vi.mocked(Templates.rebuildTemplate).mockReturnValue('<html>complete</html>');
+
+      mockMaps.renderModules.set('/test/client', {
+        renderSSR: vi.fn().mockResolvedValue({ headContent: '<title>t</title>', appHtml: '<div>a</div>' }),
+      });
+      // Config-controlled bootstrap-module path with an attribute-breakout payload.
+      mockMaps.bootstrapModules.set('/test/client', '/x.js" onerror="alert(1)');
+      vi.mocked(DataRoutes.fetchInitialData).mockResolvedValue({});
+
+      await handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps);
+
+      // bootstrapScriptTag is the tail of rebuildTemplate's bodyContent (3rd) arg.
+      const bodyContent = vi.mocked(Templates.rebuildTemplate).mock.calls[0]?.[2]!;
+      expect(bodyContent).toContain('src="/x.js&quot; onerror=&quot;alert(1)"'); // encoded once
+      expect(bodyContent).not.toContain('onerror="alert(1)"'); // no live attribute
     });
 
     it('should handle null nonce', async () => {

--- a/packages/server/src/utils/test/HandleRender.test.ts
+++ b/packages/server/src/utils/test/HandleRender.test.ts
@@ -1400,7 +1400,10 @@ describe('handleRender', () => {
       expect(mockLogger.error).toHaveBeenCalledWith(expect.any(Object), 'PassThrough error:');
     });
 
-    it('should handle onError with client disconnect', async () => {
+    // Gate finding 1: `onError` is the renderer's FATAL channel — the server must NOT reclassify
+    // it as a benign disconnect by the shape of an app-controlled error. The only benign condition
+    // is ACTUAL request-abort state.
+    const setupStreamingRoute = () => {
       const mockRoute = createMockRouteMatch({ render: 'streaming', meta: {} });
       vi.mocked(DataRoutes.matchRoute).mockReturnValue(mockRoute);
       vi.mocked(Templates.ensureNonNull).mockReturnValue('<html></html>');
@@ -1410,22 +1413,57 @@ describe('handleRender', () => {
         beforeBody: '<body>',
         afterBody: '</body></html>',
       });
+      vi.mocked(DataRoutes.fetchInitialData).mockResolvedValue({});
+    };
+
+    const disconnectShapedErrors: ReadonlyArray<readonly [string, unknown]> = [
+      ['code EPIPE', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' })],
+      ['name AbortError', Object.assign(new Error('aborted by app'), { name: 'AbortError' })],
+      ['exact "aborted" message', new Error('aborted')],
+    ];
+
+    for (const [name, err] of disconnectShapedErrors) {
+      it(`gate finding 1: onError(${name}) while the request is LIVE enters the failure path, not benign`, async () => {
+        setupStreamingRoute();
+
+        const mockRenderStream = vi.fn((writable, callbacks) => {
+          writable.on = vi.fn();
+          callbacks.onError?.(err); // request still live: abortedState is false
+          return { abort: vi.fn(), done: Promise.resolve() };
+        });
+        mockMaps.renderModules.set('/test/client', { renderStream: mockRenderStream });
+
+        await handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps);
+
+        expect(mockLogger.error).toHaveBeenCalledWith(expect.objectContaining({ url: mockReq.url }), 'Critical rendering error during stream');
+        expect(mockLogger.warn).not.toHaveBeenCalledWith({}, 'Client disconnected before stream finished');
+        expect(mockReply.raw.write.mock.calls.some((args: any[]) => String(args[0]).includes('__INITIAL_DATA__'))).toBe(false);
+      });
+    }
+
+    it('gate finding 1: onError after an ACTUAL client disconnect (abortedState set) is benign', async () => {
+      setupStreamingRoute();
+
+      // Capture the real disconnect channel (reply.raw 'close') so we can trigger a genuine abort.
+      let closeHandler: (() => void) | undefined;
+      mockReply.raw.on = vi.fn((event: string, cb: any) => {
+        if (event === 'close') closeHandler = cb;
+        return mockReply.raw;
+      });
+      mockReply.raw.writableEnded = false;
 
       const mockRenderStream = vi.fn((writable, callbacks) => {
         writable.on = vi.fn();
-        // real socket-origin disconnect (benign by code — R0-02)
-        callbacks.onError?.(Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }));
+        closeHandler?.(); // genuine client disconnect → abortedState.aborted = true
+        callbacks.onError?.(new Error('any subsequent render error'));
         return { abort: vi.fn(), done: Promise.resolve() };
       });
-
-      const mockRenderModule = { renderStream: mockRenderStream };
-      mockMaps.renderModules.set('/test/client', mockRenderModule);
-
-      vi.mocked(DataRoutes.fetchInitialData).mockResolvedValue({});
+      mockMaps.renderModules.set('/test/client', { renderStream: mockRenderStream });
 
       await handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps);
 
       expect(mockLogger.warn).toHaveBeenCalledWith({}, 'Client disconnected before stream finished');
+      expect(mockLogger.error).not.toHaveBeenCalledWith(expect.objectContaining({ url: mockReq.url }), 'Critical rendering error during stream');
       expect(mockReply.raw.write.mock.calls.some((args: any[]) => String(args[0]).includes('__INITIAL_DATA__'))).toBe(false);
     });
 
@@ -1443,12 +1481,16 @@ describe('handleRender', () => {
       const circular: Record<string, unknown> = { name: 'x' };
       circular.self = circular;
 
+      // Capture the 'finish' listener instead of invoking it synchronously, so we can fire it on a
+      // LATER tick — matching the real EventEmitter timing (finish fires after handleRender returns,
+      // outside the request try/catch). (The crash class itself is proven in InlineData.crash.test.ts.)
+      let finishHandler: (() => void) | undefined;
       const mockRenderStream = vi.fn((writable, callbacks) => {
         callbacks.onHead?.('<title>Stream</title>');
         callbacks.onShellReady?.();
         callbacks.onAllReady?.(circular); // finalData is non-serializable
         writable.on = vi.fn((event: string, handler: any) => {
-          if (event === 'finish') handler();
+          if (event === 'finish') finishHandler = handler;
         });
         return { abort: vi.fn(), done: Promise.resolve() };
       });
@@ -1456,10 +1498,13 @@ describe('handleRender', () => {
       mockMaps.renderModules.set('/test/client', { renderStream: mockRenderStream });
       vi.mocked(DataRoutes.fetchInitialData).mockResolvedValue({});
 
-      // The finish listener must handle the serialization failure LOCALLY and never throw. (An
-      // uncaught throw from the real async listener would be an uncaughtException — the crash
-      // class itself is proven in InlineData.crash.test.ts; here we verify the handleRender wiring.)
-      await expect(handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps)).resolves.toBeUndefined();
+      await handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps);
+      expect(finishHandler).toBeTypeOf('function');
+
+      // Fire 'finish' on a later tick (post-return): the listener must handle the serialization
+      // failure LOCALLY and NEVER throw — an uncaught throw here would be an uncaughtException.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(() => finishHandler!()).not.toThrow();
 
       expect(mockLogger.error).toHaveBeenCalledWith(expect.objectContaining({ url: mockReq.url }), 'Failed to serialize streaming initial data');
       expect(mockReply.raw.write.mock.calls.some((args: any[]) => String(args[0]).includes('__INITIAL_DATA__'))).toBe(false);
@@ -1657,15 +1702,22 @@ describe('handleRender', () => {
       });
       vi.mocked(DataRoutes.fetchInitialData).mockResolvedValue({});
 
+      // The benign onError path is now reached only via ACTUAL request-abort state (gate finding 1),
+      // so trigger a genuine disconnect through the reply.raw 'close' channel first.
+      let closeHandler: (() => void) | undefined;
+      mockReply.raw.on = vi.fn((event: string, cb: any) => {
+        if (event === 'close') closeHandler = cb;
+        return mockReply.raw;
+      });
+      mockReply.raw.writableEnded = false;
       mockReply.raw.destroy = vi.fn(() => {
         throw new Error('destroy fail (benign)');
       });
 
-      const benign = Object.assign(new Error('aborted'), { code: 'ECONNRESET' });
-
       const mockRenderStream = vi.fn((writable, callbacks) => {
         writable.on = vi.fn();
-        callbacks.onError?.(benign);
+        closeHandler?.(); // genuine client disconnect → abortedState.aborted = true
+        callbacks.onError?.(new Error('subsequent render error'));
         writable.emit?.('finish');
         return { abort: vi.fn(), done: Promise.resolve() };
       });

--- a/packages/server/src/utils/test/HandleRender.test.ts
+++ b/packages/server/src/utils/test/HandleRender.test.ts
@@ -679,7 +679,7 @@ describe('handleRender', () => {
       expect(mockRenderModule.renderSSR).not.toHaveBeenCalled();
     });
 
-    it('warns and returns on benign SSR render error', async () => {
+    it('R0-02: SSR render error with a disconnect-shaped message but signal NOT aborted → 500, not a silent hang', async () => {
       const mockRoute = { route: { attr: { render: 'ssr' }, appId: 'test-app' }, params: {}, keys: [] } as any;
       vi.mocked(DataRoutes.matchRoute).mockReturnValue(mockRoute);
       vi.mocked(Templates.ensureNonNull).mockReturnValue('<html></html>');
@@ -690,16 +690,19 @@ describe('handleRender', () => {
         afterBody: '</body></html>',
       });
 
-      const renderSSR = vi.fn().mockRejectedValue(new Error('socket hang up')); // <- benign by regex
+      // render-origin error whose message merely LOOKS like a disconnect — must not be swallowed
+      // (previously returned benign+silent, hanging the request).
+      const renderSSR = vi.fn().mockRejectedValue(new Error('Payment aborted unexpectedly'));
       mockMaps.renderModules.set('/test/client', { renderSSR });
 
       vi.mocked(DataRoutes.fetchInitialData).mockResolvedValue({});
 
-      await handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps);
+      await expect(handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps)).rejects.toThrow(
+        'handleRender failed',
+      );
 
-      expect(mockLogger.warn).toHaveBeenCalledWith(expect.objectContaining({ url: mockReq.url, reason: 'socket hang up' }), 'SSR aborted mid-render (benign)');
-      expect(mockLogger.error).not.toHaveBeenCalledWith(expect.any(Object), 'SSR render failed');
-      expect(mockReply.send).not.toHaveBeenCalled();
+      expect(mockLogger.error).toHaveBeenCalledWith(expect.objectContaining({ url: mockReq.url }), 'SSR render failed');
+      expect(mockLogger.warn).not.toHaveBeenCalledWith(expect.any(Object), 'SSR aborted mid-render (client disconnected)');
     });
 
     it('logs error and rethrows on non-benign SSR render error', async () => {
@@ -756,14 +759,14 @@ describe('handleRender', () => {
       });
       vi.mocked(DataRoutes.fetchInitialData).mockResolvedValue({});
 
-      // throw benign error from send
+      // throw a real socket-origin error from send (benign by code — R0-02)
       mockReply.send = vi.fn(() => {
-        throw new Error('EPIPE');
+        throw Object.assign(new Error('write EPIPE'), { code: 'EPIPE' });
       });
 
       await expect(handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps)).resolves.toBeUndefined();
 
-      expect(mockLogger.warn).toHaveBeenCalledWith(expect.objectContaining({ url: mockReq.url, reason: 'EPIPE' }), 'SSR send aborted (benign)');
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.objectContaining({ url: mockReq.url, reason: 'write EPIPE' }), 'SSR send aborted (benign)');
       expect(mockLogger.error).not.toHaveBeenCalledWith(expect.any(Object), 'SSR send failed');
     });
 
@@ -798,8 +801,14 @@ describe('handleRender', () => {
       expect(mockLogger.warn).not.toHaveBeenCalledWith(expect.any(Object), 'SSR send aborted (benign)');
     });
 
-    it('SSR render catch: benign via string err (uses ?? err)', async () => {
+    it('R0-02: SSR render throws after the client disconnected (signal aborted) → benign, silent (?? err coverage)', async () => {
       vi.spyOn(System, 'isDevelopment', 'get').mockReturnValue(true);
+
+      // Client disconnects DURING render: signal is false at the pre-render check, true at the catch.
+      const signal = { aborted: false };
+      (globalThis as any).AbortController = vi.fn().mockImplementation(function () {
+        return { abort: vi.fn(), signal };
+      });
 
       const mockRoute = { route: { attr: { render: 'ssr' }, appId: 'test-app' }, params: {}, keys: [] } as any;
       vi.mocked(DataRoutes.matchRoute).mockReturnValue(mockRoute);
@@ -812,7 +821,10 @@ describe('handleRender', () => {
         afterBody: '</body></html>',
       });
 
-      const renderSSR = vi.fn().mockRejectedValue('aborted'); // no .message -> hits "?? err"
+      const renderSSR = vi.fn().mockImplementation(async () => {
+        signal.aborted = true; // client vanished mid-render
+        throw 'aborted'; // string, no .message -> exercises the "?? err" reason extraction
+      });
       const viteDevServer = {
         ssrLoadModule: vi.fn().mockResolvedValue({ renderSSR }),
         transformIndexHtml: vi.fn().mockResolvedValue('<html><head></head><body></body></html>'),
@@ -825,7 +837,10 @@ describe('handleRender', () => {
         viteDevServer,
       });
 
-      expect(mockLogger.warn).toHaveBeenCalledWith(expect.objectContaining({ url: mockReq.url, reason: 'aborted' }), 'SSR aborted mid-render (benign)');
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ url: mockReq.url, reason: 'aborted' }),
+        'SSR aborted mid-render (client disconnected)',
+      );
     });
 
     it('SSR render catch: non-benign via undefined err (uses ?? "")', async () => {
@@ -858,7 +873,7 @@ describe('handleRender', () => {
       expect(mockLogger.error).toHaveBeenCalledWith(expect.objectContaining({ url: mockReq.url, error: expect.any(Object) }), 'SSR render failed');
     });
 
-    it('SSR send catch: benign via string err (uses ?? err)', async () => {
+    it('R0-02: SSR send catch: a thrown string has no socket shape → NOT benign → send-failed logged (?? err coverage)', async () => {
       const mockRoute = { route: { attr: { render: 'ssr' }, appId: 'test-app' }, params: {}, keys: [] } as any;
       vi.mocked(DataRoutes.matchRoute).mockReturnValue(mockRoute);
 
@@ -876,12 +891,13 @@ describe('handleRender', () => {
       vi.mocked(DataRoutes.fetchInitialData).mockResolvedValue({});
 
       mockReply.send = vi.fn(() => {
-        throw 'premature'; // plain string -> uses ?? err
+        throw 'premature'; // plain string -> no .code/.message, so NOT benign (R0-02); '?? err' extracts the message
       }) as any;
 
       await handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps);
 
-      expect(mockLogger.warn).toHaveBeenCalledWith(expect.objectContaining({ url: mockReq.url, reason: 'premature' }), 'SSR send aborted (benign)');
+      expect(mockLogger.error).toHaveBeenCalledWith(expect.objectContaining({ url: mockReq.url }), 'SSR send failed');
+      expect(mockLogger.warn).not.toHaveBeenCalledWith(expect.any(Object), 'SSR send aborted (benign)');
     });
 
     it('SSR send catch: non-benign via undefined err (uses ?? "")', async () => {
@@ -1397,7 +1413,8 @@ describe('handleRender', () => {
 
       const mockRenderStream = vi.fn((writable, callbacks) => {
         writable.on = vi.fn();
-        callbacks.onError?.(new Error('EPIPE'));
+        // real socket-origin disconnect (benign by code — R0-02)
+        callbacks.onError?.(Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }));
         return { abort: vi.fn(), done: Promise.resolve() };
       });
 

--- a/packages/server/src/utils/test/HandleRenderRecorder.test.ts
+++ b/packages/server/src/utils/test/HandleRenderRecorder.test.ts
@@ -149,6 +149,7 @@ describe('handleRender recorder events (P0B-02 hook sites)', () => {
           cb.onAllReady(data);
           writable.end();
         });
+        return { abort: vi.fn(), done: Promise.resolve() };
       }),
     };
 
@@ -220,6 +221,7 @@ describe('dev stamp injection (P0B-04, spec 03 §7)', () => {
           cb.onAllReady(data);
           writable.end();
         });
+        return { abort: vi.fn(), done: Promise.resolve() };
       }),
     };
     const req = mkReq('/live', undefined, devServer);

--- a/packages/server/src/utils/test/InlineData.crash.test.ts
+++ b/packages/server/src/utils/test/InlineData.crash.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment node
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import ts from 'typescript';
+import { describe, it, expect } from 'vitest';
+
+// R0-04 — the second process-crash class (after R0-01's unobserved `done` rejection).
+//
+// The streaming `finish` listener in HandleRender runs on a stream tick, OUTSIDE the request
+// try/catch (see the `processTicksAndRejections` frame in the failure below), so an uncaught
+// throw there becomes an `uncaughtException` → process exit. This test proves BOTH halves:
+//   (a) an UNGUARDED `JSON.stringify(circular)` in an async 'finish' listener genuinely crashes
+//       the process under Node's DEFAULT flags, and
+//   (b) the real `serializeInlineData` boundary never throws, so the identical listener survives.
+//
+// METHODOLOGY (maintainer decision, 2026-07-11): unlike R0-01 — which transpiled the
+// self-contained `Streaming.ts` and drove it directly — the real crash lives inside
+// `handleRender`, which is NOT exported and has many extensionless relative imports Node's
+// native-TS runner cannot resolve, so it cannot be executed in a child. We therefore prove the
+// crash CLASS generically here (transpiling the self-contained `InlineData.ts` and using the REAL
+// `serializeInlineData` as the fix primitive), and verify the actual `handleRender` finish-listener
+// wiring with an in-process integration test (`HandleRender.test.ts`: streaming route, circular
+// data, real async finish → deterministic termination, no data script, no crash). The same split
+// applies to any future crash-class test for a multi-import server module.
+
+function buildChild(bodyExpr: string): string {
+  const inlineDataTs = fileURLToPath(new URL('../InlineData.ts', import.meta.url));
+  const transpiled = ts.transpileModule(readFileSync(inlineDataTs, 'utf8'), {
+    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 },
+  }).outputText;
+
+  return [
+    `import { PassThrough } from 'node:stream';`,
+    transpiled,
+    `const circular = {}; circular.self = circular;`,
+    `const w = new PassThrough();`,
+    // 'finish' fires ASYNCHRONOUSLY (real stream tick), outside any try/catch — the R0-04 shape.
+    `w.on('finish', () => { ${bodyExpr} });`,
+    `w.end();`,
+    `setTimeout(() => { console.log('SURVIVED'); process.exit(0); }, 150);`,
+  ].join('\n');
+}
+
+function runChild(script: string): { status: number; stdout: string } {
+  let status = 0;
+  let stdout = '';
+  try {
+    stdout = execFileSync(process.execPath, ['--input-type=module', '-e', script], { encoding: 'utf8' });
+  } catch (err) {
+    status = (err as { status?: number | null }).status ?? 1;
+    stdout = String((err as { stdout?: unknown }).stdout ?? '');
+  }
+  return { status, stdout };
+}
+
+describe('R0-04 crash class — serialization in an async finish listener', () => {
+  it('an UNGUARDED JSON.stringify(circular) crashes the process (proves the class)', () => {
+    const { status, stdout } = runChild(buildChild('JSON.stringify(circular);'));
+
+    expect(status).not.toBe(0);
+    expect(stdout).not.toContain('SURVIVED');
+  });
+
+  it('the real serializeInlineData boundary never throws — the identical listener survives', () => {
+    const { status, stdout } = runChild(buildChild('serializeInlineData(circular);'));
+
+    expect(status).toBe(0);
+    expect(stdout).toContain('SURVIVED');
+  });
+});

--- a/packages/server/src/utils/test/InlineData.test.ts
+++ b/packages/server/src/utils/test/InlineData.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+
+import { serializeInlineData } from '../InlineData';
+
+// The pre-R0-04 inline expression, kept as the byte-identity oracle: valid inputs MUST serialize
+// identically to before so cached pages and existing tests never observe a diff.
+const legacy = (v: unknown) => JSON.stringify(v).replace(/</g, '\\u003c');
+
+describe('serializeInlineData (R0-04)', () => {
+  describe('valid inputs — byte-identical to the legacy inline expression', () => {
+    const cases: ReadonlyArray<readonly [string, unknown]> = [
+      ['empty object', {}],
+      ['nested', { a: 1, b: { c: [1, 2, 3], d: 'x' } }],
+      ['null', null],
+      ['array', [1, 'two', { three: 3 }]],
+      ['string with quotes', { s: 'he said "hi"' }],
+      ['unicode text', { s: 'café — naïve' }],
+    ];
+
+    for (const [name, v] of cases) {
+      it(name, () => {
+        const r = serializeInlineData(v);
+        expect(r.ok).toBe(true);
+        if (r.ok) expect(r.js).toBe(legacy(v));
+      });
+    }
+  });
+
+  it('escapes `<` so `</script>` and `<!--` cannot break out (byte-identical to legacy)', () => {
+    const payload = { html: '</script><!-- <div>' };
+    const r = serializeInlineData(payload);
+
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.js).not.toContain('<'); // every '<' escaped
+      expect(r.js).toContain('\\u003c');
+      expect(r.js).toBe(legacy(payload));
+      // reverses cleanly on the client (< is a valid JSON unicode escape for '<')
+      expect(JSON.parse(r.js)).toEqual(payload);
+    }
+  });
+
+  it('passes U+2028 / U+2029 through unescaped (legal in ES2019+ string literals)', () => {
+    const payload = { s: 'a b c' };
+    const r = serializeInlineData(payload);
+
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.js).toContain(' ');
+      expect(r.js).toContain(' ');
+      expect(r.js).toBe(legacy(payload));
+    }
+  });
+
+  it('preserves a "__proto__" key as an ordinary JSON key (SEC4 — no prototype pollution on re-parse)', () => {
+    const payload = { ['__proto__']: { polluted: true }, ok: 1 };
+    const r = serializeInlineData(payload);
+
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.js).toContain('__proto__');
+      const parsed = JSON.parse(r.js);
+      // re-parses as an OWN property, not a prototype mutation
+      expect(Object.prototype.hasOwnProperty.call(parsed, '__proto__')).toBe(true);
+      expect(({} as { polluted?: unknown }).polluted).toBeUndefined();
+    }
+  });
+
+  describe('non-serializable inputs — fail deterministically and NEVER throw', () => {
+    it('circular reference', () => {
+      const a: Record<string, unknown> = { name: 'a' };
+      a.self = a;
+      const r = serializeInlineData(a);
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error).toBeInstanceOf(Error);
+    });
+
+    it('BigInt', () => {
+      expect(serializeInlineData({ big: 1n }).ok).toBe(false);
+    });
+
+    it('throwing toJSON', () => {
+      const r = serializeInlineData({
+        bad: {
+          toJSON() {
+            throw new Error('toJSON boom');
+          },
+        },
+      });
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error.message).toContain('toJSON boom');
+    });
+
+    it('undefined (JSON.stringify returns undefined)', () => {
+      expect(serializeInlineData(undefined).ok).toBe(false);
+    });
+
+    it('a bare function', () => {
+      expect(serializeInlineData(() => {}).ok).toBe(false);
+    });
+
+    it('a toJSON that throws a hostile non-Error (throwing string coercion) still does not throw', () => {
+      const hostile = {
+        toJSON() {
+          throw {
+            [Symbol.toPrimitive]() {
+              throw new Error('coercion boom');
+            },
+            toString() {
+              throw new Error('coercion boom');
+            },
+          };
+        },
+      };
+
+      let result: ReturnType<typeof serializeInlineData> | undefined;
+      expect(() => {
+        result = serializeInlineData(hostile);
+      }).not.toThrow();
+      expect(result?.ok).toBe(false);
+    });
+
+    it('never throws for any non-serializable input', () => {
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+      const inputs: unknown[] = [circular, { big: 1n }, undefined, () => {}, Symbol('s')];
+      for (const i of inputs) expect(() => serializeInlineData(i)).not.toThrow();
+    });
+  });
+});

--- a/packages/server/src/utils/test/InlineData.test.ts
+++ b/packages/server/src/utils/test/InlineData.test.ts
@@ -52,18 +52,41 @@ describe('serializeInlineData (R0-04)', () => {
     }
   });
 
-  it('preserves a "__proto__" key as an ordinary JSON key (SEC4 — no prototype pollution on re-parse)', () => {
+  it('a "__proto__" key sets the emitted object literal\'s prototype (SEC4 — no GLOBAL pollution; documented fidelity drift)', () => {
     const payload = { ['__proto__']: { polluted: true }, ok: 1 };
     const r = serializeInlineData(payload);
 
     expect(r.ok).toBe(true);
     if (r.ok) {
       expect(r.js).toContain('__proto__');
-      const parsed = JSON.parse(r.js);
-      // re-parses as an OWN property, not a prototype mutation
-      expect(Object.prototype.hasOwnProperty.call(parsed, '__proto__')).toBe(true);
+      // The page emits `window.__INITIAL_DATA__ = <js>` as a JS OBJECT LITERAL — evaluate THAT
+      // form, not JSON.parse. A quoted "__proto__": key sets the prototype (Annex B.3.1).
+      const evaluated = new Function(`return (${r.js});`)() as Record<string, unknown>;
+
+      expect(Object.prototype.hasOwnProperty.call(evaluated, '__proto__')).toBe(false); // NOT an own property
+      expect((evaluated as { polluted?: unknown }).polluted).toBe(true); // reachable via the prototype
+      expect(Object.getPrototypeOf(evaluated)).toMatchObject({ polluted: true });
+      // the GLOBAL prototype is never polluted
       expect(({} as { polluted?: unknown }).polluted).toBeUndefined();
     }
+  });
+
+  it('nested undefined/function/symbol follow standard JSON semantics (omitted / null), not rejection (crash-safety, not contract enforcement)', () => {
+    const obj = serializeInlineData({ a: 1, skip: undefined, fn() {}, sym: Symbol('s') });
+    expect(obj.ok).toBe(true);
+    if (obj.ok) expect(obj.js).toBe('{"a":1}'); // nested undefined/function/symbol omitted
+
+    const arr = serializeInlineData([1, undefined, () => {}, Symbol('s')]);
+    expect(arr.ok).toBe(true);
+    if (arr.ok) expect(arr.js).toBe('[1,null,null,null]'); // nulled in arrays
+  });
+
+  it('nested BigInt / circular still fail deterministically (JSON.stringify throws anywhere in the tree)', () => {
+    expect(serializeInlineData({ nested: { deep: 1n } }).ok).toBe(false);
+
+    const circular: Record<string, unknown> = {};
+    circular.child = { back: circular };
+    expect(serializeInlineData(circular).ok).toBe(false);
   });
 
   describe('non-serializable inputs — fail deterministically and NEVER throw', () => {

--- a/packages/server/src/utils/test/Templates.test.ts
+++ b/packages/server/src/utils/test/Templates.test.ts
@@ -13,6 +13,8 @@ import {
   rebuildTemplate,
   addNonceToInlineScripts,
   injectCssLink,
+  injectBootstrapModule,
+  escapeHtmlAttribute,
   extractHeadInner,
 } from '../Templates';
 import { SSRTAG } from '../../constants';
@@ -448,5 +450,43 @@ describe('injectCssLink', () => {
     const tpl = '<html><head></head><body></body></html>';
     const cssLink = '<link rel="stylesheet" href="/app.css">';
     expect(injectCssLink(tpl, cssLink)).toBe('<html><head><link rel="stylesheet" href="/app.css"></head><body></body></html>');
+  });
+});
+
+describe('escapeHtmlAttribute (SEC2, R2-02)', () => {
+  it('escapes the five HTML-sensitive characters (attribute-safe, both quote styles)', () => {
+    expect(escapeHtmlAttribute('&')).toBe('&amp;');
+    expect(escapeHtmlAttribute('<')).toBe('&lt;');
+    expect(escapeHtmlAttribute('>')).toBe('&gt;');
+    expect(escapeHtmlAttribute('"')).toBe('&quot;');
+    expect(escapeHtmlAttribute("'")).toBe('&#39;');
+  });
+
+  it('escapes & first and coerces non-strings', () => {
+    expect(escapeHtmlAttribute('a&b')).toBe('a&amp;b');
+    expect(escapeHtmlAttribute(42 as unknown as string)).toBe('42');
+  });
+
+  it('leaves a clean module URL unchanged', () => {
+    expect(escapeHtmlAttribute('/assets/entry-client.js')).toBe('/assets/entry-client.js');
+  });
+});
+
+describe('injectBootstrapModule attribute escaping (SEC2, R2-02)', () => {
+  it('leaves a clean module URL unchanged (no behaviour change for normal config)', () => {
+    const tpl = '<html><body></body></html>';
+    expect(injectBootstrapModule(tpl, '/assets/entry.js')).toBe('<html><body><script type="module" src="/assets/entry.js" defer></script></body></html>');
+  });
+
+  it('escapes an attribute-breakout module value (defence-in-depth)', () => {
+    const tpl = '<html><body></body></html>';
+    const out = injectBootstrapModule(tpl, '/x.js" onerror="alert(1)');
+    expect(out).toContain('src="/x.js&quot; onerror=&quot;alert(1)"');
+    expect(out).not.toContain('onerror="alert(1)"');
+  });
+
+  it('returns the template unchanged when no bootstrapModule is given', () => {
+    const tpl = '<html><body></body></html>';
+    expect(injectBootstrapModule(tpl, undefined)).toBe(tpl);
   });
 });

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -61,23 +61,24 @@
     "vue": "^3.5.25"
   },
   "peerDependencies": {
-    "@vitejs/plugin-vue": "^6.0.0",
+    "@vitejs/plugin-vue": "^5.0.0 || ^6.0.0",
+    "@types/node": ">=20",
     "@vue/server-renderer": "^3.5.0",
-    "typescript": "^5.7.2",
-    "vite": "^7.1.9",
+    "typescript": "^5.5.0",
+    "vite": "^7.0.0",
     "vue": "^3.5.0"
   },
   "peerDependenciesMeta": {
     "@vitejs/plugin-vue": {
       "optional": true
     },
+    "@types/node": {
+      "optional": true
+    },
     "typescript": {
       "optional": true
     },
     "vite": {
-      "optional": true
-    },
-    "vue": {
       "optional": true
     }
   },
@@ -90,5 +91,6 @@
     "format": "prettier --write .",
     "check-format": "prettier --check .",
     "check-exports": "attw --pack . --profile esm-only"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/vue/src/SSRDataStore.ts
+++ b/packages/vue/src/SSRDataStore.ts
@@ -83,16 +83,40 @@ export function createSSRStore<T>(initialDataOrPromise: T | Promise<T> | (() => 
     readyReject(err);
   };
 
+  // R3-08 (S2, twin of the react fix): an explicit `setData` SUPERSEDES the in-flight initial
+  // promise. Without this, a late loader REJECTION flipped `status` to 'error' (contradicting the
+  // explicitly-set data in every reactive consumer) and a late RESOLUTION silently overwrote it.
+  // Guards only the ASYNC continuations — the synchronous raw-data branch below cannot race a
+  // `setData`. A superseded rejection also skips `readyReject` (a no-op after `setData`'s
+  // `readyResolve`, skipped for clarity) and the misleading "Failed to load initial data" log.
+  let superseded = false;
+
+  const loaderResolved = (value: T) => {
+    if (superseded) return;
+    settleSuccess(value);
+  };
+
+  const loaderRejected = (err: unknown) => {
+    if (superseded) return;
+    settleError(err);
+  };
+
   // Initialise
   if (typeof initialDataOrPromise === 'function') {
-    (initialDataOrPromise as () => Promise<T>)().then(settleSuccess).catch(settleError);
+    (initialDataOrPromise as () => Promise<T>)().then(loaderResolved).catch(loaderRejected);
   } else if (initialDataOrPromise instanceof Promise) {
-    initialDataOrPromise.then(settleSuccess).catch(settleError);
+    initialDataOrPromise.then(loaderResolved).catch(loaderRejected);
   } else {
     settleSuccess(initialDataOrPromise);
   }
 
+  /**
+   * Explicitly set the store value. Supersedes the in-flight initial promise: a later settlement
+   * of that promise (success or failure) is ignored — it can neither overwrite this value nor
+   * flip the store into an error state (R3-08).
+   */
   const setData = (newData: T) => {
+    superseded = true;
     handleSuccess(newData);
     // If initial load previously failed/pending, treat this as ready.
     readyResolve();

--- a/packages/vue/src/SSRDataStore.ts
+++ b/packages/vue/src/SSRDataStore.ts
@@ -8,7 +8,13 @@ export type SSRStore<T> = {
   status: Ref<SSRStoreStatus>;
   lastError: Ref<Error | undefined>;
 
-  /** Promise that resolves when initial data is available (or rejects on error). */
+  /**
+   * Promise that resolves when initial data is available, or REJECTS with the loader error on
+   * failure. Safe to leave unobserved: a no-op rejection handler is pre-attached at creation, so
+   * an unawaited store whose loader rejects cannot produce an `unhandledRejection`; consumers who
+   * `await` it still observe the rejection. NB once rejected it stays rejected — a later
+   * `setData` recovers the store's reactive state but does not re-settle `ready`.
+   */
   ready: Promise<void>;
 
   /** Vue-safe: returns data or undefined (never throws) */
@@ -59,6 +65,13 @@ export function createSSRStore<T>(initialDataOrPromise: T | Promise<T> | (() => 
     readyResolve = resolve;
     readyReject = reject;
   });
+
+  // R3-07 (S1): `ready` is public API and may legitimately never be observed (a store that is
+  // built but never rendered or awaited). Without a pre-attached observer, a rejecting loader
+  // becomes an `unhandledRejection` — a process-terminating crash under Node's default mode (the
+  // R0-01 class). This no-op handler observes the rejection WITHOUT consuming it for real
+  // consumers: `await store.ready` still rejects with the loader error.
+  ready.catch(() => {});
 
   const settleSuccess = (value: T) => {
     handleSuccess(value);

--- a/packages/vue/src/SSRHydration.ts
+++ b/packages/vue/src/SSRHydration.ts
@@ -188,7 +188,21 @@ export function hydrateApp<T>({
   const bootstrap = () => {
     const rootEl = document.getElementById(rootElementId);
     if (!rootEl) {
+      // R2-03 (R5): a missing root is a bootstrap failure — report it through the client error
+      // channel, mirroring react's R2-01. Emits `hydration:error` WITHOUT a preceding `start` (vue
+      // precedent: a setupApp failure emits the same way; hydration never began). This case precedes
+      // the phase/`errored` machinery, so it is reported directly rather than routed through it.
+      // `onHydrationError` is isolated (hardening-lessons §1): a throwing observer must not escape
+      // bootstrap() (which may run directly on a non-loading document).
       error(`Root element with id "${rootElementId}" not found.`);
+      const err = new Error(`Root element with id "${rootElementId}" not found.`);
+      emitDevHook('hydration:error', err);
+      try {
+        onHydrationError?.(err);
+      } catch (cbErr) {
+        error('onHydrationError callback threw (ignored):', cbErr);
+      }
+
       return;
     }
 

--- a/packages/vue/src/SSRHydration.ts
+++ b/packages/vue/src/SSRHydration.ts
@@ -50,10 +50,12 @@ export type HydrateAppOptions<T> = {
  * - Otherwise, hydrate SSR markup, emitting `hydration:start|success|error` to the
  *   dev-only `window.__TAUJS_DEVTOOLS_HOOK__` around the user callbacks.
  *
- * Unlike React (which surfaces hydration failures as synchronous throws), Vue reports them
- * through `app.config.errorHandler` and recoverable warnings — so this installs an error
+ * Both frameworks surface client render failures ASYNCHRONOUSLY, not as throws from the
+ * mount/hydrate call (React via the root's `onUncaughtError`, established and tested in R2-01;
+ * Vue via `app.config.errorHandler` plus recoverable warnings) — so this installs an error
  * handler before mount and treats errors during the hydration phase as hydration failures.
- * `onStart`/`onSuccess` receive the `App` instance (react's take no args).
+ * `onStart`/`onSuccess` receive the `App` instance (react's take no args). All user callbacks are
+ * advisory and isolated: a throw is logged, never altering settlement or preventing mount.
  */
 export function hydrateApp<T>({
   appComponent,
@@ -71,6 +73,23 @@ export function hydrateApp<T>({
     context: { scope: 'vue-hydration' },
     enableDebug,
   });
+
+  // User lifecycle callbacks are ADVISORY observers - every one is isolated here (hardening-lessons
+  // §1). This is load-bearing, not defensive: `onStart`/`onSuccess` run inside the hydration
+  // try/catch, and `onHydrationError` runs from Vue's errorHandler / a catch block. Un-isolated, an
+  // observer throw would (a) be misread as a hydration failure - a throwing `onStart` would emit
+  // `hydration:error` and PREVENT `app.mount`, (b) manufacture an error AFTER success - a throwing
+  // `onSuccess` would emit `hydration:error` for an attempt that already emitted
+  // `hydration:success`, or (c) escape `hydrateApp` entirely from inside a catch block. An observer
+  // must never alter settlement, stop the app mounting, or escape the framework boundary; a throw is
+  // logged only, and is NEVER fed back into `reportHydrationFailure`.
+  const runObserver = (label: string, run: () => void) => {
+    try {
+      run();
+    } catch (cbErr) {
+      error(`${label} callback threw (ignored):`, cbErr);
+    }
+  };
 
   const normalizeRoot = (): Component => {
     // Allow passing either a component or a render function.
@@ -98,9 +117,10 @@ export function hydrateApp<T>({
     } catch (err) {
       // R2: a throwing setupApp/mount is an application error — route to onHydrationError
       // (the only client error channel). The CSR path emits NO beacon events: a CSR mount is
-      // not a hydration, and react's CSR path emits nothing either.
+      // not a hydration, and react's CSR path emits nothing either. Isolated: this runs inside a
+      // catch block, so an un-isolated observer throw would escape hydrateApp.
       error('CSR mount error:', err);
-      onHydrationError?.(err);
+      runObserver('onHydrationError', () => onHydrationError?.(err));
     }
   };
 
@@ -126,7 +146,9 @@ export function hydrateApp<T>({
       if (!inHydrationPhase || errored) return;
       errored = true;
       emitDevHook('hydration:error', err);
-      onHydrationError?.(err);
+      // Isolated: this runs from Vue's app.config.errorHandler and from the outer catch, where an
+      // un-isolated observer throw would escape hydrateApp.
+      runObserver('onHydrationError', () => onHydrationError?.(err));
     };
 
     try {
@@ -161,9 +183,11 @@ export function hydrateApp<T>({
         };
       }
 
-      // Beacon then user callback (internal-first), onStart receiving the configured App.
+      // Beacon then user callback (internal-first), onStart receiving the configured App. Isolated:
+      // an un-isolated throw would hit the outer catch, be misreported as a hydration failure, and
+      // PREVENT app.mount below - an advisory observer must never stop the app hydrating.
       emitDevHook('hydration:start');
-      onStart?.(app);
+      runObserver('onStart', () => onStart?.(app));
 
       // createSSRApp(...).mount() hydrates by default; no non-public second argument (F11).
       app.mount(rootEl);
@@ -171,7 +195,9 @@ export function hydrateApp<T>({
       if (!errored) {
         if (enableDebug) log('Hydration completed');
         emitDevHook('hydration:success');
-        onSuccess?.(app);
+        // Isolated: an un-isolated throw would hit the outer catch and emit hydration:error +
+        // onHydrationError for an attempt that has ALREADY emitted hydration:success.
+        runObserver('onSuccess', () => onSuccess?.(app));
       }
 
       // Close the hydration phase after the current tick.
@@ -197,11 +223,7 @@ export function hydrateApp<T>({
       error(`Root element with id "${rootElementId}" not found.`);
       const err = new Error(`Root element with id "${rootElementId}" not found.`);
       emitDevHook('hydration:error', err);
-      try {
-        onHydrationError?.(err);
-      } catch (cbErr) {
-        error('onHydrationError callback threw (ignored):', cbErr);
-      }
+      runObserver('onHydrationError', () => onHydrationError?.(err));
 
       return;
     }

--- a/packages/vue/src/SSRHydration.ts
+++ b/packages/vue/src/SSRHydration.ts
@@ -1,9 +1,9 @@
 import { createApp, createSSRApp, h, nextTick, type App, type Component, type VNode } from 'vue';
 
-import { createSSRStore, SSRStoreProvider } from './SSRDataStore';
-import { createUILogger, createVueErrorHandler } from './utils/Logger';
+import { createSSRStore, SSRStoreProvider } from './SSRDataStore.js';
+import { createUILogger, createVueErrorHandler } from './utils/Logger.js';
 
-import type { LoggerLike } from './utils/Logger';
+import type { LoggerLike } from './utils/Logger.js';
 
 // Dev-only introspection hook, set by the server-injected dev script (never by users).
 // Absent in production: emission costs one property check and can never throw into

--- a/packages/vue/src/SSRRender.ts
+++ b/packages/vue/src/SSRRender.ts
@@ -220,7 +220,15 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
     // isAborted guard makes this safe to call from both errorHandler and sink.destroy.
     const fail = (err: unknown) => {
       if (controller.isAborted) return;
-      cb.onError(err);
+      // Recheck: the host `onError` callback can NEVER veto controller cleanup/settlement. A
+      // throwing `onError` is logged and SWALLOWED — it must not veto `fatalAbort` (below, always
+      // runs) NOR escape (this may run inside an errorHandler / sink teardown where a throw would
+      // be uncaught). The ORIGINAL error stays the rejection reason.
+      try {
+        cb.onError(err);
+      } catch (cbErr) {
+        warn('onError callback threw:', cbErr);
+      }
       controller.fatalAbort(err);
     };
 

--- a/packages/vue/src/SSRRender.ts
+++ b/packages/vue/src/SSRRender.ts
@@ -229,22 +229,37 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
 
     const controller = createStreamController(writable, { log, warn, error });
 
+    // Advisory observers are ISOLATED (hardening-lessons §1): a throw is logged and swallowed - it
+    // must never enter the fatal path, escape the framework boundary (these run inside Vue's
+    // errorHandler, a promise chain, or sink teardown, where a throw would be uncaught), or suppress
+    // a sibling callback.
+    const runObserver = (label: string, run: () => void) => {
+      try {
+        run();
+      } catch (cbErr) {
+        error(`${label} callback threw (ignored):`, cbErr);
+      }
+    };
+
     // Single, idempotent fatal path. Vue swallows a component error once an
     // app.config.errorHandler is installed (see @vue/server-renderer handleError), so the
     // handler must abort itself rather than relying on the render promise to reject; the
     // isAborted guard makes this safe to call from both errorHandler and sink.destroy.
     const fail = (err: unknown) => {
       if (controller.isAborted) return;
-      // Recheck: the host `onError` callback can NEVER veto controller cleanup/settlement. A
-      // throwing `onError` is logged and SWALLOWED — it must not veto `fatalAbort` (below, always
-      // runs) NOR escape (this may run inside an errorHandler / sink teardown where a throw would
-      // be uncaught). The ORIGINAL error stays the rejection reason.
+      // Ordering (hardening-lessons §2): claim the terminal fatal state BEFORE invoking re-entrant
+      // host code. The server's `onError` synchronously calls `ac.abort()`, and that SAME AbortSignal
+      // is wired below to `controller.benignAbort` - if the callback ran first, the re-entrant benign
+      // abort would win the one-shot controller and RESOLVE `done`, silently downgrading a fatal to a
+      // benign completion and breaking the published `RenderStreamHandle` contract. fatalAbort-first
+      // makes that re-entrant benignAbort a no-op. A throwing `onError` is still swallowed (and can no
+      // longer veto settlement, already claimed); the ORIGINAL error stays the rejection reason.
+      controller.fatalAbort(err);
       try {
         cb.onError(err);
       } catch (cbErr) {
         warn('onError callback threw:', cbErr);
       }
-      controller.fatalAbort(err);
     };
 
     // AbortSignal (benign cancel)
@@ -380,7 +395,16 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
       try {
         cb.onHead(head);
       } catch (cbErr) {
-        warn('onHead callback threw:', cbErr);
+        // onHead is REQUIRED, not advisory (parity with react's R1-01 contract, and the server
+        // assumes it across BOTH renderer packages): it commits the response prefix and connects the
+        // renderer's PassThrough to the HTTP response. If it throws, the response was never set up -
+        // continuing would write application bytes into an unconnected sink and can yield a malformed
+        // "successful" response with no head/prefix/body. Stop here: rethrow so the enclosing catch
+        // routes it through the single `fail` path (fatal abort + onError, `done` rejects with this
+        // error) and we never reach renderToSimpleStream.
+        error('onHead callback threw (fatal):', cbErr);
+
+        throw cbErr;
       }
 
       // Route Vue render-time errors into the fatal path (see `fail` above). R3: chain after
@@ -405,8 +429,12 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
           if (controller.isAborted) return;
           const data = s.getSnapshot();
           if (data !== undefined) {
-            cb.onAllReady(data);
-            cb.onFinish(data);
+            // Isolated INDEPENDENTLY (hardening-lessons §1): an advisory observer must not be able to
+            // turn a successfully resolved data load + completed render into a fatal stream failure
+            // (its throw would otherwise reach the `.catch` below and call `fail`), nor suppress its
+            // sibling (a throwing onAllReady previously prevented the legacy onFinish alias firing).
+            runObserver('onAllReady', () => cb.onAllReady(data));
+            runObserver('onFinish', () => cb.onFinish(data));
           }
         })
         .catch((e) => {

--- a/packages/vue/src/SSRRender.ts
+++ b/packages/vue/src/SSRRender.ts
@@ -2,6 +2,7 @@ import { createSSRApp, h, type App, type Component, type VNode } from 'vue';
 import { renderToSimpleStream, renderToString, type SimpleReadable, type SSRContext } from '@vue/server-renderer';
 
 import { createSSRStore, SSRStoreProvider, type SSRStore } from './SSRDataStore';
+import { escapeHtml } from './utils/Html';
 import { createUILogger } from './utils/Logger';
 
 import type { Writable } from 'node:stream';
@@ -294,9 +295,12 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
     const finishStream = () => {
       if (controller.isAborted) return;
       if (bootstrapModules) {
-        const nonceAttr = cspNonce ? ` nonce="${cspNonce}"` : '';
+        // R2-03 (V2/SEC2): escape the manually-written bootstrap attributes. `escapeHtml` is a no-op
+        // on clean module URLs and base64 CSP nonces (attribute-safe for both quote styles), so it is
+        // defence-in-depth with no tag-shape change on valid input.
+        const nonceAttr = cspNonce ? ` nonce="${escapeHtml(cspNonce)}"` : '';
         try {
-          writable.write(`<script type="module" src="${bootstrapModules}" async${nonceAttr}></script>`);
+          writable.write(`<script type="module" src="${escapeHtml(bootstrapModules)}" async${nonceAttr}></script>`);
         } catch {}
       }
       try {

--- a/packages/vue/src/SSRRender.ts
+++ b/packages/vue/src/SSRRender.ts
@@ -321,7 +321,10 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
       },
       destroy: (err: unknown) => {
         if (controller.isAborted) return;
-        if (isBenignStreamErr(err)) {
+        // R0-02: `destroy` is fed by the render pipeline — render-origin, never benign by shape.
+        // Real client disconnects arrive via the writable guards ('socket') and the AbortSignal,
+        // which remain benign-capable.
+        if (isBenignStreamErr(err, 'render')) {
           controller.benignAbort('Client disconnected during stream');
           return;
         }

--- a/packages/vue/src/SSRRender.ts
+++ b/packages/vue/src/SSRRender.ts
@@ -1,14 +1,14 @@
 import { createSSRApp, h, type App, type Component, type VNode } from 'vue';
 import { renderToSimpleStream, renderToString, type SimpleReadable, type SSRContext } from '@vue/server-renderer';
 
-import { createSSRStore, SSRStoreProvider, type SSRStore } from './SSRDataStore';
-import { escapeHtml } from './utils/Html';
-import { createUILogger } from './utils/Logger';
+import { createSSRStore, SSRStoreProvider, type SSRStore } from './SSRDataStore.js';
+import { escapeHtml } from './utils/Html.js';
+import { createUILogger } from './utils/Logger.js';
 
 import type { Writable } from 'node:stream';
-import type { LoggerLike } from './utils/Logger';
+import type { LoggerLike } from './utils/Logger.js';
 
-import { createStreamController, isBenignStreamErr, startShellTimer, wireWritableGuards } from './utils/Streaming';
+import { createStreamController, isBenignStreamErr, startShellTimer, wireWritableGuards } from './utils/Streaming.js';
 
 export type RenderCallbacks<T> = {
   /**

--- a/packages/vue/src/SSRRender.ts
+++ b/packages/vue/src/SSRRender.ts
@@ -33,6 +33,12 @@ export type StreamOptions = {
   shellTimeoutMs?: number;
 };
 
+/**
+ * Context passed to `headContent`: `data` is the resolved route data, `meta`/`routeContext` the
+ * route's static metadata and per-request context. NB `headContent` returns RAW `<head>` HTML — any
+ * value interpolated from `data` (or other services/user input) must be escaped with `escapeHtml`
+ * (see the `headContent` option's docs).
+ */
 export type HeadContext<T extends Record<string, unknown> = Record<string, unknown>, R = unknown> = {
   data: T;
   meta: Record<string, unknown>;
@@ -103,6 +109,14 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
    * It will be invoked/rendered with props: { location, routeContext? }
    */
   appComponent: Component | ((props: { location: string; routeContext?: R }) => VNode);
+  /**
+   * Returns the per-route `<head>` inner HTML. The return value is written into `<head>` VERBATIM as
+   * RAW HTML — it is deliberately NOT auto-escaped, so you can emit `<meta>`/`<link>`/`<script>` tags.
+   * Therefore any value interpolated from `data` (services or user input) MUST be escaped first with
+   * `escapeHtml` (exported from `@taujs/vue`), e.g.
+   * `` `<meta property="og:image" content="${escapeHtml(data.ogImage)}">` ``. See the head-management
+   * guide, "Best Practices — Escape User Content".
+   */
   headContent: (ctx: HeadContext<T, R>) => string;
   enableDebug?: boolean;
   logger?: LoggerLike;

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,8 +1,8 @@
-export * from './SSRDataStore';
-export * from './SSRHydration';
-export * from './SSRRender';
+export * from './SSRDataStore.js';
+export * from './SSRHydration.js';
+export * from './SSRRender.js';
 
-export type { SSRStore, SSRStoreStatus } from './SSRDataStore';
-export type { ServerLogs, LoggerLike } from './utils/Logger';
-export { createVueErrorHandler } from './utils/Logger';
-export { escapeHtml } from './utils/Html';
+export type { SSRStore, SSRStoreStatus } from './SSRDataStore.js';
+export type { ServerLogs, LoggerLike } from './utils/Logger.js';
+export { createVueErrorHandler } from './utils/Logger.js';
+export { escapeHtml } from './utils/Html.js';

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -5,3 +5,4 @@ export * from './SSRRender';
 export type { SSRStore, SSRStoreStatus } from './SSRDataStore';
 export type { ServerLogs, LoggerLike } from './utils/Logger';
 export { createVueErrorHandler } from './utils/Logger';
+export { escapeHtml } from './utils/Html';

--- a/packages/vue/src/test/ClientBundle.test.ts
+++ b/packages/vue/src/test/ClientBundle.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment node
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { build, type Rollup } from 'vite';
+import { describe, expect, it } from 'vitest';
+
+// R3-05 (Q6, signed 2026-07-12) — vue's half of the entry-point guard. Unlike react, vue's client
+// bundle was NEVER materially polluted: `@vue/server-renderer`'s import condition is pure ESM and
+// tree-shakes to ~0 bytes. This guard is STRUCTURAL HARDENING — it pins the absence so the react
+// defect class can never appear here if `@vue/server-renderer`'s build shape (or our module graph)
+// changes. Assertion on rollup MODULE IDS + rendered bytes — authoritative, not a string grep.
+//
+// Runs against the BUILT dist (the shipped artifact). CI builds before testing.
+const DIST_ENTRY = fileURLToPath(new URL('../../dist/index.js', import.meta.url));
+
+describe('R3-05 client bundle excludes the SSR renderer', () => {
+  it('a production browser bundle importing only hydrateApp renders no @vue/server-renderer code', { timeout: 120_000 }, async () => {
+    expect(existsSync(DIST_ENTRY), `dist missing at ${DIST_ENTRY} — run \`pnpm build\` first (CI builds before tests)`).toBe(true);
+    // Belt: the dist must be the multi-module (bundle:false) shape, or reachability is meaningless.
+    expect(readFileSync(DIST_ENTRY, 'utf8')).toMatch(/from ["']\.\/SSRHydration\.js["']/);
+
+    const dir = mkdtempSync(path.join(tmpdir(), 'taujs-vue-bundle-guard-'));
+    try {
+      const entry = path.join(dir, 'entry.js');
+      writeFileSync(entry, `import { hydrateApp } from '@taujs/vue';\nconsole.log(hydrateApp);\n`);
+
+      const result = (await build({
+        logLevel: 'silent',
+        configFile: false,
+        envFile: false,
+        root: dir,
+        resolve: { alias: { '@taujs/vue': DIST_ENTRY } },
+        build: { outDir: path.join(dir, 'out'), emptyOutDir: true, rollupOptions: { input: entry } },
+      })) as Rollup.RollupOutput | Rollup.RollupOutput[];
+
+      const outputs = Array.isArray(result) ? result : [result];
+      const chunks = outputs.flatMap((r) => r.output).filter((o): o is Rollup.OutputChunk => o.type === 'chunk');
+
+      // Sanity: the graph really was built and includes vue itself.
+      expect(chunks.flatMap((c) => Object.keys(c.modules)).some((id) => id.includes('node_modules'))).toBe(true);
+
+      const serverRendered = chunks
+        .flatMap((c) => Object.entries(c.modules))
+        .filter(([id]) => id.includes('@vue/server-renderer') || id.includes('server-renderer'))
+        .reduce((total, [, mod]) => total + ((mod as { renderedLength?: number }).renderedLength ?? 0), 0);
+
+      expect(serverRendered, `@vue/server-renderer rendered ${serverRendered} bytes into the client bundle`).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/vue/src/test/ClientBundle.test.ts
+++ b/packages/vue/src/test/ClientBundle.test.ts
@@ -27,14 +27,30 @@ describe('R3-05 client bundle excludes the SSR renderer', () => {
       const entry = path.join(dir, 'entry.js');
       writeFileSync(entry, `import { hydrateApp } from '@taujs/vue';\nconsole.log(hydrateApp);\n`);
 
+      // Gate-review fix (react twin): assert on the FULL RESOLVED GRAPH, not only the final
+      // bytes. NB warnings are not a reliable channel — vite suppresses the externalization
+      // warnings whenever NODE_ENV is pre-set (vitest sets NODE_ENV=test). `moduleParsed` fires
+      // for every loaded module, including tree-shaken ones and `__vite-browser-external` stubs.
+      const loadedModules: string[] = [];
+      const graphRecorder = {
+        name: 'taujs-guard-graph-recorder',
+        moduleParsed(info: { id: string }) {
+          loadedModules.push(info.id);
+        },
+      };
+
       const result = (await build({
         logLevel: 'silent',
         configFile: false,
         envFile: false,
         root: dir,
+        plugins: [graphRecorder],
         resolve: { alias: { '@taujs/vue': DIST_ENTRY } },
         build: { outDir: path.join(dir, 'out'), emptyOutDir: true, rollupOptions: { input: entry } },
       })) as Rollup.RollupOutput | Rollup.RollupOutput[];
+
+      const nodeOnlyLoaded = loadedModules.filter((id) => /__vite-browser-external/.test(id));
+      expect(nodeOnlyLoaded, `Node-only modules were resolved into the browser build graph:\n${nodeOnlyLoaded.join('\n')}`).toEqual([]);
 
       const outputs = Array.isArray(result) ? result : [result];
       const chunks = outputs.flatMap((r) => r.output).filter((o): o is Rollup.OutputChunk => o.type === 'chunk');

--- a/packages/vue/src/test/SSRDataStore.crash.test.ts
+++ b/packages/vue/src/test/SSRDataStore.crash.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+import { createSSRStore } from '../SSRDataStore';
+
+// R3-07 (S1) — the public `ready` promise must not be an unhandled-rejection crash class.
+//
+// `createSSRStore` is publicly exported; a user-constructed store whose loader rejects and whose
+// `ready` is never rendered/awaited previously produced an `unhandledRejection`, which Node's
+// default mode turns into a process-terminating `uncaughtException` (the R0-01 class, live in a
+// shipped public API). As with R0-01, an in-process `process.on('unhandledRejection')` listener
+// would itself change Node's default behaviour, so the crash is proven in a real CHILD process
+// under DEFAULT flags, running the REAL `SSRDataStore.ts` transpiled at test time (the R0-01
+// methodology — portable to the whole `engines.node >=20.11` range). `vue` resolves from this
+// package's node_modules because the child inherits this package as cwd.
+function buildChildScript(): string {
+  const storeTs = fileURLToPath(new URL('../SSRDataStore.ts', import.meta.url));
+  const transpiled = ts.transpileModule(readFileSync(storeTs, 'utf8'), {
+    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 },
+  }).outputText;
+
+  return [
+    transpiled,
+    // The store's own console.error diagnostic is expected noise; silence it so stdout is clean.
+    `console.error = () => {};`,
+    `createSSRStore(() => Promise.reject(new Error('R3-07 loader boom')));`,
+    // The unhandled rejection (when the fix is absent) crashes the process well before this timer.
+    `setTimeout(() => { console.log('SURVIVED'); process.exit(0); }, 150);`,
+  ].join('\n');
+}
+
+describe('R3-07 public `ready` unhandled-rejection hardening', () => {
+  it('a rejecting loader on a never-observed store does not crash the process (child process, default rejection mode)', () => {
+    let status = 0;
+    let stdout = '';
+    try {
+      stdout = execFileSync(process.execPath, ['--input-type=module', '-e', buildChildScript()], { encoding: 'utf8' });
+    } catch (err) {
+      status = (err as { status?: number | null }).status ?? 1;
+      stdout = String((err as { stdout?: unknown }).stdout ?? '');
+    }
+
+    expect(status).toBe(0);
+    expect(stdout).toContain('SURVIVED');
+  });
+
+  it('`await store.ready` still rejects with the loader error (the no-op handler does not consume the rejection)', async () => {
+    const consoleError = console.error;
+    console.error = () => {};
+    try {
+      const store = createSSRStore<{ v: string }>(() => Promise.reject(new Error('R3-07 loader boom')));
+
+      await expect(store.ready).rejects.toThrow('R3-07 loader boom');
+      expect(store.status.value).toBe('error');
+    } finally {
+      console.error = consoleError;
+    }
+  });
+
+  it('`ready` stays rejected after a recovering setData (settle-once pinned)', async () => {
+    const consoleError = console.error;
+    console.error = () => {};
+    try {
+      const store = createSSRStore<{ v: string }>(() => Promise.reject(new Error('R3-07 loader boom')));
+      await expect(store.ready).rejects.toThrow('R3-07 loader boom');
+
+      store.setData({ v: 'recovered' });
+
+      expect(store.status.value).toBe('success');
+      expect(store.getSnapshot()).toEqual({ v: 'recovered' });
+      // Promises settle once: the recovering setData cannot re-settle `ready`.
+      await expect(store.ready).rejects.toThrow('R3-07 loader boom');
+    } finally {
+      console.error = consoleError;
+    }
+  });
+});

--- a/packages/vue/src/test/SSRDataStore.supersede.test.ts
+++ b/packages/vue/src/test/SSRDataStore.supersede.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createSSRStore } from '../SSRDataStore.js';
+
+// R3-08 (S2, vue twin) — an explicit `setData` supersedes the in-flight initial promise. Pre-fix,
+// a LATE loader rejection flipped `status` to 'error' (contradicting the explicitly-set data in
+// every reactive consumer, with a misleading "Failed to load initial data" log) and a LATE
+// resolution silently overwrote `data.value`. Vue's `getSnapshot` never throws, so unlike react
+// there is no tree teardown — state corruption only.
+
+let consoleError: ReturnType<typeof vi.spyOn>;
+beforeEach(() => {
+  consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  consoleError.mockRestore();
+});
+
+describe('R3-08 setData supersedes the in-flight initial promise (vue twin)', () => {
+  it('a late loader REJECTION does not flip the store into an error state', async () => {
+    let rejectLoader!: (e: Error) => void;
+    const store = createSSRStore<{ v: string }>(
+      new Promise((_, rej) => {
+        rejectLoader = rej;
+      }),
+    );
+    store.setData({ v: 'from-setData' });
+
+    rejectLoader(new Error('loader failed late'));
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(store.status.value).toBe('success');
+    expect(store.data.value).toEqual({ v: 'from-setData' });
+    expect(store.lastError.value).toBeUndefined();
+    expect(consoleError).not.toHaveBeenCalled();
+    await expect(store.ready).resolves.toBeUndefined();
+  });
+
+  it('a late loader RESOLUTION does not overwrite an explicit setData', async () => {
+    let resolveLoader!: (v: { v: string }) => void;
+    const store = createSSRStore<{ v: string }>(
+      new Promise((res) => {
+        resolveLoader = res;
+      }),
+    );
+    store.setData({ v: 'from-setData' });
+
+    resolveLoader({ v: 'from-loader' });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(store.data.value).toEqual({ v: 'from-setData' });
+    expect(store.getSnapshot()).toEqual({ v: 'from-setData' });
+  });
+
+  it('control: without setData the loader still settles the store normally (success and error)', async () => {
+    const success = createSSRStore<{ v: string }>(Promise.resolve({ v: 'from-loader' }));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(success.data.value).toEqual({ v: 'from-loader' });
+    await expect(success.ready).resolves.toBeUndefined();
+
+    const failure = createSSRStore<{ v: string }>(Promise.reject(new Error('loader boom')));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(failure.status.value).toBe('error');
+    expect(consoleError).toHaveBeenCalled();
+    await expect(failure.ready).rejects.toThrow('loader boom');
+  });
+});

--- a/packages/vue/src/test/SSRHydration.test.ts
+++ b/packages/vue/src/test/SSRHydration.test.ts
@@ -271,3 +271,97 @@ describe('hydrateApp — setupApp (V1-06)', () => {
     expect(apps[1]).toBe(apps[2]);
   });
 });
+
+describe('hydrateApp — observer isolation (gate review R2-03/R2-04, hardening-lessons §1)', () => {
+  it('a throwing onStart is isolated: the app still mounts and success is still emitted (no manufactured error)', () => {
+    setRoot('<div>app</div>');
+    setData({ a: 1 });
+    const events: string[] = [];
+    (window as any).__TAUJS_DEVTOOLS_HOOK__ = { emit: (ev: string) => events.push(ev) };
+    const onHydrationError = vi.fn();
+    const onSuccess = vi.fn();
+    const onStart = vi.fn(() => {
+      throw new Error('onStart boom');
+    });
+
+    expect(() => hydrateApp({ appComponent: CleanApp, logger: { error: vi.fn() }, onStart, onSuccess, onHydrationError })).not.toThrow();
+
+    // An advisory observer must never stop the app hydrating.
+    expect(document.getElementById('root')!.textContent).toBe('app');
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(events).toEqual(['hydration:start', 'hydration:success']);
+    expect(onHydrationError).not.toHaveBeenCalled();
+  });
+
+  it('a throwing onSuccess is isolated: one success, and NO hydration:error is manufactured after it', () => {
+    setRoot('<div>app</div>');
+    setData({ a: 1 });
+    const events: string[] = [];
+    (window as any).__TAUJS_DEVTOOLS_HOOK__ = { emit: (ev: string) => events.push(ev) };
+    const onHydrationError = vi.fn();
+    const onSuccess = vi.fn(() => {
+      throw new Error('onSuccess boom');
+    });
+
+    expect(() => hydrateApp({ appComponent: CleanApp, logger: { error: vi.fn() }, onSuccess, onHydrationError })).not.toThrow();
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(events).toEqual(['hydration:start', 'hydration:success']);
+    expect(events).not.toContain('hydration:error');
+    expect(onHydrationError).not.toHaveBeenCalled();
+  });
+
+  it('a throwing onHydrationError cannot escape a setupApp/mount failure', () => {
+    setRoot('<div>app</div>');
+    setData({ a: 1 });
+    const onHydrationError = vi.fn(() => {
+      throw new Error('onHydrationError boom');
+    });
+
+    expect(() =>
+      hydrateApp({
+        appComponent: CleanApp,
+        logger: { error: vi.fn() },
+        onHydrationError,
+        setupApp: () => {
+          throw new Error('setup exploded');
+        },
+      }),
+    ).not.toThrow();
+
+    expect(onHydrationError).toHaveBeenCalledTimes(1);
+  });
+
+  it('a throwing onHydrationError cannot escape the CSR mount failure path', () => {
+    setRoot('<div>stale</div>');
+    setData(undefined); // no SSR data -> CSR
+    const onHydrationError = vi.fn(() => {
+      throw new Error('onHydrationError boom');
+    });
+
+    expect(() =>
+      hydrateApp({
+        appComponent: CleanApp,
+        logger: { error: vi.fn() },
+        onHydrationError,
+        setupApp: () => {
+          throw new Error('csr setup exploded');
+        },
+      }),
+    ).not.toThrow();
+
+    expect(onHydrationError).toHaveBeenCalledTimes(1);
+  });
+
+  it('a throwing onHydrationError cannot escape the missing-root path', () => {
+    document.body.innerHTML = '<div id="somewhere-else"></div>';
+    setData({ a: 1 });
+    const onHydrationError = vi.fn(() => {
+      throw new Error('onHydrationError boom');
+    });
+
+    expect(() => hydrateApp({ appComponent: CleanApp, rootElementId: 'root', logger: { error: vi.fn() }, onHydrationError })).not.toThrow();
+
+    expect(onHydrationError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/vue/src/test/SSRHydration.test.ts
+++ b/packages/vue/src/test/SSRHydration.test.ts
@@ -66,6 +66,25 @@ describe('hydrateApp — mount paths', () => {
     expect(String(error.mock.calls[0]![0])).toContain('Root element with id "root" not found');
     expect(onStart).not.toHaveBeenCalled();
   });
+
+  it('missing root: reports via onHydrationError + hydration:error beacon; hydration never starts (R2-03)', () => {
+    document.body.innerHTML = '<div id="somewhere-else"></div>';
+    setData({ a: 1 });
+    const events: string[] = [];
+    (window as any).__TAUJS_DEVTOOLS_HOOK__ = { emit: (ev: string) => events.push(ev) };
+    const error = vi.fn();
+    const onHydrationError = vi.fn();
+    const onStart = vi.fn();
+
+    hydrateApp({ appComponent: CleanApp, rootElementId: 'root', logger: { error }, onHydrationError, onStart });
+
+    expect(onHydrationError).toHaveBeenCalledTimes(1);
+    expect((onHydrationError.mock.calls[0]![0] as Error).message).toContain('Root element with id "root" not found');
+    // error-without-start (vue precedent — a setupApp failure emits the same way); hydration never began
+    expect(events).toEqual(['hydration:error']);
+    expect(onStart).not.toHaveBeenCalled();
+    expect(String(error.mock.calls[0]![0])).toContain('not found');
+  });
 });
 
 describe('hydrateApp — error handler wiring (F11)', () => {

--- a/packages/vue/src/test/SSRRender.integration.test.ts
+++ b/packages/vue/src/test/SSRRender.integration.test.ts
@@ -340,3 +340,169 @@ describe('renderStream — server integration (byte order)', () => {
     expect((onError[0] as Error).message).toContain('component exploded');
   });
 });
+
+describe('renderStream — server-join regressions (gate review R2-03/R2-04)', () => {
+  // Faithful reproduction of the server's streaming failure-path wiring (HandleRender.ts:419-602),
+  // which driveLikeServer (happy-path byte order) deliberately omits: the head commit that connects
+  // the renderer's stream to the response, the PRODUCTION onError teardown whose ac.abort()
+  // re-enters the renderer through the very signal wired to benign-cancel, and the writable
+  // 'finish' listener that appends the data script + tail and records the response as sent. The
+  // gate-review HIGHs live in exactly this join, so the regressions must drive the real callback
+  // sequence, not a simplified observer.
+  const driveServerJoin = <T extends Record<string, unknown>>(
+    renderStream: ReturnType<typeof createRenderer<T>>['renderStream'],
+    initialData: T,
+    { commitHead }: { commitHead?: () => void } = {},
+  ) => {
+    // reply.raw stand-in: enough state for the join's branching (headersSent gates 500-vs-destroy).
+    const reply = {
+      headersSent: false,
+      statusCode: null as number | null,
+      writableEnded: false,
+      destroyed: false,
+      body: [] as string[],
+      sent200: false,
+      writeHead(status: number) {
+        this.statusCode = status;
+        this.headersSent = true;
+      },
+      write(chunk: unknown) {
+        this.headersSent = true;
+        this.body.push(String(chunk));
+      },
+      end(chunk?: unknown) {
+        if (chunk != null) this.write(chunk);
+        this.writableEnded = true;
+      },
+      destroy() {
+        this.destroyed = true;
+      },
+      output() {
+        return this.body.join('');
+      },
+    };
+
+    const writable = new Collector();
+    const ac = new AbortController();
+    let abortedState = false;
+    let finalData: unknown = undefined;
+    let pipedToReply = false;
+
+    // writable.pipe(reply.raw, { end: false }) — the renderer's bytes reach the response only
+    // once onHead has connected them (HandleRender.ts:450-453).
+    const rendererWrite = writable.write.bind(writable);
+    writable.write = (chunk: unknown): boolean => {
+      const ok = rendererWrite(chunk);
+      if (pipedToReply) reply.write(chunk);
+      return ok;
+    };
+
+    // The production FATAL channel teardown (HandleRender.ts:480-534, minus telemetry). The
+    // ac.abort() here is the re-entrancy under test: the same signal is wired to renderStream below.
+    const onError = vi.fn((err: unknown) => {
+      void err;
+      if (abortedState) return;
+      abortedState = true;
+      try {
+        ac.abort();
+      } catch {}
+      if (!reply.headersSent) {
+        reply.writeHead(500);
+        reply.end('Internal Server Error');
+        return;
+      }
+      if (!reply.writableEnded && !reply.destroyed) reply.destroy();
+    });
+
+    const { done } = renderStream(
+      writable as any,
+      {
+        // The head commit connects the renderer's stream to the HTTP response
+        // (HandleRender.ts:434-454); commitHead is where the production write can throw.
+        onHead: (headContent: string) => {
+          commitHead?.();
+          reply.write(`${TEMPLATE.beforeHead}${headContent}${TEMPLATE.afterHead}${TEMPLATE.beforeBody}`);
+          pipedToReply = true;
+        },
+        onAllReady: (data: unknown) => {
+          if (!abortedState) finalData = data;
+        },
+        onError,
+      },
+      initialData,
+      '/server-join',
+      '/entry-client.js',
+      {},
+      undefined,
+      ac.signal, // HandleRender.ts:541 — the signal the production onError aborts re-entrantly
+    );
+
+    // On renderer finish, the server appends the data script + template tail and records the
+    // response as SENT with a 200 (HandleRender.ts:552-602). After a failed head commit this
+    // listener is what assembled the malformed "successful" response pre-fix.
+    writable.once('finish', () => {
+      if (abortedState || reply.writableEnded) return;
+      reply.write(`<script>window.__INITIAL_DATA__ = ${JSON.stringify(finalData ?? {})};</script>${TEMPLATE.afterBody}`);
+      reply.end();
+      reply.sent200 = true; // recorder?.sent({ status: 200, mode: 'streaming' })
+    });
+
+    return { done, writable, reply, ac, onError };
+  };
+
+  it('gate finding 3: a throwing head commit cannot continue to a partial 200 — the join sends a real 500 and never records sent', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { renderStream } = createRenderer<{ msg: string }>({
+      appComponent: () => h('div', { id: 'app' }, 'app-body'),
+      headContent: () => '<title>x</title>',
+    });
+
+    const { done, reply, onError } = driveServerJoin(
+      renderStream,
+      { msg: 'hello' },
+      {
+        commitHead: () => {
+          throw new Error('head commit failed');
+        },
+      },
+    );
+
+    await expect(done).rejects.toThrow('head commit failed');
+    expect(onError).toHaveBeenCalledTimes(1);
+    // Nothing was committed, so the join sent a REAL error response…
+    expect(reply.statusCode).toBe(500);
+    expect(reply.output()).toBe('Internal Server Error');
+    // …and the finish listener could not assemble the pre-fix malformed "success": app bytes into
+    // an unconnected sink, then data script + tail recorded as a 200 with no head/prefix/body.
+    expect(reply.sent200).toBe(false);
+    expect(reply.output()).not.toContain('app-body');
+    expect(reply.output()).not.toContain('__INITIAL_DATA__');
+  });
+
+  it('gate finding 2: a fatal whose onError re-enters via the production ac.abort() still rejects done; writable and reply torn down', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const Boom = defineComponent({
+      name: 'Boom',
+      setup() {
+        throw new Error('server-join-fatal');
+      },
+    });
+    const { renderStream } = createRenderer<{ x: number }>({
+      appComponent: () => h(Boom),
+      headContent: () => '<title>boom</title>',
+    });
+
+    const { done, writable, reply, ac, onError } = driveServerJoin(renderStream, { x: 1 });
+
+    await expect(done).rejects.toThrow('server-join-fatal'); // NOT benign-resolved by the re-entry
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(ac.signal.aborted).toBe(true); // the production re-entry really fired
+    expect(writable.destroyed).toBe(true); // renderer-side teardown still ran
+    // The head had already been committed, so the join destroys the response instead of 500ing —
+    // and the fatal can never be recorded as a sent 200.
+    expect(reply.headersSent).toBe(true);
+    expect(reply.destroyed).toBe(true);
+    expect(reply.sent200).toBe(false);
+  });
+});

--- a/packages/vue/src/test/SSRRender.test.ts
+++ b/packages/vue/src/test/SSRRender.test.ts
@@ -369,6 +369,24 @@ describe('createRenderer.renderStream — error & abort paths', () => {
     expect(onError).toHaveBeenCalledTimes(1);
   });
 
+  it('recheck: a throwing onError does not veto fatal settlement — done rejects with the ORIGINAL error, writable destroyed', async () => {
+    const writable = new Collector();
+    const original = new Error('render boom');
+    const onError = vi.fn(() => {
+      throw new Error('onError boom');
+    });
+
+    const { done } = makeRenderer().renderStream(writable as any, { onError }, {} as any, '/fatal-throwing-cb');
+
+    getSink().destroy(original);
+
+    // fail() runs controller.fatalAbort in `finally`, so settlement + cleanup happen even though
+    // cb.onError threw: `done` rejects with the ORIGINAL error and the writable is destroyed.
+    await expect(done).rejects.toBe(original);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(writable.destroyed).toBe(true);
+  });
+
   it('R0-02: sink.destroy with a disconnect-shaped error is still fatal (destroy is render-origin)', async () => {
     const writable = new Collector();
     const onError = vi.fn();

--- a/packages/vue/src/test/SSRRender.test.ts
+++ b/packages/vue/src/test/SSRRender.test.ts
@@ -164,19 +164,22 @@ describe('createRenderer.renderStream — head contract (F2)', () => {
     expect(onHead).toHaveBeenCalledWith('<title>H-3</title>');
   });
 
-  it('onHead callback throwing is caught (warns) and does not abort the stream', () => {
+  it('a throwing onHead is FATAL: done rejects, nothing is rendered into the unconnected sink', async () => {
+    // onHead is REQUIRED, not advisory: at the server boundary it commits the response prefix and
+    // connects the renderer's PassThrough to the HTTP response. If it throws and we carried on, app
+    // bytes would be written into an unconnected sink -> a malformed "successful" response.
     const writable = new Collector();
-    const warn = vi.fn();
+    const onError = vi.fn();
     const onHead = vi.fn(() => {
       throw new Error('head-cb boom');
     });
 
-    makeRenderer({ logger: { warn } } as any).renderStream(writable as any, { onHead }, {} as any, '/onhead-throws');
+    const { done } = makeRenderer({ logger: { error: vi.fn() } } as any).renderStream(writable as any, { onHead, onError }, {} as any, '/onhead-throws');
 
-    expect(SR.renderToSimpleStream).toHaveBeenCalledTimes(1);
-    const [msg, err] = warn.mock.calls.find(([m]) => String(m).includes('onHead callback threw'))!;
-    expect(msg).toContain('onHead callback threw:');
-    expect((err as Error).message).toBe('head-cb boom');
+    await expect(done).rejects.toThrow('head-cb boom');
+    expect(SR.renderToSimpleStream).not.toHaveBeenCalled(); // stopped before rendering
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect((onError.mock.calls[0]![0] as Error).message).toBe('head-cb boom');
   });
 });
 
@@ -358,6 +361,89 @@ describe('createRenderer.renderStream — completion & data delivery', () => {
 
     sink.push(null);
     await done;
+  });
+
+  it('a throwing onAllReady is ISOLATED: onFinish still fires, done follows the render outcome, no manufactured fatal', async () => {
+    // An advisory observer must not turn successfully resolved data + a completed render into a fatal
+    // stream failure (its throw previously reached the .catch and called fail), nor suppress onFinish.
+    const writable = new Collector();
+    const onAllReady = vi.fn(() => {
+      throw new Error('onAllReady boom');
+    });
+    const onFinish = vi.fn();
+    const onError = vi.fn();
+
+    const { done } = makeRenderer({ logger: { error: vi.fn() } } as any).renderStream(
+      writable as any,
+      { onAllReady, onFinish, onError },
+      () => Promise.resolve({ userId: 7 }) as any,
+      '/data',
+    );
+
+    const sink = getSink();
+    sink.push('<div/>');
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(onAllReady).toHaveBeenCalledTimes(1);
+    expect(onFinish).toHaveBeenCalledWith({ userId: 7 }); // sibling not suppressed
+    expect(onError).not.toHaveBeenCalled(); // no manufactured fatal
+
+    sink.push(null);
+    await expect(done).resolves.toBeUndefined();
+  });
+
+  it('a throwing onFinish is ISOLATED: done still resolves, single fire', async () => {
+    const writable = new Collector();
+    const onAllReady = vi.fn();
+    const onFinish = vi.fn(() => {
+      throw new Error('onFinish boom');
+    });
+    const onError = vi.fn();
+
+    const { done } = makeRenderer({ logger: { error: vi.fn() } } as any).renderStream(
+      writable as any,
+      { onAllReady, onFinish, onError },
+      () => Promise.resolve({ userId: 7 }) as any,
+      '/data',
+    );
+
+    const sink = getSink();
+    sink.push('<div/>');
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(onAllReady).toHaveBeenCalledWith({ userId: 7 });
+    expect(onFinish).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+
+    sink.push(null);
+    await expect(done).resolves.toBeUndefined();
+  });
+
+  it('re-entrant abort: a fatal whose onError aborts the passed signal still REJECTS done (no benign downgrade)', async () => {
+    // The server's onError synchronously calls ac.abort() on the SAME signal wired here to
+    // benign-cancel. If fail() ran the callback before claiming fatal, that re-entrant benignAbort
+    // would win the one-shot controller and RESOLVE done - a fatal reported as a benign completion.
+    const writable = new Collector();
+    const ac = new AbortController();
+    const original = new Error('vue-fatal-original');
+    const onError = vi.fn(() => ac.abort());
+
+    const { done } = makeRenderer({ logger: { error: vi.fn() } } as any).renderStream(
+      writable as any,
+      { onError },
+      {} as any,
+      '/reentrant',
+      undefined,
+      {},
+      undefined,
+      ac.signal,
+    );
+
+    const sink = getSink();
+    sink.destroy(original); // render-origin fatal
+
+    await expect(done).rejects.toThrow('vue-fatal-original');
+    expect(onError).toHaveBeenCalledTimes(1);
   });
 
   it('a rejected data thunk becomes a fatal error (onError + done rejects)', async () => {

--- a/packages/vue/src/test/SSRRender.test.ts
+++ b/packages/vue/src/test/SSRRender.test.ts
@@ -369,25 +369,27 @@ describe('createRenderer.renderStream — error & abort paths', () => {
     expect(onError).toHaveBeenCalledTimes(1);
   });
 
-  it('sink.destroy with a benign disconnect → done resolves, no onError', async () => {
+  it('R0-02: sink.destroy with a disconnect-shaped error is still fatal (destroy is render-origin)', async () => {
     const writable = new Collector();
     const onError = vi.fn();
 
     const { done } = makeRenderer().renderStream(writable as any, { onError }, {} as any, '/disconnect');
 
+    // `destroy` is fed by the render pipeline — a disconnect-shaped message must not be swallowed.
     getSink().destroy(new Error('ECONNRESET'));
 
-    await expect(done).resolves.toBeUndefined();
-    expect(onError).not.toHaveBeenCalled();
+    await expect(done).rejects.toThrow('ECONNRESET');
+    expect(onError).toHaveBeenCalledTimes(1);
   });
 
-  it('a benign writable error resolves done (client disconnect)', async () => {
+  it('a benign writable error (socket disconnect by code) resolves done', async () => {
     const writable = new Collector();
     const onError = vi.fn();
 
     const { done } = makeRenderer().renderStream(writable as any, { onError }, {} as any, '/writable-benign');
 
-    writable.emit('error', new Error('EPIPE'));
+    // real client disconnect surfaced on the writable ('socket'-origin), benign by code (R0-02)
+    writable.emit('error', Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' }));
 
     await expect(done).resolves.toBeUndefined();
     expect(onError).not.toHaveBeenCalled();

--- a/packages/vue/src/test/SSRRender.test.ts
+++ b/packages/vue/src/test/SSRRender.test.ts
@@ -444,6 +444,7 @@ describe('createRenderer.renderStream — completion & data delivery', () => {
 
     await expect(done).rejects.toThrow('vue-fatal-original');
     expect(onError).toHaveBeenCalledTimes(1);
+    expect(writable.destroyed).toBe(true); // fatal teardown still ran despite the re-entry
   });
 
   it('a rejected data thunk becomes a fatal error (onError + done rejects)', async () => {

--- a/packages/vue/src/test/SSRRender.test.ts
+++ b/packages/vue/src/test/SSRRender.test.ts
@@ -212,6 +212,22 @@ describe('createRenderer.renderStream — bootstrap & hydration (F3)', () => {
     expect(writable.output()).not.toContain('nonce=');
   });
 
+  it('escapes the bootstrap src and nonce attributes (SEC2, R2-03)', async () => {
+    const writable = new Collector();
+
+    makeRenderer().renderStream(writable as any, {}, {} as any, '/', '/x.js" onmouseover="alert(1)', {}, 'n"once');
+
+    const sink = getSink();
+    sink.push('<div id="app"></div>');
+    sink.push(null);
+    await new Promise((r) => setTimeout(r, 0));
+
+    const boot = writable.writeCalls.filter((c) => c.includes('type="module"'))[0]!;
+    expect(boot).toContain('src="/x.js&quot; onmouseover=&quot;alert(1)"'); // src encoded
+    expect(boot).not.toContain('onmouseover="alert(1)"'); // no live attribute breakout
+    expect(boot).toContain('nonce="n&quot;once"'); // nonce encoded
+  });
+
   it('emits no bootstrap tag when bootstrapModules is undefined', async () => {
     const writable = new Collector();
 

--- a/packages/vue/src/test/SpecifierExtensions.test.ts
+++ b/packages/vue/src/test/SpecifierExtensions.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment node
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+// R3-05 (Q6) — every relative import/export specifier in emitted source must carry an explicit
+// `.js` extension. tsup builds with `bundle: false` and emits specifiers AS-IS; an extensionless
+// relative specifier ships a dist that fails Node ESM with ERR_MODULE_NOT_FOUND. Test files are
+// excluded (they run under vitest's resolver and are never emitted), as are `.d.ts` files.
+const SRC = fileURLToPath(new URL('..', import.meta.url));
+
+const RELATIVE_SPECIFIER = /(?:from\s+|import\s*\(\s*|import\s+)['"](\.\.?\/[^'"]+)['"]/g;
+
+function emittedSourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return entry.name === 'test' ? [] : emittedSourceFiles(full);
+    if (!/\.(ts|tsx)$/.test(entry.name) || entry.name.endsWith('.d.ts')) return [];
+    return [full];
+  });
+}
+
+describe('R3-05 relative specifier extensions (dist integrity guard)', () => {
+  it('every relative specifier in emitted source carries an explicit extension', () => {
+    const offenders: string[] = [];
+
+    for (const file of emittedSourceFiles(SRC)) {
+      const source = readFileSync(file, 'utf8');
+      for (const match of source.matchAll(RELATIVE_SPECIFIER)) {
+        const spec = match[1]!;
+        if (!/\.(js|json|css)$/.test(spec)) offenders.push(`${path.relative(SRC, file)} -> '${spec}'`);
+      }
+    }
+
+    expect(offenders, `extensionless relative specifiers break the bundle:false dist (Node ESM ERR_MODULE_NOT_FOUND):\n${offenders.join('\n')}`).toEqual([]);
+  });
+});

--- a/packages/vue/src/test/contract.test-d.ts
+++ b/packages/vue/src/test/contract.test-d.ts
@@ -5,19 +5,42 @@
 // runs as a spec. NOTE: requires @taujs/server to be built first (types resolve to its dist).
 import { h } from 'vue';
 
-import type { RenderModule, RenderSSR, RenderStream } from '@taujs/server';
+import type { RenderModule, RenderSSR, RenderStream, RenderStreamHandle } from '@taujs/server';
 
 import { createRenderer } from '../SSRRender';
 
 // The load-bearing assertion: the whole renderer module conforms, cast-free.
-const _module: RenderModule = createRenderer({
+// The CONCRETE renderer output, deliberately un-annotated so tsc keeps its real inferred types.
+// (Annotating this as `RenderModule` would erase them, and every return-shape assertion below would
+// degrade into a tautology comparing the contract against itself - the width-subtyping blindness
+// critical review #3 warns about.)
+const _renderer = createRenderer({
   appComponent: () => h('div'),
   headContent: () => '',
 });
+
+// The load-bearing assertion: the whole renderer module conforms, cast-free.
+const _module: RenderModule = _renderer;
 void _module;
 
 // And each half individually, for a sharper error if one diverges.
-const _renderSSR: RenderSSR = _module.renderSSR;
-const _renderStream: RenderStream = _module.renderStream;
+const _renderSSR: RenderSSR = _renderer.renderSSR;
+const _renderStream: RenderStream = _renderer.renderStream;
 void _renderSSR;
 void _renderStream;
+
+// R3-01 / critical review #3 (mirrored from react): assignability of the FUNCTION alone can hide a
+// capability gap through width-subtyping, so pin the RETURN shape explicitly and in BOTH directions.
+type VueStreamHandle = ReturnType<typeof _renderer.renderStream>;
+
+// 1. What the renderer actually returns must satisfy the published handle contract.
+const _handleSatisfiesContract: RenderStreamHandle = null as unknown as VueStreamHandle;
+void _handleSatisfiesContract;
+
+// 2. ...and every capability the contract REQUIRES must actually be present on it.
+const _contractSatisfiedByHandle: VueStreamHandle = null as unknown as RenderStreamHandle;
+void _contractSatisfiedByHandle;
+
+// 3. `done` is the load-bearing member (R0-01: an unobserved rejection is the process-crash class).
+const _done: Promise<void> = null as unknown as VueStreamHandle['done'];
+void _done;

--- a/packages/vue/src/utils/Html.ts
+++ b/packages/vue/src/utils/Html.ts
@@ -1,5 +1,5 @@
 /**
- * Escape a string for safe interpolation into RAW HTML — both element text and attribute values,
+ * Escape a value for safe interpolation into RAW HTML — both element text and attribute values,
  * single- AND double-quoted. Escapes the five HTML-sensitive characters:
  *
  * - `&` → `&amp;`

--- a/packages/vue/src/utils/Html.ts
+++ b/packages/vue/src/utils/Html.ts
@@ -8,15 +8,21 @@
  * - `"` → `&quot;`
  * - `'` → `&#39;`
  *
+ * SCOPE — this makes a value safe ONLY for HTML text and QUOTED HTML attributes. It does NOT make a
+ * value safe for other contexts: JavaScript, `<script>` JSON / JSON-LD data (character references are
+ * NOT decoded in script raw text — there you must escape `<` as the JSON escape `\u003c`), CSS, or URL
+ * scheme validation. For URL-bearing attributes it prevents attribute breakout but does not validate the
+ * scheme or authorize the destination — construct or allow-list URLs separately.
+ *
  * Intended for `headContent` interpolations (see `HeadContext`): a renderer's `headContent` return
  * value is written into `<head>` as RAW HTML, so any value drawn from services or user input must be
  * escaped before interpolation. The framework-rendered application HTML does NOT need this — React and
  * Vue escape it for you.
  *
  * `&` is replaced FIRST so a freshly produced entity (e.g. `&lt;`) is not corrupted. This function is
- * therefore NOT idempotent — escape each value exactly once; do not double-escape. Non-string input is
- * coerced with `String(value)`.
+ * therefore NOT idempotent — escape each value exactly once; do not double-escape. Input is `unknown`
+ * and coerced with `String(value)`, so non-string values are supported.
  */
-export function escapeHtml(value: string): string {
+export function escapeHtml(value: unknown): string {
   return String(value).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }

--- a/packages/vue/src/utils/Html.ts
+++ b/packages/vue/src/utils/Html.ts
@@ -1,0 +1,22 @@
+/**
+ * Escape a string for safe interpolation into RAW HTML — both element text and attribute values,
+ * single- AND double-quoted. Escapes the five HTML-sensitive characters:
+ *
+ * - `&` → `&amp;`
+ * - `<` → `&lt;`
+ * - `>` → `&gt;`
+ * - `"` → `&quot;`
+ * - `'` → `&#39;`
+ *
+ * Intended for `headContent` interpolations (see `HeadContext`): a renderer's `headContent` return
+ * value is written into `<head>` as RAW HTML, so any value drawn from services or user input must be
+ * escaped before interpolation. The framework-rendered application HTML does NOT need this — React and
+ * Vue escape it for you.
+ *
+ * `&` is replaced FIRST so a freshly produced entity (e.g. `&lt;`) is not corrupted. This function is
+ * therefore NOT idempotent — escape each value exactly once; do not double-escape. Non-string input is
+ * coerced with `String(value)`.
+ */
+export function escapeHtml(value: string): string {
+  return String(value).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}

--- a/packages/vue/src/utils/Logger.ts
+++ b/packages/vue/src/utils/Logger.ts
@@ -22,7 +22,25 @@ type Opts = {
   enableDebug?: boolean;
 };
 
-const toJSONString = (v: unknown) => (typeof v === 'string' ? v : v instanceof Error ? (v.stack ?? v.message) : JSON.stringify(v));
+// R0-03/gate: NON-THROWING value formatting. Renderer errors are `unknown`, and this runs on
+// error paths that log BEFORE cleanup (see `createStreamController.fatalAbort`), so it must never
+// throw — `JSON.stringify` alone would on a `BigInt`, a circular object, or a throwing
+// `toJSON`/`Symbol.toPrimitive`. Falls back to a best-effort string that also cannot throw.
+const toJSONString = (v: unknown): string => {
+  if (typeof v === 'string') return v;
+  if (v instanceof Error) return v.stack ?? v.message;
+  try {
+    const json = JSON.stringify(v);
+    if (json !== undefined) return json;
+  } catch {
+    // fall through to String() best-effort
+  }
+  try {
+    return String(v);
+  } catch {
+    return '[unserializable]';
+  }
+};
 
 const splitMsgAndMeta = (args: unknown[]) => {
   const [first, ...rest] = args;
@@ -33,6 +51,18 @@ const splitMsgAndMeta = (args: unknown[]) => {
   const meta = only && typeof only === 'object' && !(only instanceof Error) ? only : { args: rest.map(toJSONString) };
 
   return { msg, meta };
+};
+
+// R0-03/gate: a diagnostic logger must never break the code path it observes (`fatalAbort` logs
+// BEFORE cleanup). `safe` isolates BOTH value formatting and the user-provided logger method — a
+// swallowed failure loses a log line, never settlement/cleanup. Documented policy: the UI logger
+// is best-effort and non-throwing.
+const safe = (fn: () => void): void => {
+  try {
+    fn();
+  } catch {
+    // best-effort: diagnostics must not throw
+  }
 };
 
 export function createUILogger(logger?: LoggerLike, opts: Opts = {}): UILogger {
@@ -72,37 +102,40 @@ export function createUILogger(logger?: LoggerLike, opts: Opts = {}): UILogger {
 
     return {
       log: enableDebug
-        ? (...args: unknown[]) => {
-            const { msg, meta } = splitMsgAndMeta(args);
+        ? (...args: unknown[]) =>
+            safe(() => {
+              const { msg, meta } = splitMsgAndMeta(args);
 
-            if (debug) {
-              const enabled = (isDebugEnabled ? isDebugEnabled(debugCategory) : false) || preferDebug;
+              if (debug) {
+                const enabled = (isDebugEnabled ? isDebugEnabled(debugCategory) : false) || preferDebug;
 
-              if (enabled) {
-                debug(debugCategory, msg, meta);
-                return;
+                if (enabled) {
+                  debug(debugCategory, msg, meta);
+                  return;
+                }
               }
-            }
 
-            info(msg, meta);
-          }
+              info(msg, meta);
+            })
         : () => {},
-      warn: (...args: unknown[]) => {
-        const { msg, meta } = splitMsgAndMeta(args);
-        warn(msg, meta);
-      },
-      error: (...args: unknown[]) => {
-        const { msg, meta } = splitMsgAndMeta(args);
-        error(msg, meta);
-      },
+      warn: (...args: unknown[]) =>
+        safe(() => {
+          const { msg, meta } = splitMsgAndMeta(args);
+          warn(msg, meta);
+        }),
+      error: (...args: unknown[]) =>
+        safe(() => {
+          const { msg, meta } = splitMsgAndMeta(args);
+          error(msg, meta);
+        }),
     };
   }
 
   const ui = (logger as Partial<UILogger>) || {};
   return {
-    log: enableDebug ? (...a) => (ui.log ?? console.log)(...a) : () => {},
-    warn: (...a) => (ui.warn ?? console.warn)(...a),
-    error: (...a) => (ui.error ?? console.error)(...a),
+    log: enableDebug ? (...a) => safe(() => (ui.log ?? console.log)(...a)) : () => {},
+    warn: (...a) => safe(() => (ui.warn ?? console.warn)(...a)),
+    error: (...a) => safe(() => (ui.error ?? console.error)(...a)),
   };
 }
 

--- a/packages/vue/src/utils/Logger.ts
+++ b/packages/vue/src/utils/Logger.ts
@@ -38,14 +38,9 @@ const splitMsgAndMeta = (args: unknown[]) => {
 export function createUILogger(logger?: LoggerLike, opts: Opts = {}): UILogger {
   const { debugCategory = 'ssr', context, preferDebug = false, enableDebug = false } = opts;
 
-  if (!enableDebug) {
-    return {
-      log: () => {},
-      warn: () => {},
-      error: () => {},
-    };
-  }
-
+  // R0-03: `enableDebug` gates VERBOSITY (the `log` channel), not error visibility. `warn` and
+  // `error` always route — to the provided logger if any, else `console`. Only `log` is gated,
+  // so production consumers still see renderer warnings/errors (RFC S2).
   const looksServer = !!logger && ('info' in logger || 'debug' in logger || 'child' in logger || 'isDebugEnabled' in logger);
 
   if (looksServer) {
@@ -76,20 +71,22 @@ export function createUILogger(logger?: LoggerLike, opts: Opts = {}): UILogger {
     const isDebugEnabled = s.isDebugEnabled ? (category: string) => s.isDebugEnabled!(category) : undefined;
 
     return {
-      log: (...args: unknown[]) => {
-        const { msg, meta } = splitMsgAndMeta(args);
+      log: enableDebug
+        ? (...args: unknown[]) => {
+            const { msg, meta } = splitMsgAndMeta(args);
 
-        if (debug) {
-          const enabled = (isDebugEnabled ? isDebugEnabled(debugCategory) : false) || preferDebug;
+            if (debug) {
+              const enabled = (isDebugEnabled ? isDebugEnabled(debugCategory) : false) || preferDebug;
 
-          if (enabled) {
-            debug(debugCategory, msg, meta);
-            return;
+              if (enabled) {
+                debug(debugCategory, msg, meta);
+                return;
+              }
+            }
+
+            info(msg, meta);
           }
-        }
-
-        info(msg, meta);
-      },
+        : () => {},
       warn: (...args: unknown[]) => {
         const { msg, meta } = splitMsgAndMeta(args);
         warn(msg, meta);
@@ -103,7 +100,7 @@ export function createUILogger(logger?: LoggerLike, opts: Opts = {}): UILogger {
 
   const ui = (logger as Partial<UILogger>) || {};
   return {
-    log: (...a) => (ui.log ?? console.log)(...a),
+    log: enableDebug ? (...a) => (ui.log ?? console.log)(...a) : () => {},
     warn: (...a) => (ui.warn ?? console.warn)(...a),
     error: (...a) => (ui.error ?? console.error)(...a),
   };

--- a/packages/vue/src/utils/Streaming.ts
+++ b/packages/vue/src/utils/Streaming.ts
@@ -6,12 +6,32 @@ export type StreamLogger = {
   error: (msg: string, extra?: unknown) => void;
 };
 
-export const DEFAULT_BENIGN_ERRORS = /ECONNRESET|EPIPE|socket hang up|aborted|premature/i;
+// R0-02: benignity is a property of an error's ORIGIN, never of its message/name/user-set
+// properties when it came from render/data code. Classify by origin AND shape.
+export type StreamErrSource = 'socket' | 'render';
 
-export function isBenignStreamErr(err: unknown): boolean {
-  const msg = String((err as any)?.message ?? '');
+// Disconnect signals worth trusting on a socket/writable-origin error.
+const BENIGN_SOCKET_CODES = new Set(['ECONNRESET', 'EPIPE', 'ERR_STREAM_PREMATURE_CLOSE', 'ERR_STREAM_DESTROYED']);
+// Exact (case-insensitive, trimmed) node/undici socket messages — NOT loose substrings, so an
+// app error whose message merely contains "aborted" is not mistaken for a disconnect.
+const BENIGN_SOCKET_MESSAGES = new Set(['aborted', 'socket hang up', 'premature close', 'request aborted']);
 
-  return DEFAULT_BENIGN_ERRORS.test(msg);
+export function isBenignStreamErr(err: unknown, source: StreamErrSource): boolean {
+  // Render/data-origin errors are never benign by shape: a component can throw
+  // `new Error('Payment aborted unexpectedly')` or `Object.assign(new Error(), { code: 'EPIPE' })`.
+  // The only benign render outcome is one the controller already knows about (callers check
+  // `controller.isAborted` before classifying).
+  if (source !== 'socket') return false;
+
+  const e = err as { code?: unknown; name?: unknown; message?: unknown } | null | undefined;
+  if (typeof e?.code === 'string' && BENIGN_SOCKET_CODES.has(e.code)) return true;
+  if (e?.name === 'AbortError') return true;
+
+  return BENIGN_SOCKET_MESSAGES.has(
+    String(e?.message ?? '')
+      .trim()
+      .toLowerCase(),
+  );
 }
 
 export type Settler = {
@@ -58,13 +78,11 @@ export function wireWritableGuards(
     fatalAbort,
     onError,
     onFinish,
-    benignErrorPattern = DEFAULT_BENIGN_ERRORS,
   }: {
     benignAbort: (why: string) => void;
     fatalAbort: (err: unknown) => void;
     onError?: (e: unknown) => void;
     onFinish?: () => void;
-    benignErrorPattern?: RegExp;
   },
 ): WritableGuards {
   const handlers: Array<() => void> = [];
@@ -74,8 +92,9 @@ export function wireWritableGuards(
   };
 
   add('error', (err) => {
-    const msg = String((err as any)?.message ?? '');
-    if (benignErrorPattern.test(msg)) {
+    // These are writable/socket-origin errors (the destination emitted 'error'): classify as
+    // 'socket' (R0-02).
+    if (isBenignStreamErr(err, 'socket')) {
       benignAbort('Client disconnected during stream');
     } else {
       onError?.(err);

--- a/packages/vue/src/utils/Streaming.ts
+++ b/packages/vue/src/utils/Streaming.ts
@@ -123,6 +123,12 @@ export function createStreamController(writable: Writable, logger: StreamLogger)
 
   let aborted = false;
   const settle = createSettler();
+  // R0-01: pre-attach a no-op rejection handler to `settle.done`. This marks the SAME promise
+  // as handled, so an unobserved `done` can never raise `unhandledRejection` (Node's default
+  // mode turns that into a process-terminating `uncaughtException`) — while consumers who await
+  // `done` still receive the fatal rejection on their own handler. Safe-by-default: the renderer
+  // must not hand out a footgun promise (see server call site + `RenderStreamHandle`).
+  settle.done.catch(() => {});
 
   let stopShellTimer: (() => void) | undefined;
   let removeAbortListener: (() => void) | undefined;

--- a/packages/vue/src/utils/Streaming.ts
+++ b/packages/vue/src/utils/Streaming.ts
@@ -202,21 +202,30 @@ export function createStreamController(writable: Writable, logger: StreamLogger)
     complete(message?: string) {
       if (aborted) return;
 
-      if (message) (log ?? warn)(message);
+      // Gate: a throwing logger must never prevent cleanup/settlement — the diagnostic must not
+      // break the control-flow path it observes. (createUILogger is already non-throwing; this is
+      // defence in depth for any StreamLogger, including a `fatalAbort(<BigInt>)`.)
+      try {
+        if (message) (log ?? warn)(message);
+      } catch {}
       cleanup(true);
     },
 
     benignAbort(why) {
       if (aborted) return;
 
-      warn(why);
+      try {
+        warn(why);
+      } catch {}
       cleanup(true);
     },
 
     fatalAbort(err) {
       if (aborted) return;
 
-      error('Stream aborted with error:', err);
+      try {
+        error('Stream aborted with error:', err);
+      } catch {}
       cleanup(false, err);
     },
 

--- a/packages/vue/src/utils/test/Html.test.ts
+++ b/packages/vue/src/utils/test/Html.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+
+import { escapeHtml } from '../Html';
+
+describe('escapeHtml', () => {
+  it('escapes all five HTML-sensitive characters (text- AND attribute-safe, both quote styles)', () => {
+    expect(escapeHtml('&')).toBe('&amp;');
+    expect(escapeHtml('<')).toBe('&lt;');
+    expect(escapeHtml('>')).toBe('&gt;');
+    expect(escapeHtml('"')).toBe('&quot;');
+    expect(escapeHtml("'")).toBe('&#39;');
+  });
+
+  it('escapes & FIRST so freshly produced entities are not corrupted', () => {
+    expect(escapeHtml('a & b < c')).toBe('a &amp; b &lt; c');
+    // an existing entity has its `&` escaped — double-escaping is the caller's concern (below)
+    expect(escapeHtml('&amp;')).toBe('&amp;amp;');
+  });
+
+  it('escapes a mixed attribute-breakout payload', () => {
+    const raw = `" onload='alert(1)' <img src=x>`;
+    expect(escapeHtml(raw)).toBe('&quot; onload=&#39;alert(1)&#39; &lt;img src=x&gt;');
+  });
+
+  it('coerces non-string input via String()', () => {
+    expect(escapeHtml(42 as unknown as string)).toBe('42');
+    expect(escapeHtml(null as unknown as string)).toBe('null');
+    expect(escapeHtml(undefined as unknown as string)).toBe('undefined');
+    expect(escapeHtml({ toString: () => '<x>' } as unknown as string)).toBe('&lt;x&gt;');
+  });
+
+  it('leaves safe text unchanged', () => {
+    expect(escapeHtml('hello world 123')).toBe('hello world 123');
+    expect(escapeHtml('')).toBe('');
+  });
+
+  it('is NOT idempotent — the caller must not double-escape (documented)', () => {
+    expect(escapeHtml(escapeHtml('<'))).toBe('&amp;lt;');
+  });
+});

--- a/packages/vue/src/utils/test/Html.test.ts
+++ b/packages/vue/src/utils/test/Html.test.ts
@@ -22,11 +22,11 @@ describe('escapeHtml', () => {
     expect(escapeHtml(raw)).toBe('&quot; onload=&#39;alert(1)&#39; &lt;img src=x&gt;');
   });
 
-  it('coerces non-string input via String()', () => {
-    expect(escapeHtml(42 as unknown as string)).toBe('42');
-    expect(escapeHtml(null as unknown as string)).toBe('null');
-    expect(escapeHtml(undefined as unknown as string)).toBe('undefined');
-    expect(escapeHtml({ toString: () => '<x>' } as unknown as string)).toBe('&lt;x&gt;');
+  it('coerces non-string input via String() (public signature accepts unknown)', () => {
+    expect(escapeHtml(42)).toBe('42');
+    expect(escapeHtml(null)).toBe('null');
+    expect(escapeHtml(undefined)).toBe('undefined');
+    expect(escapeHtml({ toString: () => '<x>' })).toBe('&lt;x&gt;');
   });
 
   it('leaves safe text unchanged', () => {

--- a/packages/vue/src/utils/test/Logger.test.ts
+++ b/packages/vue/src/utils/test/Logger.test.ts
@@ -21,36 +21,36 @@ afterEach(() => {
 });
 
 describe('createUILogger - enableDebug gate', () => {
-  it('returns no-op functions when enableDebug is false (default)', () => {
+  it('R0-03: with enableDebug false (default), only `log` is silent — warn/error route to console', () => {
     const { logSpy, warnSpy, errSpy } = mkSpies();
     const ui = createUILogger(undefined); // enableDebug defaults to false
 
-    ui.log('should not appear');
-    ui.warn('should not appear');
-    ui.error('should not appear');
+    ui.log('debug only');
+    ui.warn('a warning');
+    ui.error('an error');
 
-    expect(logSpy).not.toHaveBeenCalled();
-    expect(warnSpy).not.toHaveBeenCalled();
-    expect(errSpy).not.toHaveBeenCalled();
+    expect(logSpy).not.toHaveBeenCalled(); // verbosity gated
+    expect(warnSpy).toHaveBeenCalled(); // error visibility is NOT gated (RFC S2)
+    expect(errSpy).toHaveBeenCalled();
   });
 
-  it('returns no-op functions when enableDebug is explicitly false', () => {
+  it('R0-03: with enableDebug false, `log` is gated but warn/error still route (console fallback)', () => {
     const { logSpy, warnSpy, errSpy } = mkSpies();
     const customLog = vi.fn();
 
     const ui = createUILogger({ log: customLog }, { enableDebug: false });
 
-    ui.log('nope');
-    ui.warn('nope');
-    ui.error('nope');
+    ui.log('debug only');
+    ui.warn('a warning');
+    ui.error('an error');
 
     expect(customLog).not.toHaveBeenCalled();
     expect(logSpy).not.toHaveBeenCalled();
-    expect(warnSpy).not.toHaveBeenCalled();
-    expect(errSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled(); // ui logger has no warn -> console.warn
+    expect(errSpy).toHaveBeenCalled(); // ui logger has no error -> console.error
   });
 
-  it('returns no-op functions even when server logger is provided and enableDebug is false', () => {
+  it('R0-03: with a server logger and enableDebug false, warn/error reach the server logger; log stays silent', () => {
     const info = vi.fn();
     const warn = vi.fn();
     const error = vi.fn();
@@ -58,13 +58,13 @@ describe('createUILogger - enableDebug gate', () => {
     const server: ServerLogs = { info, warn, error };
     const ui = createUILogger(server, { enableDebug: false });
 
-    ui.log('hidden');
-    ui.warn('hidden');
-    ui.error('hidden');
+    ui.log('debug only');
+    ui.warn('a warning');
+    ui.error('an error');
 
-    expect(info).not.toHaveBeenCalled();
-    expect(warn).not.toHaveBeenCalled();
-    expect(error).not.toHaveBeenCalled();
+    expect(info).not.toHaveBeenCalled(); // `log` channel gated
+    expect(warn).toHaveBeenCalled(); // warn routes to the provided logger
+    expect(error).toHaveBeenCalled(); // error routes to the provided logger
   });
 
   it('enables logging when enableDebug is true', () => {
@@ -550,13 +550,13 @@ describe('createVueErrorHandler', () => {
     expect(error).toHaveBeenCalledWith('Vue error', expect.objectContaining({ component: undefined }));
   });
 
-  it('is a no-op when debug is disabled (default) — nothing logged', () => {
+  it('R0-03: reports errors even when debug is disabled (default) — error visibility is not gated', () => {
     const error = vi.fn();
     const handler = createVueErrorHandler({ error }); // enableDebug defaults to false
 
     handler(new Error('x'), { type: { name: 'C' } }, 'render');
 
-    expect(error).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith('Vue error', expect.objectContaining({ info: 'render', component: 'C' }));
   });
 
   it('handles a nullish instance without throwing', () => {

--- a/packages/vue/src/utils/test/Logger.test.ts
+++ b/packages/vue/src/utils/test/Logger.test.ts
@@ -77,6 +77,69 @@ describe('createUILogger - enableDebug gate', () => {
   });
 });
 
+describe('createUILogger — non-throwing on hostile values (gate finding 2)', () => {
+  const circular: Record<string, unknown> = {};
+  circular.self = circular;
+
+  const hostileToJSON = {
+    toJSON() {
+      throw new Error('toJSON boom');
+    },
+  };
+  const hostileCoercion = {
+    [Symbol.toPrimitive]() {
+      throw new Error('coercion boom');
+    },
+    toString() {
+      throw new Error('coercion boom');
+    },
+  };
+
+  const values: ReadonlyArray<readonly [string, unknown]> = [
+    ['BigInt', 1n],
+    ['circular', circular],
+    ['symbol', Symbol('s')],
+    ['throwing toJSON', hostileToJSON],
+    ['throwing Symbol.toPrimitive', hostileCoercion],
+  ];
+
+  for (const [name, v] of values) {
+    it(`server-shaped logger: error(${name}) does not throw (formatting is isolated)`, () => {
+      const server: ServerLogs = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      const ui = createUILogger(server, { enableDebug: false });
+
+      expect(() => ui.error('boom', v)).not.toThrow();
+      expect(() => ui.warn('boom', v)).not.toThrow();
+    });
+  }
+
+  it('isolates a server logger method that itself throws', () => {
+    const server: ServerLogs = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(() => {
+        throw new Error('logger.error boom');
+      }),
+    };
+    const ui = createUILogger(server, { enableDebug: false });
+
+    expect(() => ui.error('anything')).not.toThrow();
+  });
+
+  it('isolates a UI-shaped logger method that itself throws', () => {
+    const ui = createUILogger(
+      {
+        error: () => {
+          throw new Error('ui.error boom');
+        },
+      },
+      { enableDebug: false },
+    );
+
+    expect(() => ui.error('anything')).not.toThrow();
+  });
+});
+
 describe('createUILogger - UI-logger-shaped input', () => {
   it('uses provided UI methods and falls back to console for missing ones; forwards raw args', () => {
     const { warnSpy, errSpy } = mkSpies();

--- a/packages/vue/src/utils/test/Streaming.crash.test.ts
+++ b/packages/vue/src/utils/test/Streaming.crash.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment node
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { PassThrough } from 'node:stream';
+import { fileURLToPath } from 'node:url';
+
+import ts from 'typescript';
+import { describe, it, expect } from 'vitest';
+
+import { createStreamController } from '../Streaming';
+
+// R0-01 — crash-safe `done` (vue drift-copy of react's crash regression; `utils/Streaming.ts`
+// is byte-identical across both packages — see UtilsDrift.test.ts).
+//
+// Every in-process streaming test AWAITS `done`, which is exactly why the unobserved-rejection
+// crash was invisible to the suite. An in-process `process.on('unhandledRejection')` listener
+// would itself change Node's default behaviour, so the crash is proven in a real CHILD process
+// under DEFAULT flags — Node's default (crash) mode applies.
+//
+// The child runs the REAL `Streaming.ts`, transpiled to plain JS at test time (via the
+// TypeScript compiler, a devDependency) and executed with `node --input-type=module -e`. This
+// keeps the guard portable to EVERY supported Node (`engines.node` is `>=20.11`, `.nvmrc` is
+// `22.17.0`) instead of relying on native `.ts` execution (Node >= 22.18 only) — while still
+// exercising the actual source, so reverting the `settle.done.catch(...)` fix fails this test.
+function buildChildScript(): string {
+  const streamingTs = fileURLToPath(new URL('../Streaming.ts', import.meta.url));
+  const transpiled = ts.transpileModule(readFileSync(streamingTs, 'utf8'), {
+    compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2022 },
+  }).outputText;
+
+  return [
+    `import { PassThrough } from 'node:stream';`,
+    transpiled,
+    `const noop = () => {};`,
+    `const controller = createStreamController(new PassThrough(), { log: noop, warn: noop, error: noop });`,
+    // Stands in for any fatal stream error (a non-benign writable error, `onShellError`, or the
+    // first-content watchdog) — all route through `fatalAbort` -> `settle.reject`. `done` is
+    // never observed here, exactly as the server call site did before R0-01.
+    `controller.fatalAbort(new Error('R0-01 fatal-boom'));`,
+    `setTimeout(() => { console.log('SURVIVED'); process.exit(0); }, 150);`,
+  ].join('\n');
+}
+
+describe('R0-01 crash-safe done', () => {
+  it('does not crash the process when a fatal abort rejects an unobserved `done` (child process, default rejection mode)', () => {
+    let status = 0;
+    let stdout = '';
+    try {
+      stdout = execFileSync(process.execPath, ['--input-type=module', '-e', buildChildScript()], { encoding: 'utf8' });
+    } catch (err) {
+      status = (err as { status?: number | null }).status ?? 1;
+      stdout = String((err as { stdout?: unknown }).stdout ?? '');
+    }
+
+    expect(status).toBe(0);
+    expect(stdout).toContain('SURVIVED');
+  });
+
+  it('still rejects `done` for consumers who await it', async () => {
+    const noop = () => {};
+    const controller = createStreamController(new PassThrough(), { log: noop, warn: noop, error: noop });
+
+    controller.fatalAbort(new Error('R0-01 fatal-boom'));
+
+    await expect(controller.done).rejects.toThrow('R0-01 fatal-boom');
+  });
+});

--- a/packages/vue/src/utils/test/Streaming.test.ts
+++ b/packages/vue/src/utils/test/Streaming.test.ts
@@ -1,14 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import {
-  DEFAULT_BENIGN_ERRORS,
-  isBenignStreamErr,
-  createSettler,
-  startShellTimer,
-  wireWritableGuards,
-  createStreamController,
-  type StreamLogger,
-} from '../Streaming';
+import { isBenignStreamErr, createSettler, startShellTimer, wireWritableGuards, createStreamController, type StreamLogger } from '../Streaming';
 
 function makeWritableMock() {
   const events = new Map<string, Set<Function>>();
@@ -92,19 +84,46 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe('isBenignStreamErr / DEFAULT_BENIGN_ERRORS', () => {
-  it('matches known benign patterns', () => {
-    const msgs = ['ECONNRESET', 'EPIPE', 'socket hang up', 'aborted', 'premature close'];
-    for (const m of msgs) {
-      expect(DEFAULT_BENIGN_ERRORS.test(m)).toBe(true);
-      expect(isBenignStreamErr(new Error(m))).toBe(true);
+describe('isBenignStreamErr (origin-aware, R0-02)', () => {
+  it('render-origin errors are NEVER benign, whatever their shape', () => {
+    expect(isBenignStreamErr(new Error('Payment aborted unexpectedly'), 'render')).toBe(false);
+    expect(isBenignStreamErr(Object.assign(new Error('x'), { code: 'EPIPE' }), 'render')).toBe(false);
+    expect(isBenignStreamErr(Object.assign(new Error('x'), { name: 'AbortError' }), 'render')).toBe(false);
+    expect(isBenignStreamErr(new Error('aborted'), 'render')).toBe(false);
+  });
+
+  it('socket-origin: benign by exact (case-insensitive, trimmed) message', () => {
+    for (const m of ['aborted', 'socket hang up', 'premature close', 'request aborted', '  ABORTED  ']) {
+      expect(isBenignStreamErr(new Error(m), 'socket')).toBe(true);
     }
   });
 
-  it('non-matching errors are not benign', () => {
-    expect(isBenignStreamErr(new Error('boom'))).toBe(false);
-    expect(isBenignStreamErr({ message: 'other' })).toBe(false);
-    expect(isBenignStreamErr({})).toBe(false);
+  it('socket-origin: a message that merely CONTAINS a benign word is not benign', () => {
+    expect(isBenignStreamErr(new Error('Payment aborted unexpectedly'), 'socket')).toBe(false);
+    expect(isBenignStreamErr(new Error('stream premature something'), 'socket')).toBe(false);
+    // legacy substrings that used to match the retired regex now do not
+    expect(isBenignStreamErr(new Error('ECONNRESET'), 'socket')).toBe(false);
+    expect(isBenignStreamErr(new Error('EPIPE'), 'socket')).toBe(false);
+  });
+
+  it('socket-origin: benign by disconnect code', () => {
+    for (const code of ['ECONNRESET', 'EPIPE', 'ERR_STREAM_PREMATURE_CLOSE', 'ERR_STREAM_DESTROYED']) {
+      expect(isBenignStreamErr(Object.assign(new Error('whatever'), { code }), 'socket')).toBe(true);
+    }
+    expect(isBenignStreamErr(Object.assign(new Error('x'), { code: 'ENOENT' }), 'socket')).toBe(false);
+  });
+
+  it('socket-origin: benign by AbortError name', () => {
+    expect(isBenignStreamErr(Object.assign(new Error('x'), { name: 'AbortError' }), 'socket')).toBe(true);
+    expect(isBenignStreamErr(new DOMException('', 'AbortError'), 'socket')).toBe(true);
+  });
+
+  it('non-Error values are not benign and do not throw', () => {
+    expect(isBenignStreamErr(undefined, 'socket')).toBe(false);
+    expect(isBenignStreamErr(null, 'socket')).toBe(false);
+    expect(isBenignStreamErr({}, 'socket')).toBe(false);
+    expect(isBenignStreamErr('aborted', 'socket')).toBe(false); // raw string has no `.message`
+    expect(isBenignStreamErr(undefined, 'render')).toBe(false);
   });
 });
 

--- a/packages/vue/src/utils/test/Streaming.test.ts
+++ b/packages/vue/src/utils/test/Streaming.test.ts
@@ -496,4 +496,36 @@ describe('createStreamController', () => {
     expect(warn).not.toHaveBeenCalled();
     expect(error).not.toHaveBeenCalled();
   });
+
+  it('gate finding 2: fatalAbort still cleans up and rejects done when the logger throws', async () => {
+    const w = makeWritableMock();
+    const throwingLogger: StreamLogger = {
+      warn: vi.fn(),
+      error: () => {
+        throw new Error('logger boom');
+      },
+    };
+    const c = createStreamController(w, throwingLogger);
+
+    c.fatalAbort(new Error('fatal'));
+
+    await expect(c.done).rejects.toThrow('fatal');
+    expect(w.destroyed).toBe(true); // cleanup ran despite the logger throwing
+  });
+
+  it('gate finding 2: benignAbort still cleans up and resolves done when the logger throws', async () => {
+    const w = makeWritableMock();
+    const throwingLogger: StreamLogger = {
+      warn: () => {
+        throw new Error('logger boom');
+      },
+      error: vi.fn(),
+    };
+    const c = createStreamController(w, throwingLogger);
+
+    c.benignAbort('client gone');
+
+    await expect(c.done).resolves.toBeUndefined();
+    expect(w.destroyed).toBe(true);
+  });
 });

--- a/packages/vue/src/utils/test/UtilsDrift.test.ts
+++ b/packages/vue/src/utils/test/UtilsDrift.test.ts
@@ -13,10 +13,16 @@ const vueStreaming = read('../Streaming.ts');
 const reactStreaming = read('../../../../react/src/utils/Streaming.ts');
 const vueLogger = read('../Logger.ts');
 const reactLogger = read('../../../../react/src/utils/Logger.ts');
+const vueHtml = read('../Html.ts');
+const reactHtml = read('../../../../react/src/utils/Html.ts');
 
 describe('utils upstream-sync drift guard', () => {
   it('Streaming.ts is byte-identical to @taujs/react/src/utils/Streaming.ts', () => {
     expect(vueStreaming).toBe(reactStreaming);
+  });
+
+  it('Html.ts is byte-identical to @taujs/react/src/utils/Html.ts (R2-02)', () => {
+    expect(vueHtml).toBe(reactHtml);
   });
 
   it('Logger.ts equals react/src/utils/Logger.ts plus only the appended createVueErrorHandler block', () => {

--- a/packages/vue/tsup.config.ts
+++ b/packages/vue/tsup.config.ts
@@ -1,9 +1,18 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
+  // R3-05 (Q6, signed 2026-07-12): `bundle: false` preserves the source module graph in dist.
+  // For vue this is STRUCTURAL HARDENING, not a defect fix — `@vue/server-renderer`'s import
+  // condition is pure ESM and already tree-shakes to ~0 bytes in client bundles; the unbundled
+  // graph removes the latent dependence on that build STAYING tree-shakeable and keeps both
+  // renderers' toolchain shape identical (react is the defect case — see its tsup config).
+  // Same load-bearing details as react: every module must be an entry (`bundle: false` does not
+  // follow the import graph), and relative specifiers must carry explicit `.js` extensions
+  // (guards: `SpecifierExtensions.test.ts`, `ClientBundle.test.ts`).
+  bundle: false,
   clean: true,
   dts: true,
-  entryPoints: ['src/index.ts', 'src/plugin.ts'],
+  entryPoints: ['src/**/*.ts', '!src/**/test/**', '!src/**/*.d.ts'],
   external: ['vue', '@vue/server-renderer', 'vite', '@vitejs/plugin-vue'],
   format: ['esm'],
   outDir: 'dist',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,9 @@ importers:
       '@babel/preset-typescript':
         specifier: ^7.24.7
         version: 7.29.7(@babel/core@7.29.7)
+      '@taujs/server':
+        specifier: workspace:*
+        version: link:../server
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,7 +163,7 @@ importers:
   packages/react:
     dependencies:
       '@vitejs/plugin-react':
-        specifier: ^5.1.2
+        specifier: ^4.6.0 || ^5.0.0
         version: 5.2.0(vite@7.3.6(@types/node@24.13.3)(tsx@4.23.0))
     devDependencies:
       '@arethetypeswrong/cli':

--- a/website/src/content/docs/guides/head-management.md
+++ b/website/src/content/docs/guides/head-management.md
@@ -5,6 +5,14 @@ description: How τjs manages document head content
 
 τjs provides flexible document `<head>` management through a `headContent` function defined in your `entry-server.tsx`.
 
+:::caution[headContent is a raw-HTML sink]
+Whatever `headContent` returns is written into `<head>` **verbatim** - it is not auto-escaped. Escape
+every value you interpolate that could carry service data, user input, or other untrusted content
+(from **either** `data` **or** `meta` - route meta is often built from application data too). Use the
+`escapeHtml` helper exported by `@taujs/react` / `@taujs/vue` for HTML text and quoted attributes; see
+[Escape User Content](#3-escape-user-content) for the important exceptions (JSON-LD / `<script>`, URLs).
+:::
+
 ## Composition Order
 
 τjs assembles the document head in a fixed, intentional order:
@@ -43,18 +51,18 @@ This separation ensures:
 
 ```typescript
 // entry-server.tsx
-import { createRenderer } from "@taujs/react";
+import { createRenderer, escapeHtml } from "@taujs/react";
 import { App } from "./App";
 
 export const { renderSSR, renderStream } = createRenderer({
   appComponent: ({ location }) => <App location={location} />,
   headContent: ({ data, meta }) => `
-    <title>${meta?.title || "τjs - Composing systems, not just apps"}</title>
-    <meta name="description" content="${
+    <title>${escapeHtml(meta?.title || "τjs - Composing systems, not just apps")}</title>
+    <meta name="description" content="${escapeHtml(
       meta?.description ||
-      data?.message ||
-      "τjs - Composing systems, not just apps"
-    }">
+        data?.message ||
+        "τjs - Composing systems, not just apps",
+    )}">
   `,
 });
 ```
@@ -109,8 +117,8 @@ Data is **always fully resolved** before `headContent` runs:
 
 ```typescript
 headContent: ({ data, meta }) => `
-  <title>${meta?.title || "Products"}</title>
-  <meta name="description" content="${data.product.description}">
+  <title>${escapeHtml(meta?.title || "Products")}</title>
+  <meta name="description" content="${escapeHtml(data.product.description)}">
 `;
 ```
 
@@ -122,10 +130,12 @@ Data may not be ready when `headContent` runs. Use `meta` for reliable SEO:
 headContent: ({ data, meta }) => {
   // Use meta for guaranteed values
   return `
-    <title>${meta?.title || "Streaming page"}</title>
-    <meta name="description" content="${meta.description}">
+    <title>${escapeHtml(meta?.title || "Streaming page")}</title>
+    <meta name="description" content="${escapeHtml(meta.description)}">
     ${
-      data.ogImage ? `<meta property="og:image" content="${data.ogImage}">` : ""
+      data.ogImage
+        ? `<meta property="og:image" content="${escapeHtml(data.ogImage)}">`
+        : ""
     }
   `;
 };
@@ -136,6 +146,8 @@ headContent: ({ data, meta }) => {
 
 ## Common Patterns
 
+Each interpolated value below is passed through `escapeHtml` at the point it enters the HTML string.
+
 ### Open Graph Tags
 
 ```typescript
@@ -145,27 +157,35 @@ headContent: ({ data, meta }) => {
   const image = data?.ogImage || meta?.ogImage;
 
   return `
-    <title>${title}</title>
-    <meta property="og:title" content="${title}">
-    <meta property="og:description" content="${description}">
-    ${image ? `<meta property="og:image" content="${image}">` : ""}
+    <title>${escapeHtml(title)}</title>
+    <meta property="og:title" content="${escapeHtml(title)}">
+    <meta property="og:description" content="${escapeHtml(description)}">
+    ${image ? `<meta property="og:image" content="${escapeHtml(image)}">` : ""}
   `;
 };
 ```
 
 ### Structured Data (JSON-LD)
 
+JSON-LD is written into `<script>` **raw text**, which is a different context from HTML - HTML
+character references are _not_ decoded there, so `escapeHtml` is the wrong tool and would corrupt the
+JSON. `JSON.stringify` alone is **not** safe either: a value containing `</script>` closes the element
+and lets the rest parse as markup. Escape `<` as the JSON unicode escape so the tag can never be
+closed from inside the data:
+
 ```typescript
+// `<` -> `\u003c` keeps valid JSON but prevents `</script>` breakout.
+const jsonForScript = (value: unknown) =>
+  JSON.stringify(value).replace(/</g, "\\u003c");
+
 headContent: ({ data, meta }) => {
   const jsonLd = data?.jsonLd || meta?.jsonLd;
 
   return `
-    <title>${meta?.title || "Page"}</title>
+    <title>${escapeHtml(meta?.title || "Page")}</title>
     ${
       jsonLd
-        ? `<script type="application/ld+json">${JSON.stringify(
-            jsonLd
-          )}</script>`
+        ? `<script type="application/ld+json">${jsonForScript(jsonLd)}</script>`
         : ""
     }
   `;
@@ -181,11 +201,19 @@ headContent: ({ data, meta }) => {
   const canonical = data.canonical || meta.canonical;
 
   return `
-    <title>${meta.title}</title>
-    ${canonical ? `<link rel="canonical" href="${canonical}">` : ""}
+    <title>${escapeHtml(meta.title)}</title>
+    ${
+      canonical
+        ? `<link rel="canonical" href="${escapeHtml(canonical)}">`
+        : ""
+    }
   `;
 };
 ```
+
+> `escapeHtml` stops a URL from breaking out of the `href` attribute, but it does **not** validate the
+> scheme. If the URL is user-influenced, also reject/allow-list schemes (e.g. permit only
+> `https:`/`http:`) so you don't emit `javascript:` or `data:` links.
 
 ## Best Practices
 
@@ -196,10 +224,10 @@ import { escapeHtml } from "@taujs/react"; // or "@taujs/vue"
 
 // reliable in streaming
 headContent: ({ data, meta }) => `
-  <title>${meta?.title || "Default Title"}</title>
-  <meta name="description" content="${
-    meta?.description || "Default description"
-  }">
+  <title>${escapeHtml(meta?.title || "Default Title")}</title>
+  <meta name="description" content="${escapeHtml(
+    meta?.description || "Default description",
+  )}">
   ${
     data?.ogImage
       ? `<meta property="og:image" content="${escapeHtml(data.ogImage)}">`
@@ -207,8 +235,6 @@ headContent: ({ data, meta }) => `
   }
 `;
 ```
-
-> `headContent` returns **raw** HTML — escape any interpolated `data` (see [Escape User Content](#3-escape-user-content) below).
 
 ### 2. Provide Fallbacks
 
@@ -218,23 +244,33 @@ const title = data.title || meta.title || "Default Title";
 
 ### 3. Escape User Content
 
-`headContent` returns **raw HTML** written verbatim into `<head>`, so any value drawn from services
-or user input must be escaped before you interpolate it. Both renderers export an `escapeHtml` helper
-— text- and attribute-safe, including single quotes:
+`headContent` returns **raw HTML** written verbatim into `<head>`, so any value that could carry
+service data or user input - from **`data` or `meta`** - must be escaped at the point it enters the
+string. Escape by output **context**, not by property name:
+
+- **HTML text and quoted attributes** → `escapeHtml` (exported by both renderers; escapes
+  `& < > " '`, so it is safe in single- and double-quoted attributes):
+
+  ```typescript
+  import { escapeHtml } from "@taujs/react"; // or "@taujs/vue"
+
+  headContent: ({ data }) => `
+    <meta property="og:image" content="${escapeHtml(data.ogImage)}">
+  `;
+  ```
+
+- **`<script>` / JSON-LD data** → not `escapeHtml`; escape `<` as `\u003c` in the serialised JSON
+  (see [Structured Data](#structured-data-json-ld)).
+- **URL attributes** → `escapeHtml` prevents attribute breakout but does not validate the scheme;
+  allow-list schemes separately for user-influenced URLs.
+
+`escapeHtml` accepts any value (`String()`-coerced) and is not idempotent - escape each value exactly
+once. If you can't import it, roll your own - but escape `'` too, or single-quoted attributes stay
+vulnerable:
 
 ```typescript
-import { escapeHtml } from "@taujs/react"; // or "@taujs/vue"
-
-headContent: ({ data }) => `
-  <meta property="og:image" content="${escapeHtml(data.ogImage)}">
-`;
-```
-
-Or roll your own — but escape `'` too, or single-quoted attributes stay vulnerable:
-
-```typescript
-function escapeHtml(str: string): string {
-  return String(str)
+function escapeHtml(value: unknown): string {
+  return String(value)
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")

--- a/website/src/content/docs/guides/head-management.md
+++ b/website/src/content/docs/guides/head-management.md
@@ -192,15 +192,23 @@ headContent: ({ data, meta }) => {
 ### 1. Prioritise Meta Over Data in Streaming
 
 ```typescript
+import { escapeHtml } from "@taujs/react"; // or "@taujs/vue"
+
 // reliable in streaming
 headContent: ({ data, meta }) => `
   <title>${meta?.title || "Default Title"}</title>
   <meta name="description" content="${
     meta?.description || "Default description"
   }">
-  ${data?.ogImage ? `<meta property="og:image" content="${data.ogImage}">` : ""}
+  ${
+    data?.ogImage
+      ? `<meta property="og:image" content="${escapeHtml(data.ogImage)}">`
+      : ""
+  }
 `;
 ```
+
+> `headContent` returns **raw** HTML — escape any interpolated `data` (see [Escape User Content](#3-escape-user-content) below).
 
 ### 2. Provide Fallbacks
 
@@ -210,13 +218,28 @@ const title = data.title || meta.title || "Default Title";
 
 ### 3. Escape User Content
 
+`headContent` returns **raw HTML** written verbatim into `<head>`, so any value drawn from services
+or user input must be escaped before you interpolate it. Both renderers export an `escapeHtml` helper
+— text- and attribute-safe, including single quotes:
+
+```typescript
+import { escapeHtml } from "@taujs/react"; // or "@taujs/vue"
+
+headContent: ({ data }) => `
+  <meta property="og:image" content="${escapeHtml(data.ogImage)}">
+`;
+```
+
+Or roll your own — but escape `'` too, or single-quoted attributes stay vulnerable:
+
 ```typescript
 function escapeHtml(str: string): string {
-  return str
+  return String(str)
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 ```
 

--- a/website/src/content/docs/reference/taujs-config.md
+++ b/website/src/content/docs/reference/taujs-config.md
@@ -241,6 +241,15 @@ Complete HTML rendered before sending:
 - Complete HTML in single response
 - Guaranteed data in `headContent`
 
+**React renderer semantics (`@taujs/react`):** the `ssr` strategy renders complete HTML with
+React's `prerenderToNodeStream`, so `React.lazy` and `use()` content is included in the response.
+Earlier versions used `renderToString`, which silently replaced any suspending subtree with its
+Suspense fallback. The render is bounded by the renderer's `ssrOptions.prerenderTimeoutMs`
+(default 10000 ms). On expiry, a page whose shell completed is served with its unfinished
+Suspense boundaries in their fallback state - the client completes them after hydration - while a
+page whose shell never completed fails the request instead of serving a blank page. Set
+`prerenderTimeoutMs: 0` to wait indefinitely.
+
 ### Streaming SSR
 
 Progressive HTML delivery:

--- a/website/src/content/docs/renderers/react.mdx
+++ b/website/src/content/docs/renderers/react.mdx
@@ -487,9 +487,10 @@ hydrateApp({
 - Callbacks are isolated: a throwing `onStart`/`onSuccess`/`onHydrationError` is logged and can
   neither break hydration nor tear down the committed tree
 - Recoverable hydration mismatches (React repairs the DOM and continues) and errors caught by your
-  own error boundaries are logged as warnings only - they settle NEITHER callback. Settlement is
-  reserved for the first root commit (`onSuccess`) vs the first uncaught client render error
-  (`onHydrationError`), exactly one of which fires per `hydrateApp` call
+  own error boundaries are logged only - caught errors at error level, recoverable mismatches at
+  warning level - and settle NEITHER callback. Settlement is reserved for the first root commit
+  (`onSuccess`) vs the first uncaught client render error (`onHydrationError`), exactly one of
+  which fires per `hydrateApp` call
 - Uncaught render errors still surface to global monitoring (`window` `error` /
   `reportError`) in addition to `onHydrationError`
 - Automatically handles `DOMContentLoaded` timing
@@ -991,7 +992,7 @@ export const { renderSSR, renderStream } = createRenderer<
 ### With Express
 
 ```typescript
-// server.ts
+// server.tsx
 import express from "express";
 import { createRenderer, escapeHtml } from "@taujs/react";
 import { App } from "./App";
@@ -1065,7 +1066,7 @@ app.listen(3000, () => {
 ### With Native Node.js HTTP
 
 ```typescript
-// server.ts
+// server.tsx
 import http from "node:http";
 import { createRenderer, escapeHtml } from "@taujs/react";
 import { App } from "./App";
@@ -1116,7 +1117,7 @@ server.listen(3000);
 ### With Hono
 
 ```typescript
-// server.ts
+// server.tsx
 import { Hono } from "hono";
 import { createRenderer, escapeHtml } from "@taujs/react";
 import { streamSSR } from "hono/streaming";
@@ -1172,7 +1173,7 @@ For simpler cases where you want complete HTML in a single response. NB `renderS
 `ssrOptions.prerenderTimeoutMs`) - it requires a Node runtime:
 
 ```typescript
-// server.ts
+// server.tsx
 import { createRenderer, escapeHtml } from "@taujs/react";
 import { App } from "./App";
 
@@ -2252,7 +2253,7 @@ await createServer({ fastify, config, serviceRegistry, clientRoot });
 **What you get:**
 
 - Direct control over rendering process
-- Framework/runtime agnostic
+- Framework agnostic on Node
 - Minimal abstraction
 - Explicit SSR and hydration APIs
 

--- a/website/src/content/docs/renderers/react.mdx
+++ b/website/src/content/docs/renderers/react.mdx
@@ -9,7 +9,7 @@ import { LinkButton } from "@astrojs/starlight/components";
 
 **React SSR (Server-Side Rendering) with Streaming Support**
 
-A lightweight, React SSR library with streaming capabilities, built for modern TypeScript applications. Designed as part of the taujs (τjs) ecosystem but fully standalone and runtime-agnostic.
+A lightweight, React SSR library with streaming capabilities, built for modern TypeScript applications. Designed as part of the taujs (τjs) ecosystem but fully standalone and framework-agnostic: bring any Node HTTP server (the server render paths need Node; the client surface is browser-only).
 
 <LinkButton
   href="https://github.com/aoede3/taujs-react"
@@ -49,7 +49,7 @@ A lightweight, React SSR library with streaming capabilities, built for modern T
 - **Type-safe data stores** using React hooks
 - **Robust error handling** for production environments
 - **Flexible logging** for debugging and monitoring
-- **Runtime agnostic** - works with Node.js, Fastify, Express, or any HTTP server
+- **Framework agnostic** - works with Fastify, Express, native `node:http` or any Node HTTP server (both server render paths require Node capabilities)
 
 ---
 
@@ -433,7 +433,7 @@ hydrateApp({
     console.error("Hydration failed:", err);
   },
   onSuccess: () => {
-    console.log("App hydrated successfully!");
+    console.log("App root committed");
   },
 });
 ```
@@ -464,14 +464,15 @@ hydrateApp({
   dataKey: "__INITIAL_DATA__",
   enableDebug: process.env.NODE_ENV === "development",
   onHydrationError: (err) => {
-    console.error("Hydration failed, falling back to CSR:", err);
+    console.error("Client render failed:", err);
     // Optionally report to error tracking service
   },
   onStart: () => {
     console.log("Starting hydration...");
   },
   onSuccess: () => {
-    console.log("Hydration complete!");
+    // First root commit - fires on the hydrate AND CSR-fallback paths
+    console.log("App root committed");
     // Initialise client-side only features
     initialiseAnalytics();
   },
@@ -485,6 +486,10 @@ hydrateApp({
 - If the root element is missing: reports through `onHydrationError` (nothing is mounted)
 - Callbacks are isolated: a throwing `onStart`/`onSuccess`/`onHydrationError` is logged and can
   neither break hydration nor tear down the committed tree
+- Recoverable hydration mismatches (React repairs the DOM and continues) and errors caught by your
+  own error boundaries are logged as warnings only - they settle NEITHER callback. Settlement is
+  reserved for the first root commit (`onSuccess`) vs the first uncaught client render error
+  (`onHydrationError`), exactly one of which fires per `hydrateApp` call
 - Uncaught render errors still surface to global monitoring (`window` `error` /
   `reportError`) in addition to `onHydrationError`
 - Automatically handles `DOMContentLoaded` timing
@@ -1176,33 +1181,33 @@ const { renderSSR } = createRenderer({
   headContent: ({ data }) => `<title>${escapeHtml(data.pageTitle)}</title>`,
 });
 
-export default {
-  async fetch(request: Request): Promise<Response> {
-    const url = new URL(request.url);
-    const data = { pageTitle: "Home", content: "Hello World" };
+import http from "node:http";
 
-    const { headContent, appHtml } = await renderSSR(data, url.pathname);
+const server = http.createServer(async (req, res) => {
+  const data = { pageTitle: "Home", content: "Hello World" };
 
-    const html = `
-      <!DOCTYPE html>
-      <html>
-        <head>
-          <meta charset="UTF-8">
-          ${headContent}
-          <script>window.__INITIAL_DATA__=${JSON.stringify(data).replace(/</g, "\\u003c")};</script>
-        </head>
-        <body>
-          <div id="root">${appHtml}</div>
-          <script type="module" src="/assets/client.js"></script>
-        </body>
-      </html>
-    `;
+  const { headContent, appHtml } = await renderSSR(data, req.url || "/");
 
-    return new Response(html, {
-      headers: { "Content-Type": "text/html; charset=utf-8" },
-    });
-  },
-};
+  const html = `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta charset="UTF-8">
+        ${headContent}
+        <script>window.__INITIAL_DATA__=${JSON.stringify(data).replace(/</g, "\\u003c")};</script>
+      </head>
+      <body>
+        <div id="root">${appHtml}</div>
+        <script type="module" src="/assets/client.js"></script>
+      </body>
+    </html>
+  `;
+
+  res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+  res.end(html);
+});
+
+server.listen(3000);
 ```
 
 ---
@@ -2155,17 +2160,18 @@ const { renderStream } = createRenderer({
 });
 ```
 
-### 7. Implement Proper CSR Fallback
+### 7. Observe Client Render Failures
 
-Always handle the case where SSR data isn't available:
+The CSR fallback (missing `window.__INITIAL_DATA__`) is automatic. `onHydrationError` OBSERVES
+client render failures - it does not trigger a fallback:
 
 ```typescript
 // client.ts
 hydrateApp({
   appComponent: <App />,
   onHydrationError: (err) => {
-    // Log error but don't crash
-    console.error("Hydration failed, falling back to CSR", err);
+    // Log/report the failure - nothing is remounted on your behalf
+    console.error("Client render failed", err);
   },
 });
 ```

--- a/website/src/content/docs/renderers/react.mdx
+++ b/website/src/content/docs/renderers/react.mdx
@@ -33,7 +33,7 @@ A lightweight, React SSR library with streaming capabilities, built for modern T
   - [Vite Plugin](#vite-plugin)
 - [Usage in taujs Ecosystem](#usage-in-taujs-ecosystem)
 - [Standalone Usage](#standalone-usage)
-- [Advanced Examples](#advanced-examples)
+- [Advanced Patterns](#advanced-patterns)
 - [TypeScript Support](#typescript-support)
 - [Best Practices](#best-practices)
 
@@ -43,7 +43,7 @@ A lightweight, React SSR library with streaming capabilities, built for modern T
 
 `@taujs/react` provides:
 
-- **Streaming SSR** with React 18+ `renderToPipeableStream`
+- **Streaming SSR** with React 19 `renderToPipeableStream`
 - **Static SSR** with `prerenderToNodeStream` - complete HTML including `React.lazy`/`use()` content, bounded by a configurable render deadline
 - **Automatic hydration** with built-in data synchronisation
 - **Type-safe data stores** using React hooks
@@ -85,7 +85,7 @@ The `createRenderer` function creates a reusable renderer with your app componen
 ```typescript
 const { renderSSR, renderStream } = createRenderer({
   appComponent: ({ location }) => <App location={location} />,
-  headContent: ({ data, meta }) => `<title>${data.title}</title>`,
+  headContent: ({ data, meta }) => `<title>${escapeHtml(data.title)}</title>`,
   streamOptions: { shellTimeoutMs: 10000 },
 });
 ```
@@ -147,16 +147,22 @@ function createRenderer<
 
 > `bootstrapModules`: URL to your client entry module. `@taujs/react` forwards it to React as a single-item `bootstrapModules` array.
 
+> `done` resolves on completion or benign cancellation and REJECTS on a fatal stream error. The rejection is pre-observed inside the renderer, so ignoring `done` can never crash your process with an unhandled rejection - but if you `await` it, handle the rejection.
+
 `routeContext` is optional / advanced. See Advanced Patterns
 
 **Parameters:**
 
 - `appComponent`: Function that returns your root React component, receives `{ location: string; routeContext?: R }`
-- `headContent`: Function that generates HTML head content, receives `{ data: T, meta: Record<string, unknown>, routeContext?: R }`. **Note:** In streaming mode, `data` may not be resolved when shell is ready - guard optional fields or rely on `meta`.
-- `enableDebug`: Enable detailed logging (default: `false`)
+- `headContent`: Function that generates HTML head content, receives `{ data: T, meta: Record<string, unknown>, routeContext?: R }`. **Note:** In streaming mode, `data` may not be resolved when shell is ready - guard optional fields or rely on `meta`. **Security:** the return value is written into `<head>` verbatim as raw HTML - escape every value derived from data or user input with `escapeHtml` (exported from `@taujs/react`; see the [head management guide](/guides/head-management/)).
+- `enableDebug`: Enable detailed debug logging (default: `false`). `warn` and `error` always reach your logger (or the console) regardless - only debug-level logging is gated.
 - `logger`: Custom logger implementation
 - `streamOptions`: Streaming configuration
-  - `shellTimeoutMs`: Timeout for initial shell render (default: `10000`)
+  - `shellTimeoutMs`: Timeout for the initial shell render (default: `10000`)
+  - `dataTimeoutMs`: Timeout for route data to settle after React has finished rendering (default: `30000`). Bounds the stream so a never-settling loader cannot hold the response open indefinitely.
+- `ssrOptions`: Static SSR configuration
+  - `prerenderTimeoutMs`: Deadline for the `ssr` strategy's complete-HTML render (default: `10000`; `0` or `Infinity` = wait forever; anything else must be a positive finite number or `createRenderer` throws). See `renderSSR()` for the expiry behaviour.
+- `identifierPrefix`: React's `useId` prefix, passed to both rendering paths. Must match the value passed to `hydrateApp` for the same root. Set it when rendering more than one taujs root on a page so `useId` values are collision-free.
 
 **Returns:**
 
@@ -171,6 +177,8 @@ Both methods accept a final `opts` argument:
 
 - `logger`: Optional per-call logger (overrides the one passed to `createRenderer`)
 - `routeContext`: Per-request route context value forwarded into `appComponent` and `headContent`.
+- `renderStream` only: any `StreamOptions` field (`shellTimeoutMs`, `dataTimeoutMs`) may also be
+  overridden per call.
 
 ---
 
@@ -215,7 +223,7 @@ const { renderSSR, renderStream } = createRenderer<PageData, RouteContext>({
         ? " · Home"
         : "";
 
-    return `<title>${baseTitle}${suffix}</title>`;
+    return `<title>${escapeHtml(baseTitle)}${suffix}</title>`;
   },
 });
 ```
@@ -262,12 +270,26 @@ See Per-call options for opts.
 
 Renders the complete application to a string (static SSR).
 
+Uses React's `prerenderToNodeStream`, so the result is COMPLETE HTML: `React.lazy`, `use()` and
+Suspense content is awaited and included (the legacy `renderToString` silently replaced any
+suspending subtree with its fallback). The render is bounded by `ssrOptions.prerenderTimeoutMs`:
+
+- render finishes in time: complete HTML, exactly as before for non-suspending trees
+  (byte-identical output);
+- deadline expires with the shell complete: the page is served with its unfinished Suspense
+  boundaries in their fallback state (the client completes them after hydration) and an advisory
+  warning is logged;
+- deadline expires before the shell completes: `renderSSR` throws instead of returning a blank
+  page - let it reach your error handling.
+
+This path is Node-only (`react-dom/static`'s Node build).
+
 **Example:**
 
 ```typescript
 const { renderSSR } = createRenderer({
   appComponent: ({ location }) => <App location={location} />,
-  headContent: ({ data }) => `<title>${data.pageTitle}</title>`,
+  headContent: ({ data }) => `<title>${escapeHtml(data.pageTitle)}</title>`,
 });
 
 const result = await renderSSR(
@@ -287,19 +309,31 @@ const result = await renderSSR(
 
 See Per-call options for opts.
 
-Streams the application with React 18+ streaming SSR.
+Streams the application with React 19 streaming SSR.
 
 **Callbacks:**
 
 ```typescript
 type RenderCallbacks<T> = {
-  onHead?: (head: string) => void;
-  onShellReady?: () => void;
-  onAllReady?: (data: T) => void;
-  onFinish?: (data: T) => void;
-  onError?: (err: unknown) => void;
+  onHead?: (head: string) => void; // required operationally: commits the head + connects the sink
+  onShellReady?: () => void; // advisory
+  onAllReady?: (data: T) => void; // advisory; fires once with the resolved route data
+  onFinish?: (data: T) => void; // deprecated alias of onAllReady
+  onError?: (err: unknown) => void; // FATAL channel only
+  onRenderError?: (info: {
+    error: unknown;
+    phase: "pre-shell" | "post-shell";
+    recoverable: boolean | "unknown";
+  }) => void; // advisory, NON-fatal render errors
 };
 ```
+
+**Error channel semantics:** `onError` fires only for fatal stream failures (shell error,
+timeouts, writable guards). React render errors that do NOT fail the response - notably
+post-shell Suspense boundary errors, which React recovers client-side - arrive on
+`onRenderError` instead, with the observed `phase` and a `recoverable` flag that is `true` only
+where React's semantics guarantee it (`post-shell`). A throwing `onHead` is fatal (the response
+cannot proceed without its head).
 
 **Output ownership & backpressure**
 
@@ -315,7 +349,7 @@ If you are writing an HTML template prefix/suffix (common for Express/Fastify), 
 ```typescript
 const { renderStream } = createRenderer({
   appComponent: ({ location }) => <App location={location} />,
-  headContent: ({ data }) => `<title>${data.pageTitle}</title>`,
+  headContent: ({ data }) => `<title>${escapeHtml(data.pageTitle)}</title>`,
 });
 
 const { done, abort } = renderStream(
@@ -365,6 +399,7 @@ function hydrateApp<T>(options: {
   enableDebug?: boolean;
   logger?: LoggerLike;
   dataKey?: string;
+  identifierPrefix?: string;
   onHydrationError?: (err: unknown) => void;
   onStart?: () => void;
   onSuccess?: () => void;
@@ -378,9 +413,10 @@ function hydrateApp<T>(options: {
 - `enableDebug`: Enable debug logging (default: `false`)
 - `logger`: Custom logger implementation
 - `dataKey`: Key for initial data on window object (default: `'__INITIAL_DATA__'`)
-- `onHydrationError`: Callback for hydration errors
-- `onStart`: Callback when hydration starts
-- `onSuccess`: Callback when hydration completes
+- `identifierPrefix`: React's `useId` prefix, passed to both `hydrateRoot` and the CSR-fallback `createRoot`. Must be identical to the value the server rendered with (`createRenderer`'s `identifierPrefix`), or hydration mismatches.
+- `onHydrationError`: Callback for client render failures on EITHER path (hydration or CSR fallback). Fires at most once per `hydrateApp` call - settlement is single-fire.
+- `onStart`: Callback when hydration begins (hydrate path only - it does not fire for the CSR fallback)
+- `onSuccess`: Callback on the FIRST ROOT COMMIT (also on the CSR path). This signals the root committed - it does not claim every Suspense boundary has hydrated.
 
 **Example:**
 
@@ -442,10 +478,15 @@ hydrateApp({
 });
 ```
 
-**Behavior:**
+**Behaviour:**
 
 - If `window[dataKey]` exists: Performs SSR hydration with the provided data
-- If `window[dataKey]` is missing: Falls back to client-side rendering (CSR)
+- If `window[dataKey]` is missing: Falls back to client-side rendering (CSR) from empty data
+- If the root element is missing: reports through `onHydrationError` (nothing is mounted)
+- Callbacks are isolated: a throwing `onStart`/`onSuccess`/`onHydrationError` is logged and can
+  neither break hydration nor tear down the committed tree
+- Uncaught render errors still surface to global monitoring (`window` `error` /
+  `reportError`) in addition to `onHydrationError`
 - Automatically handles `DOMContentLoaded` timing
 - Wraps your app in `React.StrictMode` and `SSRStoreProvider`
 
@@ -499,7 +540,7 @@ function createSSRStore<T>(
 **Returns:** `SSRStore<T>` with methods:
 
 - `getSnapshot()` / `getServerSnapshot()`: Read the current data. Both throw the underlying promise while status is 'pending', so they integrate with React Suspense; both throw an Error if status is 'error'.
-- `setData(newData)`: Replace the stored value and notify subscribers. Transitions status to 'success'.
+- `setData(newData)`: Replace the stored value and notify subscribers. Transitions status to 'success'. An explicit `setData` supersedes the store's in-flight initial promise: a later settlement of that promise (success or failure) is ignored - it can neither overwrite the explicit value nor flip the store into an error state.
 - `subscribe(callback)`: Register a change listener; returns the unsubscribe function.
 - `status (readonly)`: Live lifecycle of the store - 'pending' until the initial promise settles, then 'success' or 'error'. Always reflects the current state, including transitions after the store was created.
 - `lastError (readonly)`: undefined unless status is 'error', in which case it holds the Error that caused the failure.
@@ -585,7 +626,8 @@ function App() {
 **Notes:**
 
 - Must be used within `SSRStoreProvider` - throws otherwise.
-- Subscribes via `useSyncExternalStore` so the component re-renders on setData or once the initial promise resolves; the value is then passed through `useDeferredValue` to keep updates concurrent-friendly under load.
+- Subscribes via `useSyncExternalStore`, so the component re-renders on `setData` or once the initial promise resolves - the hook always returns the store's current value.
+- **Suspension caveat (official React guidance):** a render triggered by a store MUTATION cannot be a non-blocking Transition. If the render caused by a `setData` suspends through constructs derived from the store value (a `React.lazy` component selected by it, or a `use()` promise built from it), React replaces already-revealed content with the nearest Suspense fallback. After hydration, drive suspension-prone UI from component state inside `startTransition` rather than directly from store values - see the [useSyncExternalStore caveats](https://react.dev/reference/react/useSyncExternalStore#caveats).
 - Suspends automatically while data is loading. The store's `getSnapshot` throws the underlying promise when status is 'pending', which the nearest `<Suspense fallback={...}>` ancestor catches until the promise settles. If the promise rejects, `getSnapshot` throws an Error instead - surface it with an error boundary.
 - For code that runs outside React (logging, conditional bootstrap, side-effect setup), read `store.status` and `store.lastError` directly - see [Data Store](#data-store).
 
@@ -603,6 +645,24 @@ function SSRStoreProvider<T>(props: {
   children: React.ReactNode;
 }): JSX.Element;
 ```
+
+---
+
+#### `escapeHtml(value)`
+
+Escape a value for safe interpolation into HTML text or quoted attributes (`& < > " '`;
+non-strings are coerced with `String()`).
+
+```typescript
+import { escapeHtml } from "@taujs/react";
+
+headContent: ({ data }) => `<title>${escapeHtml(data.pageTitle)}</title>`;
+```
+
+Use it for every `headContent` value derived from data or user input. It is for HTML text and
+quoted attributes ONLY - not for JavaScript, `<script>`/JSON-LD bodies, CSS, or URL scheme
+validation (for inline JSON use `JSON.stringify(value).replace(/</g, "\u003c")`; see the
+[head management guide](/guides/head-management/)).
 
 ---
 
@@ -882,7 +942,7 @@ export const serviceRegistry = defineServiceRegistry({
 When you use `@taujs/server`, you can derive a typed route context from your config and feed it into `createRenderer`:
 
 ```typescript
-import { createRenderer } from "@taujs/react";
+import { createRenderer, escapeHtml } from "@taujs/react";
 
 import config from "../taujs.config";
 import { AppBootstrap } from "./AppBootstrap";
@@ -902,7 +962,7 @@ export const { renderSSR, renderStream } = createRenderer<
       (meta.title as string | undefined) ??
       "My App";
 
-    return `<title>${baseTitle}</title>`;
+    return `<title>${escapeHtml(baseTitle)}</title>`;
   },
 });
 ```
@@ -928,14 +988,14 @@ export const { renderSSR, renderStream } = createRenderer<
 ```typescript
 // server.ts
 import express from "express";
-import { createRenderer } from "@taujs/react";
+import { createRenderer, escapeHtml } from "@taujs/react";
 import { App } from "./App";
 
 const app = express();
 
 const { renderStream } = createRenderer({
   appComponent: ({ location }) => <App location={location} />,
-  headContent: ({ data }) => `<title>${data.pageTitle}</title>`,
+  headContent: ({ data }) => `<title>${escapeHtml(data.pageTitle)}</title>`,
 });
 
 app.get("*", async (req, res) => {
@@ -1002,12 +1062,12 @@ app.listen(3000, () => {
 ```typescript
 // server.ts
 import http from "node:http";
-import { createRenderer } from "@taujs/react";
+import { createRenderer, escapeHtml } from "@taujs/react";
 import { App } from "./App";
 
 const { renderStream } = createRenderer({
   appComponent: ({ location }) => <App location={location} />,
-  headContent: ({ data }) => `<title>${data.pageTitle}</title>`,
+  headContent: ({ data }) => `<title>${escapeHtml(data.pageTitle)}</title>`,
 });
 
 const server = http.createServer(async (req, res) => {
@@ -1020,7 +1080,7 @@ const server = http.createServer(async (req, res) => {
     <html>
       <head>
         <meta charset="UTF-8">
-        <script>window.__INITIAL_DATA__=${JSON.stringify(data)};</script>
+        <script>window.__INITIAL_DATA__=${JSON.stringify(data).replace(/</g, "\\u003c")};</script>
       </head>
       <body><div id="root">
   `);
@@ -1053,7 +1113,7 @@ server.listen(3000);
 ```typescript
 // server.ts
 import { Hono } from "hono";
-import { createRenderer } from "@taujs/react";
+import { createRenderer, escapeHtml } from "@taujs/react";
 import { streamSSR } from "hono/streaming";
 import { App } from "./App";
 
@@ -1061,7 +1121,7 @@ const app = new Hono();
 
 const { renderStream } = createRenderer({
   appComponent: ({ location }) => <App location={location} />,
-  headContent: ({ data }) => `<title>${data.pageTitle}</title>`,
+  headContent: ({ data }) => `<title>${escapeHtml(data.pageTitle)}</title>`,
 });
 
 app.get("*", async (c) => {
@@ -1073,7 +1133,7 @@ app.get("*", async (c) => {
       <html>
         <head>
           <meta charset="UTF-8">
-          <script>window.__INITIAL_DATA__=${JSON.stringify(data)};</script>
+          <script>window.__INITIAL_DATA__=${JSON.stringify(data).replace(/</g, "\\u003c")};</script>
         </head>
         <body><div id="root">
     `);
@@ -1102,16 +1162,18 @@ export default app;
 
 ### Static SSR (No Streaming)
 
-For simpler use cases or edge runtimes that don't support streaming:
+For simpler cases where you want complete HTML in a single response. NB `renderSSR` uses
+`react-dom/static`'s Node build (complete HTML including Suspense content, bounded by
+`ssrOptions.prerenderTimeoutMs`) - it requires a Node runtime:
 
 ```typescript
 // server.ts
-import { createRenderer } from "@taujs/react";
+import { createRenderer, escapeHtml } from "@taujs/react";
 import { App } from "./App";
 
 const { renderSSR } = createRenderer({
   appComponent: ({ location }) => <App location={location} />,
-  headContent: ({ data }) => `<title>${data.pageTitle}</title>`,
+  headContent: ({ data }) => `<title>${escapeHtml(data.pageTitle)}</title>`,
 });
 
 export default {
@@ -1127,7 +1189,7 @@ export default {
         <head>
           <meta charset="UTF-8">
           ${headContent}
-          <script>window.__INITIAL_DATA__=${JSON.stringify(data)};</script>
+          <script>window.__INITIAL_DATA__=${JSON.stringify(data).replace(/</g, "\\u003c")};</script>
         </head>
         <body>
           <div id="root">${appHtml}</div>
@@ -1185,7 +1247,7 @@ hydrateApp({
 **client/entry-server.tsx:**
 
 ```typescript
-import { createRenderer } from "@taujs/react";
+import { createRenderer, escapeHtml } from "@taujs/react";
 import { App } from "./App";
 
 export const { renderSSR, renderStream } = createRenderer({
@@ -1193,10 +1255,10 @@ export const { renderSSR, renderStream } = createRenderer({
   headContent: ({ data, meta }) => `
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>${data?.title ?? meta.title ?? "My App"}</title>
+    <title>${escapeHtml(data?.title ?? meta.title ?? "My App")}</title>
     ${
       data?.description
-        ? `<meta name="description" content="${data.description}">`
+        ? `<meta name="description" content="${escapeHtml(data.description)}">`
         : ""
     }
   `,
@@ -1345,7 +1407,7 @@ export default defineConfig({
     "start": "NODE_ENV=production tsx server/index.ts"
   },
   "dependencies": {
-    "@taujs/react": "^0.1.1",
+    "@taujs/react": "^0.2.1",
     "@taujs/server": "latest",
     "fastify": "^5.0.0",
     "react": "^19.0.0",
@@ -1399,14 +1461,14 @@ hydrateApp({
 **src/server/render.tsx:**
 
 ```typescript
-import { createRenderer } from "@taujs/react";
+import { createRenderer, escapeHtml } from "@taujs/react";
 import { App } from "../client/App";
 
 export const { renderSSR, renderStream } = createRenderer({
   appComponent: ({ location }) => <App location={location} />,
   headContent: ({ data }) => `
     <meta charset="UTF-8">
-    <title>${data.pageTitle}</title>
+    <title>${escapeHtml(data.pageTitle)}</title>
   `,
 });
 ```
@@ -1429,7 +1491,7 @@ app.get("*", async (req, res) => {
     <!DOCTYPE html>
     <html>
       <head>
-        <script>window.__INITIAL_DATA__=${JSON.stringify(data)};</script>
+        <script>window.__INITIAL_DATA__=${JSON.stringify(data).replace(/</g, "\\u003c")};</script>
       </head>
       <body><div id="root">
   `);
@@ -1536,7 +1598,7 @@ When you use `@taujs/server`, it handles all the rendering automatically. Here's
 export const { renderSSR, renderStream } = createRenderer({
   appComponent: ({ location }) => <App location={location} />,
   headContent: ({ data, meta }) =>
-    `<title>${data?.title ?? meta.title ?? "App"}</title>`,
+    `<title>${escapeHtml(data?.title ?? meta.title ?? "App")}</title>`,
 });
 ```
 
@@ -1589,7 +1651,7 @@ The server orchestrates everything based on your declarative configuration.
 ```typescript
 const { renderStream } = createRenderer({
   appComponent: ({ location }) => <App location={location} />,
-  headContent: ({ data }) => `<title>${data.pageTitle}</title>`,
+  headContent: ({ data }) => `<title>${escapeHtml(data.pageTitle)}</title>`,
 });
 
 app.get("/products/:id", async (req, res) => {
@@ -1615,7 +1677,7 @@ app.get("/products/:id", async (req, res) => {
       onAllReady: (data) => {
         // All Suspense boundaries resolved
         res.write(`</div>
-          <script>window.__INITIAL_DATA__=${JSON.stringify(data)};</script>
+          <script>window.__INITIAL_DATA__=${JSON.stringify(data).replace(/</g, "\\u003c")};</script>
           <script type="module" src="/assets/client.js"></script>
         </body></html>`);
         res.end();
@@ -1638,7 +1700,7 @@ app.get("/products/:id", async (req, res) => {
 
 ```typescript
 import winston from "winston";
-import { createRenderer } from "@taujs/react";
+import { createRenderer, escapeHtml } from "@taujs/react";
 
 const logger = winston.createLogger({
   level: "info",
@@ -1669,7 +1731,7 @@ const customLogger = {
 
 const { renderStream } = createRenderer({
   appComponent: ({ location }) => <App location={location} />,
-  headContent: ({ data }) => `<title>${data.pageTitle}</title>`,
+  headContent: ({ data }) => `<title>${escapeHtml(data.pageTitle)}</title>`,
   logger: customLogger,
   enableDebug: true,
 });
@@ -1757,7 +1819,7 @@ app.get("*", (req, res) => {
   {
     onAllReady: (data) => {
       res.write(`<script nonce="${nonce}">
-        window.__INITIAL_DATA__ = ${JSON.stringify(data)};
+        window.__INITIAL_DATA__ = ${JSON.stringify(data).replace(/</g, "\\u003c")};
       </script>`);
     },
   }
@@ -1869,7 +1931,7 @@ const { renderSSR, renderStream } = createRenderer<PageData>({
   appComponent: ({ location }) => <App location={location} />,
   headContent: ({ data, meta }) => {
     // data is typed as PageData
-    return `<title>${data.pageTitle}</title>`;
+    return `<title>${escapeHtml(data.pageTitle)}</title>`;
   },
 });
 
@@ -1954,6 +2016,9 @@ When using `renderStream` in production, ensure you have the following in place:
 - `socket hang up` - client closed connection
 - `aborted` - request cancelled
 - `premature close` - stream ended early
+
+  Classification is origin-aware: only genuine socket/writable errors are treated as benign - a
+  RENDER error whose message merely looks like a disconnect is never reclassified.
 
 - **Implement onError callback**: Always handle errors gracefully
 
@@ -2068,10 +2133,12 @@ const { renderStream } = createRenderer({
   appComponent: ({ location }) => <App location={location} />,
   headContent: ({ data, meta }) => {
     return `
-      <title>${data.pageTitle}</title>
-      <meta name="description" content="${data.description}">
+      <title>${escapeHtml(data.pageTitle)}</title>
+      <meta name="description" content="${escapeHtml(data.description)}">
       ${meta.extraMeta || ""}
     `;
+    // meta.extraMeta is your own static config HTML (trusted); every value derived
+    // from data or user input goes through escapeHtml
   },
 });
 ```
@@ -2083,7 +2150,7 @@ Use detailed logging during development:
 ```typescript
 const { renderStream } = createRenderer({
   appComponent: ({ location }) => <App location={location} />,
-  headContent: ({ data }) => `<title>${data.pageTitle}</title>`,
+  headContent: ({ data }) => `<title>${escapeHtml(data.pageTitle)}</title>`,
   enableDebug: process.env.NODE_ENV === "development",
 });
 ```
@@ -2187,11 +2254,11 @@ await createServer({ fastify, config, serviceRegistry, clientRoot });
 
 ```typescript
 // Full control over rendering
-import { createRenderer } from "@taujs/react";
+import { createRenderer, escapeHtml } from "@taujs/react";
 
 const { renderStream } = createRenderer({
   appComponent: ({ location }) => <App location={location} />,
-  headContent: ({ data }) => `<title>${data.title}</title>`,
+  headContent: ({ data }) => `<title>${escapeHtml(data.title)}</title>`,
 });
 
 app.get("*", (req, res) => {

--- a/website/src/content/docs/renderers/react.mdx
+++ b/website/src/content/docs/renderers/react.mdx
@@ -44,7 +44,7 @@ A lightweight, React SSR library with streaming capabilities, built for modern T
 `@taujs/react` provides:
 
 - **Streaming SSR** with React 18+ `renderToPipeableStream`
-- **Static SSR** with `renderToString` for simpler use cases
+- **Static SSR** with `prerenderToNodeStream` - complete HTML including `React.lazy`/`use()` content, bounded by a configurable render deadline
 - **Automatic hydration** with built-in data synchronisation
 - **Type-safe data stores** using React hooks
 - **Robust error handling** for production environments

--- a/website/src/content/docs/renderers/vue.mdx
+++ b/website/src/content/docs/renderers/vue.mdx
@@ -34,7 +34,7 @@ A lightweight, Vue 3 SSR library with streaming capabilities, built for modern T
   - [Client-side hydration](#client-side-hydration)
   - [Data store](#data-store)
   - [Vite plugin](#vite-plugin)
-- [App customization with setupApp](#app-customization-with-setupapp)
+- [App customisation with setupApp](#app-customisation-with-setupapp)
 - [Lazy hydration](#lazy-hydration)
 - [Handling hydration mismatches](#handling-hydration-mismatches)
 - [Usage in the taujs ecosystem](#usage-in-the-taujs-ecosystem)
@@ -52,7 +52,7 @@ A lightweight, Vue 3 SSR library with streaming capabilities, built for modern T
 - **Static SSR** with `renderToString` for simpler use cases and `<Teleport>` support
 - **Automatic hydration** with built-in data synchronisation and CSR fallback
 - **Vue-native data store** using reactive refs, `provide`/`inject` and `<Suspense>`
-- **App-instance customization** via `setupApp` - the integration point for Pinia, vue-i18n, directives and global components
+- **App-instance customisation** via `setupApp` - the integration point for Pinia, vue-i18n, directives and global components
 - **Robust error handling** routed through `app.config.errorHandler`
 - **Runtime agnostic** - works with Node.js, Fastify, Express, or any HTTP server
 
@@ -246,7 +246,7 @@ function createRenderer<
 - `streamOptions.shellTimeoutMs`: Time-to-first-content watchdog in ms (default `10000`). See [Streaming semantics](#streaming-semantics).
 - `logger`: Custom logger implementation (`LoggerLike`).
 - `enableDebug`: Enable detailed logging (default `false`).
-- `setupApp`: Configure the per-request `App` instance (`app.use`, directives, provides). See [App customization](#app-customization-with-setupapp).
+- `setupApp`: Configure the per-request `App` instance (`app.use`, directives, provides). See [App customisation](#app-customisation-with-setupapp).
 
 **Returns** an object with two rendering methods: `renderSSR` (static, returns complete HTML plus teleports) and `renderStream` (streaming, pipes to a writable).
 
@@ -602,7 +602,7 @@ Within the taujs ecosystem you register it per app in `taujs.config.ts` instead 
 
 ---
 
-## App customization with `setupApp`
+## App customisation with `setupApp`
 
 Vue applications are configured through the `App` instance (`app.use`, `app.directive`, global components, `app.provide`). React composes the equivalent in JSX, so `@taujs/react` never needed a hook - but `@taujs/vue` creates its apps internally, so `setupApp` is the sanctioned integration point for Pinia, vue-i18n, custom directives and global components under τjs SSR.
 

--- a/website/src/content/docs/renderers/vue.mdx
+++ b/website/src/content/docs/renderers/vue.mdx
@@ -52,11 +52,11 @@ A lightweight, Vue 3 SSR library with streaming capabilities, built for modern T
 - **Static SSR** with `renderToString` for simpler use cases and `<Teleport>` support
 - **Automatic hydration** with built-in data synchronisation and CSR fallback
 - **Vue-native data store** using reactive refs, `provide`/`inject` and `<Suspense>`
-- **App-instance customization** via `setupApp` — the integration point for Pinia, vue-i18n, directives and global components
+- **App-instance customization** via `setupApp` - the integration point for Pinia, vue-i18n, directives and global components
 - **Robust error handling** routed through `app.config.errorHandler`
-- **Runtime agnostic** — works with Node.js, Fastify, Express, or any HTTP server
+- **Runtime agnostic** - works with Node.js, Fastify, Express, or any HTTP server
 
-`@taujs/vue` mirrors the *contract and capability* of `@taujs/react` — the same render surface, the same server behaviour, the same hydration beacon events — but it is Vue-native, not a React transliteration. Where React throws promises and uses `useSyncExternalStore`, Vue uses reactivity, async `setup` and `<Suspense>`. The documented divergences (for example, `useSSRStore` returning the store) are deliberate and called out in place.
+`@taujs/vue` mirrors the *contract and capability* of `@taujs/react` - the same render surface, the same server behaviour, the same hydration beacon events - but it is Vue-native, not a React transliteration. Where React throws promises and uses `useSyncExternalStore`, Vue uses reactivity, async `setup` and `<Suspense>`. The documented divergences (for example, `useSSRStore` returning the store) are deliberate and called out in place.
 
 ---
 
@@ -136,7 +136,7 @@ Client-side hydration automatically:
 
 ## Consuming SSR data
 
-There are two idioms for reading store data inside a component, **in order of preference**. This preference order is the one stated in the package's own JSDoc — reach for Suspense first.
+There are two idioms for reading store data inside a component, **in order of preference**. This preference order is the one stated in the package's own JSDoc - reach for Suspense first.
 
 ### Suspense (recommended)
 
@@ -156,7 +156,7 @@ const data = await useSSRDataAsync<GreetingData>();
 </template>
 ```
 
-`useSSRDataAsync<T>()` returns `Promise<T>`, so `data` is the resolved value (not a ref) — use it directly in the template.
+`useSSRDataAsync<T>()` returns `Promise<T>`, so `data` is the resolved value (not a ref) - use it directly in the template.
 
 <Aside type="tip" title="This is the required idiom for streaming routes">
 On a `streaming` route the blocking Suspense idiom is what puts the resolved data into the streamed HTML. See [Streaming semantics](#streaming-semantics) for exactly what happens if you use the fallback idiom on a streamed route instead.
@@ -164,7 +164,7 @@ On a `streaming` route the blocking Suspense idiom is what puts the resolved dat
 
 ### Fallback rendering
 
-Read a non-throwing computed and guard with `v-if`. `useSSRData<T>()` returns `ComputedRef<T | undefined>` — `undefined` while pending, the value once ready — so you can render a fallback without forcing Suspense:
+Read a non-throwing computed and guard with `v-if`. `useSSRData<T>()` returns `ComputedRef<T | undefined>` - `undefined` while pending, the value once ready - so you can render a fallback without forcing Suspense:
 
 ```vue
 <script setup lang="ts">
@@ -242,7 +242,7 @@ function createRenderer<
 **Parameters:**
 
 - `appComponent`: Your Vue root. Pass the component directly (it receives `{ location, routeContext? }` as props) or a render function returning a VNode.
-- `headContent`: Generates HTML head content from `{ data, meta, routeContext? }`. **Note:** in streaming mode the data snapshot is usually still pending when the head is built, so heads must be derivable from `meta`/`routeContext` — guard optional `data` fields.
+- `headContent`: Generates HTML head content from `{ data, meta, routeContext? }`. **Note:** in streaming mode the data snapshot is usually still pending when the head is built, so heads must be derivable from `meta`/`routeContext` - guard optional `data` fields.
 - `streamOptions.shellTimeoutMs`: Time-to-first-content watchdog in ms (default `10000`). See [Streaming semantics](#streaming-semantics).
 - `logger`: Custom logger implementation (`LoggerLike`).
 - `enableDebug`: Enable detailed logging (default `false`).
@@ -305,7 +305,7 @@ const { renderSSR, renderStream } = createRenderer<PageData, RouteContext>({
 On the server you pass `routeContext` per request via the final `opts` argument of `renderSSR` / `renderStream`.
 
 <Aside type="caution" title="routeContext is server-only">
-`routeContext` is never serialized to the client. Rendering visible content from it would hydration-mismatch by construction. Use it for head generation and server-side branching only; anything the client must also see belongs in the SSR data payload.
+`routeContext` is never serialised to the client. Rendering visible content from it would hydration-mismatch by construction. Use it for head generation and server-side branching only; anything the client must also see belongs in the SSR data payload.
 </Aside>
 
 #### `renderSSR()`
@@ -347,7 +347,7 @@ result.teleports?.["#modal"]; // contains "teleported-body"
 ```
 
 <Aside type="caution" title="Teleports are unavailable in streaming">
-`renderStream` does **not** produce teleports — teleported content cannot be injected into an in-order stream after the fact, and τjs does not fake it. If a route renders `<Teleport>` targets outside the app root, use the `ssr` strategy for that route, or render the teleported content client-side after hydration.
+`renderStream` does **not** produce teleports - teleported content cannot be injected into an in-order stream after the fact, and τjs does not fake it. If a route renders `<Teleport>` targets outside the app root, use the `ssr` strategy for that route, or render the teleported content client-side after hydration.
 </Aside>
 
 #### `renderStream()`
@@ -383,7 +383,7 @@ await done;
 
 ##### Streaming semantics
 
-Vue streaming is **honest and in-order**. It emits chunked HTML in document order and **blocks at async boundaries** (an async `setup` under `<Suspense>` stalls the stream until it resolves). There is **no** React-style out-of-order shell with fallback patching — nothing is streamed early and rewritten later.
+Vue streaming is **honest and in-order**. It emits chunked HTML in document order and **blocks at async boundaries** (an async `setup` under `<Suspense>` stalls the stream until it resolves). There is **no** React-style out-of-order shell with fallback patching - nothing is streamed early and rewritten later.
 
 Because of that:
 
@@ -394,7 +394,7 @@ Because of that:
 <Aside type="caution" title="Streamed routes must use the blocking Suspense idiom">
 Use `await useSSRDataAsync` under `<Suspense>` on a `streaming` route so the resolved data is rendered into the streamed HTML.
 
-If you use the non-blocking `useSSRData` + `v-if` idiom on a streamed route, the data is still pending when the chunk is produced, so the stream renders the **fallback**. τjs gates the end of the stream on the store settling, so the resolved data is still serialized into `window.__INITIAL_DATA__` and the client hydrates with real data — but the streamed markup itself shows only the fallback, forfeiting the first-paint / SEO benefit of SSR content. Prefer the blocking idiom on streamed routes.
+If you use the non-blocking `useSSRData` + `v-if` idiom on a streamed route, the data is still pending when the chunk is produced, so the stream renders the **fallback**. τjs gates the end of the stream on the store settling, so the resolved data is still serialised into `window.__INITIAL_DATA__` and the client hydrates with real data - but the streamed markup itself shows only the fallback, forfeiting the first-paint / SEO benefit of SSR content. Prefer the blocking idiom on streamed routes.
 </Aside>
 
 **Per-call options (`opts`)**
@@ -459,7 +459,7 @@ hydrateApp({
 **Behaviour:**
 
 - If `window[dataKey]` exists: hydrates the SSR markup with `createSSRApp(...).mount(rootEl)`.
-- If `window[dataKey]` is missing: clears any stale markup and mounts a fresh CSR app. **No hydration callbacks or beacon events fire** — a CSR mount is not a hydration.
+- If `window[dataKey]` is missing: clears any stale markup and mounts a fresh CSR app. **No hydration callbacks or beacon events fire** - a CSR mount is not a hydration.
 - Automatically handles `DOMContentLoaded` timing.
 - Wraps your app in `SSRStoreProvider` on both the hydrate and CSR paths.
 
@@ -508,7 +508,7 @@ store2.getSnapshot(); // { b: 2 }
 
 The store is reactive: `data`, `status` and `lastError` are `shallowReadonly` refs, so `getSnapshot()` and `data.value` preserve object identity with the value you passed in. On a rejected promise, `status` becomes `'error'`, `lastError` holds the normalised `Error`, and `ready` rejects. Calling `setData` on a still-pending or failed store recovers it: it flips `status` to `'success'` and resolves `ready`.
 
-Inside components you rarely call `createSSRStore` directly — `@taujs/server` and `hydrateApp` create and provide the store for you. You consume it with the composables below.
+Inside components you rarely call `createSSRStore` directly - `@taujs/server` and `hydrateApp` create and provide the store for you. You consume it with the composables below.
 
 #### `useSSRStore<T>()`
 
@@ -524,14 +524,14 @@ store.getSnapshot(); // { user: "Alice" } | undefined
 ```
 
 <Aside type="note" title="Deliberate divergence from @taujs/react">
-`@taujs/react`'s `useSSRStore` returns the resolved *value* via `useSyncExternalStore`. Vue has no equivalent value-hook idiom, so `@taujs/vue`'s `useSSRStore` returns the whole store — letting components pick the right access pattern (reactive refs, `await store.ready`, `store.getSnapshot()`). This is intentional; do not expect it to mirror React. For the common cases, prefer `useSSRData` / `useSSRDataAsync` below.
+`@taujs/react`'s `useSSRStore` returns the resolved *value* via `useSyncExternalStore`. Vue has no equivalent value-hook idiom, so `@taujs/vue`'s `useSSRStore` returns the whole store - letting components pick the right access pattern (reactive refs, `await store.ready`, `store.getSnapshot()`). This is intentional; do not expect it to mirror React. For the common cases, prefer `useSSRData` / `useSSRDataAsync` below.
 </Aside>
 
-Must be called within an `SSRStoreProvider` — it throws `"useSSRStore must be used within a SSRStoreProvider"` otherwise.
+Must be called within an `SSRStoreProvider` - it throws `"useSSRStore must be used within a SSRStoreProvider"` otherwise.
 
 #### `useSSRData<T>()`
 
-Returns `ComputedRef<T | undefined>` — the non-throwing fallback path. `undefined` while pending, the value once ready. Pair with `v-if` (see [Fallback rendering](#fallback-rendering)).
+Returns `ComputedRef<T | undefined>` - the non-throwing fallback path. `undefined` while pending, the value once ready. Pair with `v-if` (see [Fallback rendering](#fallback-rendering)).
 
 ```typescript
 const data = useSSRData<{ message: string }>();
@@ -540,7 +540,7 @@ const data = useSSRData<{ message: string }>();
 
 #### `useSSRDataAsync<T>()`
 
-Returns `Promise<T>` — the recommended Suspense path. `await` it in an async `setup` under `<Suspense>` (see [Suspense](#suspense-recommended)). It awaits `store.ready`, then returns the snapshot; if the snapshot is still `undefined` after ready resolves it throws, and if the underlying data load rejected, the await rejects with that error (catchable in `setup` or surfaced through the `<Suspense>` boundary).
+Returns `Promise<T>` - the recommended Suspense path. `await` it in an async `setup` under `<Suspense>` (see [Suspense](#suspense-recommended)). It awaits `store.ready`, then returns the snapshot; if the snapshot is still `undefined` after ready resolves it throws, and if the underlying data load rejected, the await rejects with that error (catchable in `setup` or surfaced through the `<Suspense>` boundary).
 
 ```typescript
 const data = await useSSRDataAsync<{ message: string }>();
@@ -598,23 +598,23 @@ export default defineConfig({
 });
 ```
 
-Within the taujs ecosystem you register it per app in `taujs.config.ts` instead — see [Usage in the taujs ecosystem](#usage-in-the-taujs-ecosystem).
+Within the taujs ecosystem you register it per app in `taujs.config.ts` instead - see [Usage in the taujs ecosystem](#usage-in-the-taujs-ecosystem).
 
 ---
 
 ## App customization with `setupApp`
 
-Vue applications are configured through the `App` instance (`app.use`, `app.directive`, global components, `app.provide`). React composes the equivalent in JSX, so `@taujs/react` never needed a hook — but `@taujs/vue` creates its apps internally, so `setupApp` is the sanctioned integration point for Pinia, vue-i18n, custom directives and global components under τjs SSR.
+Vue applications are configured through the `App` instance (`app.use`, `app.directive`, global components, `app.provide`). React composes the equivalent in JSX, so `@taujs/react` never needed a hook - but `@taujs/vue` creates its apps internally, so `setupApp` is the sanctioned integration point for Pinia, vue-i18n, custom directives and global components under τjs SSR.
 
 `setupApp?: (app: App) => void` is accepted by **both** `createRenderer` and `hydrateApp`. It runs after the internal store provide and before render/mount, on **every** path: `renderSSR`, `renderStream`, hydration, and the CSR fallback.
 
 **Constraints** (so the identical function runs verbatim on server and client):
 
-- **Synchronous only** — no promise form.
-- **No `window`/DOM access** — it runs on the server too.
-- **Idempotent per app instance** — a fresh `App` is created per request and per mount.
+- **Synchronous only** - no promise form.
+- **No `window`/DOM access** - it runs on the server too.
+- **Idempotent per app instance** - a fresh `App` is created per request and per mount.
 
-A throwing `setupApp` is treated as an application error and routed to the path's error channel (`onError` + fatal abort on the server; `onHydrationError` on the client) — never swallowed.
+A throwing `setupApp` is treated as an application error and routed to the path's error channel (`onError` + fatal abort on the server; `onHydrationError` on the client) - never swallowed.
 
 ```typescript
 // A plugin installed via setupApp is usable by any rendered component.
@@ -629,16 +629,16 @@ const setupApp = (app: App) => {
 
 // Server
 const { renderSSR } = createRenderer({ appComponent: App, headContent, setupApp });
-// Client — the SAME function
+// Client - the SAME function
 hydrateApp({ appComponent: App, setupApp });
 ```
 
 ### Pinia
 
-Because `setupApp` runs identically on server and client, it is where you install Pinia. τjs adds **no state-serialization channel** — data flow stays request-first. Seed Pinia store state from the SSR data you already receive (`useSSRData` / `useSSRDataAsync`), which arrives via `window.__INITIAL_DATA__`:
+Because `setupApp` runs identically on server and client, it is where you install Pinia. τjs adds **no state-serialization channel** - data flow stays request-first. Seed Pinia store state from the SSR data you already receive (`useSSRData` / `useSSRDataAsync`), which arrives via `window.__INITIAL_DATA__`:
 
 ```typescript
-// setup-app.ts — shared by entry-server and entry-client
+// setup-app.ts - shared by entry-server and entry-client
 import { createPinia } from "pinia";
 import type { App } from "vue";
 
@@ -657,7 +657,7 @@ type PageData = { user: { id: string; name: string } };
 
 const data = await useSSRDataAsync<PageData>();
 const userStore = useUserStore();
-userStore.$patch({ user: data.user }); // seed from SSR data — no extra channel
+userStore.$patch({ user: data.user }); // seed from SSR data - no extra channel
 </script>
 
 <template>
@@ -671,7 +671,7 @@ The same seed runs during SSR (populating server-rendered markup) and during hyd
 
 ## Lazy hydration
 
-Vue 3.5's lazy-hydration strategies compose with `hydrateApp`. Wrap a component with `defineAsyncComponent` and pass a `hydrate` strategy; the root app that `hydrateApp` mounts will defer that component's hydration accordingly. This is a per-component concern inside your tree — `hydrateApp` itself is unchanged.
+Vue 3.5's lazy-hydration strategies compose with `hydrateApp`. Wrap a component with `defineAsyncComponent` and pass a `hydrate` strategy; the root app that `hydrateApp` mounts will defer that component's hydration accordingly. This is a per-component concern inside your tree - `hydrateApp` itself is unchanged.
 
 ```vue
 <script setup lang="ts">
@@ -722,7 +722,7 @@ Each strategy (`hydrateOnVisible`, `hydrateOnIdle`, `hydrateOnInteraction`, `hyd
 
 ## Handling hydration mismatches
 
-For content that is *intentionally* different between server and client — timestamps, locale-formatted dates, randomised values — annotate the element with Vue's official `data-allow-mismatch` attribute to suppress the hydration-mismatch warning for it:
+For content that is *intentionally* different between server and client - timestamps, locale-formatted dates, randomised values - annotate the element with Vue's official `data-allow-mismatch` attribute to suppress the hydration-mismatch warning for it:
 
 ```vue
 <template>
@@ -731,7 +731,7 @@ For content that is *intentionally* different between server and client — time
 </template>
 ```
 
-`data-allow-mismatch` accepts an optional value to narrow what is allowed to differ: `text`, `children`, `class`, `style`, or `attribute` (for example `data-allow-mismatch="text"`). Use it sparingly and only for genuinely intentional divergence — it silences a correctness signal, so a stray mismatch elsewhere in the subtree can go unnoticed.
+`data-allow-mismatch` accepts an optional value to narrow what is allowed to differ: `text`, `children`, `class`, `style`, or `attribute` (for example `data-allow-mismatch="text"`). Use it sparingly and only for genuinely intentional divergence - it silences a correctness signal, so a stray mismatch elsewhere in the subtree can go unnoticed.
 
 ---
 
@@ -739,7 +739,7 @@ For content that is *intentionally* different between server and client — time
 
 With `@taujs/server`, you don't call the render functions directly. You define rendering once in `entry-server`, hydration once in `entry-client`, and declare routes and data in `taujs.config.ts`; the server orchestrates everything.
 
-**taujs.config.ts** — register `pluginVue()` per app and declare each route's rendering strategy:
+**taujs.config.ts** - register `pluginVue()` per app and declare each route's rendering strategy:
 
 ```typescript
 import { defineConfig } from "@taujs/server/config";
@@ -777,7 +777,7 @@ export default defineConfig({
             }),
             // meta recommended for streaming routes for SEO/social and render timing
             meta: {
-              title: "τjs — Streaming",
+              title: "τjs - Streaming",
               description:
                 "Streaming SSR route (Suspense progressively reveals content).",
             },
@@ -790,10 +790,10 @@ export default defineConfig({
 ```
 
 <Aside type="note" title="Rendering strategies">
-`render` is either `'ssr'` or `'streaming'`. A route not declared in `taujs.config.ts` stays client-rendered — that is the fallthrough model, not a per-route render value. When `render` is omitted the server defaults to `ssr`.
+`render` is either `'ssr'` or `'streaming'`. A route not declared in `taujs.config.ts` stays client-rendered - that is the fallthrough model, not a per-route render value. When `render` is omitted the server defaults to `ssr`.
 </Aside>
 
-**entry-server.ts** — the renderer `@taujs/server` calls internally:
+**entry-server.ts** - the renderer `@taujs/server` calls internally:
 
 ```typescript
 import { createRenderer } from "@taujs/vue";
@@ -813,7 +813,7 @@ export const { renderSSR, renderStream } = createRenderer({
 });
 ```
 
-**entry-client.ts** — hydration entry:
+**entry-client.ts** - hydration entry:
 
 ```typescript
 import { hydrateApp } from "@taujs/vue";
@@ -826,7 +826,7 @@ hydrateApp({
 });
 ```
 
-**App.vue** — the root receives `location` from the server and picks the page. Note the `ssr` route uses the fallback idiom while the `streaming` route awaits under `<Suspense>`:
+**App.vue** - the root receives `location` from the server and picks the page. Note the `ssr` route uses the fallback idiom while the `streaming` route awaits under `<Suspense>`:
 
 ```vue
 <script setup lang="ts">
@@ -858,7 +858,7 @@ const isStreaming = computed(() => path.value.startsWith("/streaming"));
 
 **HomePage.vue** and **StreamingPage.vue** are the two page components. `HomePage.vue` (the `ssr` route) uses the fallback idiom shown in [Fallback rendering](#fallback-rendering); `StreamingPage.vue` (the `streaming` route) uses the blocking Suspense idiom shown in [Suspense](#suspense-recommended). They are the exact snippets from those sections, one per route.
 
-**index.html** — the template the server fills in (`<!--ssr-head-->` / `<!--ssr-html-->`):
+**index.html** - the template the server fills in (`<!--ssr-head-->` / `<!--ssr-html-->`):
 
 ```html
 <!DOCTYPE html>
@@ -880,13 +880,13 @@ That is the complete request flow: the server matches a route, runs its `data` l
 
 ## Standalone usage
 
-Outside `@taujs/server`, `createRenderer` and `hydrateApp` are framework-agnostic. The server plumbing — Express, Hono, native Node HTTP, backpressure, CSP nonces, `AbortSignal` — is identical to `@taujs/react`; see the [React reference](/renderers/react/#standalone-usage) for those framework-specific server walkthroughs. The only Vue-specific differences are:
+Outside `@taujs/server`, `createRenderer` and `hydrateApp` are framework-agnostic. The server plumbing - Express, Hono, native Node HTTP, backpressure, CSP nonces, `AbortSignal` - is identical to `@taujs/react`; see the [React reference](/renderers/react/#standalone-usage) for those framework-specific server walkthroughs. The only Vue-specific differences are:
 
 - `appComponent` is a Vue component (or render function), not a JSX element.
 - Data is consumed with the Vue composables and idioms above.
 - Static SSR can return `teleports`, which you splice into your template yourself.
 
-Static SSR (no streaming), for edge runtimes or simple cases — `renderSSR` returns the head and app HTML (and any `teleports`); assemble the document and inject `window.__INITIAL_DATA__` yourself:
+Static SSR (no streaming), for edge runtimes or simple cases - `renderSSR` returns the head and app HTML (and any `teleports`); assemble the document and inject `window.__INITIAL_DATA__` yourself:
 
 ```typescript
 import { createRenderer } from "@taujs/vue";
@@ -964,19 +964,19 @@ const setupApp = (app) => {
 
 1. **Prefer Suspense for data.** Reach for `await useSSRDataAsync<T>()` under `<Suspense>` first; fall back to `useSSRData<T>()` + `v-if` only when you specifically want a non-blocking render.
 2. **Streamed routes block on data.** Always use the blocking Suspense idiom on `streaming` routes so the data lands in the streamed HTML, not just in `__INITIAL_DATA__`.
-3. **Keep `headContent` derivable from `meta`.** In streaming mode the data snapshot is usually pending when the head is built — guard optional `data` fields and lean on `meta`/`routeContext`.
+3. **Keep `headContent` derivable from `meta`.** In streaming mode the data snapshot is usually pending when the head is built - guard optional `data` fields and lean on `meta`/`routeContext`.
 4. **Share one `setupApp` across server and client.** Keep it synchronous, DOM-free and idempotent so the identical function runs on both sides; seed Pinia/state from SSR data rather than adding a serialization channel.
 5. **Match `@vue/server-renderer` to `vue`.** Pin both to the same version.
 6. **Handle CSR fallback.** Provide `onHydrationError` so a hydration failure degrades gracefully; remember the CSR path emits no hydration callbacks by design.
 7. **Reserve teleports for `ssr` routes.** `<Teleport>` targets outside the app root are only captured by `renderSSR`.
-8. **Client-side updates after SSR are userland.** For data that changes after the initial render, call your own `/api/*` endpoints with a client library such as TanStack Query or SWR — τjs keeps SSR request-first and does not add a client data channel.
+8. **Client-side updates after SSR are userland.** For data that changes after the initial render, call your own `/api/*` endpoints with a client library such as TanStack Query or SWR - τjs keeps SSR request-first and does not add a client data channel.
 
 ---
 
 ## Related packages
 
-- `@taujs/server` — Fastify-based server with SSR orchestration, routing and data loading.
-- `@taujs/react` — the React renderer; shares this package's contract and streaming semantics.
+- `@taujs/server` - Fastify-based server with SSR orchestration, routing and data loading.
+- `@taujs/react` - the React renderer; shares this package's contract and streaming semantics.
 
 ---
 

--- a/website/src/content/docs/renderers/vue.mdx
+++ b/website/src/content/docs/renderers/vue.mdx
@@ -118,7 +118,7 @@ The `createRenderer` function creates a reusable renderer from your root compone
 ```typescript
 const { renderSSR, renderStream } = createRenderer({
   appComponent: App, // a Vue component, or a render function
-  headContent: ({ data, meta }) => `<title>${data.title}</title>`,
+  headContent: ({ data, meta }) => `<title>${escapeHtml(data.title)}</title>`,
   streamOptions: { shellTimeoutMs: 10000 },
 });
 ```
@@ -297,7 +297,7 @@ const { renderSSR, renderStream } = createRenderer<PageData, RouteContext>({
     const baseTitle =
       data.title ?? (meta.title as string | undefined) ?? "My App";
     const suffix = routeContext?.name === "article" ? " · Article" : "";
-    return `<title>${baseTitle}${suffix}</title>`;
+    return `<title>${escapeHtml(baseTitle)}${suffix}</title>`;
   },
 });
 ```
@@ -315,7 +315,7 @@ Renders the complete application to a string (static SSR). Returns `{ headConten
 ```typescript
 const { renderSSR } = createRenderer<{ msg: string }>({
   appComponent: () => h(App),
-  headContent: ({ data }) => `<title>${data?.msg ?? "no-data"}</title>`,
+  headContent: ({ data }) => `<title>${escapeHtml(data?.msg ?? "no-data")}</title>`,
 });
 
 const { headContent, appHtml, teleports } = await renderSSR(
@@ -635,7 +635,7 @@ hydrateApp({ appComponent: App, setupApp });
 
 ### Pinia
 
-Because `setupApp` runs identically on server and client, it is where you install Pinia. τjs adds **no state-serialization channel** - data flow stays request-first. Seed Pinia store state from the SSR data you already receive (`useSSRData` / `useSSRDataAsync`), which arrives via `window.__INITIAL_DATA__`:
+Because `setupApp` runs identically on server and client, it is where you install Pinia. τjs adds **no state-serialisation channel** - data flow stays request-first. Seed Pinia store state from the SSR data you already receive (`useSSRData` / `useSSRDataAsync`), which arrives via `window.__INITIAL_DATA__`:
 
 ```typescript
 // setup-app.ts - shared by entry-server and entry-client
@@ -796,18 +796,18 @@ export default defineConfig({
 **entry-server.ts** - the renderer `@taujs/server` calls internally:
 
 ```typescript
-import { createRenderer } from "@taujs/vue";
+import { createRenderer, escapeHtml } from "@taujs/vue";
 import App from "./App.vue";
 
 export const { renderSSR, renderStream } = createRenderer({
   appComponent: App,
   headContent: ({ data, meta }) => `
-    <title>${meta?.title || "τjs - Composing systems, not just apps"}</title>
-    <meta name="description" content="${
+    <title>${escapeHtml(meta?.title || "τjs - Composing systems, not just apps")}</title>
+    <meta name="description" content="${escapeHtml(
       meta?.description ||
-      (data as { message?: string })?.message ||
-      "τjs - Composing systems, not just apps"
-    }">
+        (data as { message?: string })?.message ||
+        "τjs - Composing systems, not just apps"
+    )}">
   `,
   enableDebug: process.env.NODE_ENV === "development",
 });
@@ -889,12 +889,12 @@ Outside `@taujs/server`, `createRenderer` and `hydrateApp` are framework-agnosti
 Static SSR (no streaming), for edge runtimes or simple cases - `renderSSR` returns the head and app HTML (and any `teleports`); assemble the document and inject `window.__INITIAL_DATA__` yourself:
 
 ```typescript
-import { createRenderer } from "@taujs/vue";
+import { createRenderer, escapeHtml } from "@taujs/vue";
 import App from "./App.vue";
 
 const { renderSSR } = createRenderer<{ message: string }>({
   appComponent: App,
-  headContent: ({ data }) => `<title>${data?.message ?? "App"}</title>`,
+  headContent: ({ data }) => `<title>${escapeHtml(data?.message ?? "App")}</title>`,
 });
 
 const data = { message: "Hello World" };
@@ -921,7 +921,7 @@ interface PageData {
 
 const { renderSSR, renderStream } = createRenderer<PageData>({
   appComponent: App,
-  headContent: ({ data }) => `<title>${data?.message ?? "App"}</title>`,
+  headContent: ({ data }) => `<title>${escapeHtml(data?.message ?? "App")}</title>`,
 });
 ```
 
@@ -965,7 +965,7 @@ const setupApp = (app) => {
 1. **Prefer Suspense for data.** Reach for `await useSSRDataAsync<T>()` under `<Suspense>` first; fall back to `useSSRData<T>()` + `v-if` only when you specifically want a non-blocking render.
 2. **Streamed routes block on data.** Always use the blocking Suspense idiom on `streaming` routes so the data lands in the streamed HTML, not just in `__INITIAL_DATA__`.
 3. **Keep `headContent` derivable from `meta`.** In streaming mode the data snapshot is usually pending when the head is built - guard optional `data` fields and lean on `meta`/`routeContext`.
-4. **Share one `setupApp` across server and client.** Keep it synchronous, DOM-free and idempotent so the identical function runs on both sides; seed Pinia/state from SSR data rather than adding a serialization channel.
+4. **Share one `setupApp` across server and client.** Keep it synchronous, DOM-free and idempotent so the identical function runs on both sides; seed Pinia/state from SSR data rather than adding a serialisation channel.
 5. **Match `@vue/server-renderer` to `vue`.** Pin both to the same version.
 6. **Handle CSR fallback.** Provide `onHydrationError` so a hydration failure degrades gracefully; remember the CSR path emits no hydration callbacks by design.
 7. **Reserve teleports for `ssr` routes.** `<Teleport>` targets outside the app root are only captured by `renderSSR`.


### PR DESCRIPTION
Executes RFC 0003 end to end: 52 commits, 31 changesets, four gated phases, every gate
independently reviewed and signed off. No breaking changes - patch bumps throughout, one
server minor for an additive contract type, `@taujs/server` stays below 1.0.0.

## What consumers will notice

- **~49% smaller React client bundles** (raw; ~48% gzip): the dist no longer couples
  `react-dom/server` into the client entry. No migration - same imports, same API.
- **The `ssr` strategy now renders complete HTML**: `React.lazy`/`use()`/Suspense content
  is awaited and included (previously it was silently replaced by its fallback with zero
  diagnostics), bounded by a new `ssrOptions.prerenderTimeoutMs` (default 10s) with a
  documented degrade path instead of blank pages.
- **Fresh scaffolds install again**: a peer-range conflict hard-failed `npm install` for
  every newly scaffolded React app; fixed and covered by packed-consumer tests.
- **Honest hydration lifecycle**: exactly one of `onSuccess`/`onHydrationError` fires per
  `hydrateApp` call; success means first root commit; failures on either path are
  observable; user callbacks are isolated so they can never tear down the tree.
- **`escapeHtml` exported from both renderers**, the `headContent` escaping contract
  documented everywhere, and every website example security-swept to match.

## Hardening (by phase)

- **R0 - crash classes:** unobserved stream rejections can no longer terminate the
  process (proven in child processes under Node's default rejection mode); one safe
  inline-data serialisation boundary for both render modes; origin-aware benign-error
  classification (render errors can never masquerade as client disconnects); `warn`/
  `error` always reach the logger in production.
- **R1 - streaming correctness:** bounded end-gate (`dataTimeoutMs`), single-fire fatal
  path proven against re-entrant server aborts, advisory `onRenderError` channel,
  request `AbortSignal` threaded into data loaders, real react-dom/server integration
  suite replacing mocked streaming tests.
- **R2 - observability + security surface:** root error adapter on both hydrate and CSR
  paths, missing-root routing, global error surfacing preserved, bootstrap attribute
  escaping server-side, `identifierPrefix` for collision-free `useId` across multiple
  roots, vue lifecycle twins fixed.
- **R3 - ship:** contract conformance tests (`RenderStreamHandle`), packaging per the
  signed ruling, module-graph guard tests that fail if a Node-only module ever re-enters
  a browser build graph, `setData` supersedes late loaders in both stores, vue's public
  `ready` promise hardened against unhandled rejections, renderer reference docs brought
  to the shipped surface.

## Verification

- Full workspace check green: react 204 / vue 181 / server 696 / mcp 28 / create-taujs 11
- `attw` and packed-consumer checks pass on both renderer packages
- Playground verified live on both render strategies; astro site builds clean (21 pages)
- Frozen-lockfile install passes on a clean checkout
- Guard tests destructively verified (each proven to fail against the defect it pins)

Release notes assemble from the changesets.
