### PR TITLE
chore: add changeset for @taujs/create-taujs dependency removal

### DIFF
--- a/.changeset/create-taujs-drop-changesets-runtime-dep.md
+++ b/.changeset/create-taujs-drop-changesets-runtime-dep.md
@@ -1,0 +1,5 @@
+---
+'@taujs/create-taujs': patch
+---
+
+Remove `@changesets/cli` from runtime dependencies. It was never imported, so every `npx @taujs/create-taujs` was downloading the entire changesets toolchain for nothing. Releases continue to use the copy provided by the workspace root.


### PR DESCRIPTION
Patch bump: @changesets/cli dropped from create-taujs runtime dependencies.