### PR TITLE
feat(server,react,vue): dynamic head data for streamed routes - RFC 0004 (attr.head)

### DIFF
--- a/.changeset/h1-attr-head-loader.md
+++ b/.changeset/h1-attr-head-loader.md
@@ -1,0 +1,22 @@
+---
+'@taujs/server': minor
+---
+
+RFC 0004 (H1): routes may declare `attr.head = { data, timeoutMs?, optional? }` - a dynamic head
+data loader resolved BEFORE the renderer starts on BOTH strategies and delivered to the renderer
+as `opts.headData` (an additive optional field on the `RenderSSR`/`RenderStream` contracts). This
+gives streamed pages dynamic `<head>` data for the first time; `attr.meta` remains the static
+layer, and head data is never serialised into `__INITIAL_DATA__`.
+
+Semantics (signed policy): the loader is bounded by `timeoutMs` (default 3000 ms, positive finite
+only - validated at boot); on deadline expiry with the request still live the render proceeds
+with `headData: undefined` plus an advisory log; a caller abort never proceeds into the renderer;
+an ordinary loader rejection fails the request through the existing error path unless the route
+opts in with `optional: true`. On the streaming branch a head failure terminates the hijacked
+reply deterministically (500 before headers, destroy after) instead of rethrowing into a response
+Fastify no longer owns.
+
+Type inference: `serviceData()` now returns a phantom-branded `ServiceDataHandler<Result>`
+(type-level only - the runtime value is still the honest service descriptor), and the new
+`HeadDataOf<Route>` helper (exported from `@taujs/server/config` with `HeadAttributes`) infers
+the actual selected service method result for `headContent` typing.

--- a/.changeset/h2-react-headdata.md
+++ b/.changeset/h2-react-headdata.md
@@ -1,0 +1,19 @@
+---
+'@taujs/react': minor
+---
+
+RFC 0004 (H2): `headContent` receives the route's resolved `attr.head` payload as
+`headData?: H` on BOTH strategies - streamed pages get dynamic `<head>` data for the first time.
+`createRenderer` gains a defaulted third generic (`createRenderer<T, R, H>`; every existing call
+site compiles unchanged) and `HeadContext` gains the optional `headData` field beside the
+untouched `data: T` (whose semantics are identical to before on both strategies). `headData` is
+optional in the type by contract: `undefined` when the route declares no `attr.head` and when the
+head loader degraded under the server's signed policy - handle it (typically by falling back to
+`meta`). Escape `headData`-derived values with `escapeHtml` like any other dynamic head value.
+
+Contract regularisation: the render functions' contract-facing parameter types are now
+honestly BROAD (`Record<string, unknown>` data/headData, `unknown` routeContext) with one
+documented internal narrowing seam per value - a renderer instantiated with NON-default generics
+is now provably assignable to `@taujs/server`'s contracts under strictFunctionTypes, pinned by a
+new non-default conformance type test (the previous default-only test masked this gap). App-facing
+typing is unchanged or better: callbacks stay fully narrow-typed via the generics.

--- a/.changeset/h6-vue-headdata.md
+++ b/.changeset/h6-vue-headdata.md
@@ -1,0 +1,18 @@
+---
+'@taujs/vue': minor
+---
+
+RFC 0004 (H6, adoption signed): `headContent` receives the route's resolved `attr.head` payload
+as `headData?: H` - vue's single, pre-render head build (timing unchanged, by design) can now see
+dynamic data on BOTH strategies, closing the gap where the renderer-agnostic `attr.head` route
+config was silently dead on vue. `createRenderer` gains a defaulted third generic
+(`createRenderer<T, R, H>`; existing call sites compile unchanged) and `HeadContext` gains the
+optional `headData` field beside the untouched `data: T`. `headData` is `undefined` when the
+route declares no `attr.head` and when the head loader degraded under the server's signed
+policy, so handle it (typically by falling back to `meta`); escape `headData`-derived values
+with `escapeHtml`.
+
+Contract regularisation (the react H2 model): the render functions' contract-facing parameter
+types are now honestly broad with documented internal narrowing seams, and the conformance type
+test additionally instantiates NON-default generics - closing vue's own latent
+strictFunctionTypes assignability gap that the default-only test masked.

--- a/fixtures/playground-vue/src/client/entry-server.ts
+++ b/fixtures/playground-vue/src/client/entry-server.ts
@@ -1,12 +1,17 @@
-import { createRenderer } from '@taujs/vue';
+import { createRenderer, escapeHtml } from '@taujs/vue';
 
 import App from './App.vue';
 import { setupApp } from './setup-app';
 
-export const { renderSSR, renderStream } = createRenderer({
+type HeadData = { ogTitle?: string; ogDescription?: string };
+
+export const { renderSSR, renderStream } = createRenderer<Record<string, unknown>, unknown, HeadData>({
   appComponent: App,
-  headContent: ({ meta }) => `
-    <title>${(meta as { title?: string } | undefined)?.title ?? 'τjs Vue playground'}</title>
+  // RFC 0004: headData is the route's attr.head payload (undefined when a route declares none,
+  // or when the head loader degraded) - meta stays the static fallback layer.
+  headContent: ({ headData, meta }) => `
+    <title>${escapeHtml(headData?.ogTitle ?? (meta as { title?: string } | undefined)?.title ?? 'τjs Vue playground')}</title>
+    ${headData?.ogDescription ? `<meta name="description" content="${escapeHtml(headData.ogDescription)}">` : ''}
   `,
   setupApp,
   enableDebug: process.env.NODE_ENV === 'development',

--- a/fixtures/playground-vue/src/server/services/content.service.ts
+++ b/fixtures/playground-vue/src/server/services/content.service.ts
@@ -7,6 +7,12 @@ export const contentService = defineService({
     timestamp: new Date().toISOString(),
   }),
 
+  // RFC 0004 (H6): the head-critical slice for the streaming route's attr.head - cheap by
+  // design (the head loader blocks the head build; default deadline 3000ms).
+  greetHead: async (params: { name: string }) => ({
+    ogTitle: `Hello ${params.name} | τjs Vue playground`,
+    ogDescription: `Live head data for ${params.name}`,
+  }),
   greet: async (params: { name: string }) => {
     // A deliberate delay so the streaming route visibly blocks at the async boundary.
     await new Promise((resolve) => setTimeout(resolve, 400));

--- a/fixtures/playground-vue/taujs.config.ts
+++ b/fixtures/playground-vue/taujs.config.ts
@@ -47,6 +47,9 @@ export default defineConfig({
             // Streaming: the blocking idiom (await useSSRDataAsync) delivers the resolved
             // data into the payload (V1-07 R1).
             data: serviceData('content', 'greet', () => ({ name: 'Vue' })),
+            // RFC 0004: dynamic head data, resolved BEFORE the head is built (streamed pages get
+            // real <head> data; attr.meta stays the static fallback layer).
+            head: { data: serviceData('content', 'greetHead', () => ({ name: 'Vue' })) },
           },
         },
       ],

--- a/fixtures/playground/src/client/entry-server.tsx
+++ b/fixtures/playground/src/client/entry-server.tsx
@@ -1,10 +1,15 @@
-import { createRenderer } from '@taujs/react';
+import { createRenderer, escapeHtml } from '@taujs/react';
 import { App } from './App';
 
-export const { renderSSR, renderStream } = createRenderer({
+type HeadData = { ogTitle?: string; ogDescription?: string };
+
+export const { renderSSR, renderStream } = createRenderer<Record<string, unknown>, unknown, HeadData>({
   appComponent: () => <App />,
-  headContent: ({ meta }) => `
-    <title>${(meta as { title?: string } | undefined)?.title ?? 'τjs playground'}</title>
+  // RFC 0004: headData is the route's attr.head payload (undefined when a route declares none,
+  // or when the head loader degraded) - meta stays the static fallback layer.
+  headContent: ({ headData, meta }) => `
+    <title>${escapeHtml(headData?.ogTitle ?? (meta as { title?: string } | undefined)?.title ?? 'τjs playground')}</title>
+    ${headData?.ogDescription ? `<meta name="description" content="${escapeHtml(headData.ogDescription)}">` : ''}
   `,
   enableDebug: process.env.NODE_ENV === 'development',
 });

--- a/fixtures/playground/src/server/services/catalog.service.ts
+++ b/fixtures/playground/src/server/services/catalog.service.ts
@@ -25,4 +25,12 @@ export const catalogService = defineService({
     params: parseProductParams,
     result: validateProductResult,
   },
+  // RFC 0004 (H2): the head-critical slice for the streaming route's attr.head - cheap by design
+  // (the head loader blocks the shell; default deadline 3000ms).
+  getProductHead: {
+    handler: async (params: { id: string }) => {
+      return { ogTitle: `Product ${params.id} | τjs playground`, ogDescription: `Live head data for product ${params.id}` };
+    },
+    params: parseProductParams,
+  },
 });

--- a/fixtures/playground/taujs.config.ts
+++ b/fixtures/playground/taujs.config.ts
@@ -34,6 +34,9 @@ export default defineConfig({
             },
             // The killer-demo route: declared edge with a narrowing mapper.
             data: serviceData('catalog', 'getProduct', (p) => ({ id: String(p.id) })),
+            // RFC 0004: dynamic head data, resolved BEFORE the shell (streamed pages get real
+            // <head> data; attr.meta stays the static fallback layer).
+            head: { data: serviceData('catalog', 'getProductHead', (p) => ({ id: String(p.id) })) },
           },
         },
         {

--- a/packages/react/src/SSRRender.tsx
+++ b/packages/react/src/SSRRender.tsx
@@ -89,11 +89,22 @@ export type SSROptions = {
 /**
  * Context passed to `headContent`: `data` is the resolved route data, `meta`/`routeContext` the
  * route's static metadata and per-request context. NB `headContent` returns RAW `<head>` HTML — any
- * value interpolated from `data` (or other services/user input) must be escaped with `escapeHtml`
- * (see the `headContent` option's docs).
+ * value interpolated from `data`, `headData` (or other services/user input) must be escaped with
+ * `escapeHtml` (see the `headContent` option's docs).
+ *
+ * RFC 0004 (H2): `headData` is the route's `attr.head` payload, resolved by the host BEFORE the
+ * render starts on BOTH strategies and delivered via `opts.headData`. It is OPTIONAL in the type
+ * by contract: `undefined` when the route declares no `attr.head`, and when the head loader
+ * degraded under the signed policy (deadline expiry, or an `optional` loader failure) — handle
+ * the undefined case (typically by falling back to `meta`).
  */
-export type HeadContext<T extends Record<string, unknown> = Record<string, unknown>, R = unknown> = {
+export type HeadContext<
+  T extends Record<string, unknown> = Record<string, unknown>,
+  R = unknown,
+  H extends Record<string, unknown> = Record<string, unknown>,
+> = {
   data: T;
+  headData?: H;
   meta: Record<string, unknown>;
   routeContext?: R;
 };
@@ -102,12 +113,22 @@ type SSRResult = { headContent: string; appHtml: string; aborted: boolean };
 
 type StreamCallOptions<R> = StreamOptions & {
   logger?: LoggerLike;
-  routeContext?: R;
+  // RFC 0004 (H2): broad at the contract boundary (same contravariance reality as headData/T);
+  // narrowed to `R` at the single read below. `R` remains the app-facing type via HeadContext
+  // and appComponent.
+  routeContext?: unknown;
+  // RFC 0004 (H2): BROAD at the contract boundary (the host cannot know `H`); narrowed to `H` at
+  // the single seam where `headContent` is invoked — the same trust model as the body data.
+  headData?: Record<string, unknown>;
 };
 
 const NOOP = () => {};
 
-export function createRenderer<T extends Record<string, unknown> = Record<string, unknown>, R = unknown>({
+export function createRenderer<
+  T extends Record<string, unknown> = Record<string, unknown>,
+  R = unknown,
+  H extends Record<string, unknown> = Record<string, unknown>,
+>({
   appComponent,
   headContent,
   streamOptions = {},
@@ -125,7 +146,7 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
    * `` `<meta property="og:image" content="${escapeHtml(data.ogImage)}">` ``. See the head-management
    * guide, "Best Practices — Escape User Content".
    */
-  headContent: (ctx: HeadContext<T, R>) => string;
+  headContent: (ctx: HeadContext<T, R, H>) => string;
   enableDebug?: boolean;
   logger?: LoggerLike;
   streamOptions?: StreamOptions;
@@ -155,12 +176,17 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
     );
   }
 
+  // RFC 0004 (H2): the contract-facing parameter types are BROAD (`Record<string, unknown>`) so a
+  // renderer instantiated with non-default generics stays assignable to the host's RenderSSR /
+  // RenderStream contracts under strictFunctionTypes (the non-default conformance test pins this).
+  // The values are trusted as `T`/`H` at ONE internal seam each — route-config inference is the
+  // type authority, exactly as it always was for the body data.
   const renderSSR = async (
-    initialData: T,
+    initialData: Record<string, unknown>,
     location: string,
     meta: Record<string, unknown> = {},
     signal?: AbortSignal,
-    opts?: { logger?: LoggerLike; routeContext?: R },
+    opts?: { logger?: LoggerLike; routeContext?: unknown; headData?: Record<string, unknown> },
   ): Promise<SSRResult> => {
     const { log, warn } = createUILogger(opts?.logger ?? logger, {
       debugCategory: 'ssr',
@@ -186,13 +212,15 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
     };
     signal?.addEventListener('abort', onAbort, { once: true });
 
-    const routeContext = opts?.routeContext;
+    // The R narrowing seam (RFC 0004 H2).
+    const routeContext = opts?.routeContext as R | undefined;
 
     try {
       log('Starting SSR:', location);
 
-      const dynamicHead = headContent({ data: initialData, meta, routeContext });
-      const store = createSSRStore(initialData);
+      // The T/H narrowing seam for this strategy (see the note on renderSSR's signature).
+      const dynamicHead = headContent({ data: initialData as T, headData: opts?.headData as H | undefined, meta, routeContext });
+      const store = createSSRStore(initialData as T);
 
       // R3-06 (Q3, Policy A): `prerenderToNodeStream` replaces `renderToString`, which could not
       // suspend - any `React.lazy`/`use()` subtree SILENTLY became its fallback plus a
@@ -268,7 +296,7 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
   const renderStream = (
     writable: Writable,
     callbacks: RenderCallbacks<T> = {},
-    initialData: T | Promise<T> | (() => Promise<T>),
+    initialData: Record<string, unknown> | Promise<Record<string, unknown>> | (() => Promise<Record<string, unknown>>),
     location: string,
     bootstrapModules?: string,
     meta: Record<string, unknown> = {},
@@ -289,7 +317,8 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
       context: { scope: 'react-streaming' },
       enableDebug,
     });
-    const routeContext = opts?.routeContext;
+    // The R narrowing seam (RFC 0004 H2).
+    const routeContext = opts?.routeContext as R | undefined;
 
     // Merge renderer defaults with per-call overrides
     const effectiveShellTimeout = opts?.shellTimeoutMs ?? shellTimeoutMs;
@@ -376,8 +405,9 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
 
     try {
       // Store is created here so the renderer can read its INTERNAL readiness (design 1) for the
-      // bounded end-gate; the public SSRStore type is unchanged.
-      const store = createSSRStore(initialData);
+      // bounded end-gate; the public SSRStore type is unchanged. This is the streaming strategy's
+      // T narrowing seam (RFC 0004 H2 - see the note on renderSSR's signature).
+      const store = createSSRStore(initialData as T | Promise<T> | (() => Promise<T>));
       const readiness = getStoreReadiness(store) ?? Promise.resolve();
 
       // Single-fire delivery (design 2): fires onAllReady/onFinish exactly once, from the end-gate
@@ -522,9 +552,9 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
 
           try {
             // Prefer current snapshot if available (sync path).
-            let headData: T | undefined;
+            let snapshotData: T | undefined;
             try {
-              headData = store.getSnapshot();
+              snapshotData = store.getSnapshot();
             } catch (thrown) {
               // In async/lazy cases, snapshot may not be ready yet. That's fine.
               // If it's a promise (thenable), attach a rejection handler to prevent unhandled rejection
@@ -535,7 +565,10 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
               }
             }
 
-            const head = headContent({ data: headData ?? ({} as T), meta, routeContext });
+            // RFC 0004 (H2): `headData` (host-resolved, pre-shell) rides alongside the snapshot -
+            // the H narrowing seam for this strategy. `data` semantics are UNCHANGED (current
+            // snapshot, or `{}` while route data is still pending at shell-ready).
+            const head = headContent({ data: snapshotData ?? ({} as T), headData: opts?.headData as H | undefined, meta, routeContext });
 
             // onHead is REQUIRED (design 6): it commits the response head and connects the sink. A
             // throwing onHead is fatal — do NOT pipe into an unconsumed sink (hung response).

--- a/packages/react/src/test/SSRHydration.integration.test.tsx
+++ b/packages/react/src/test/SSRHydration.integration.test.tsx
@@ -12,7 +12,20 @@ import { createRenderer } from '../SSRRender';
 // FAILING-FIRST against the pre-R2-01 renderer (which emits success synchronously and routes no
 // client render error); they go green once the single root-error adapter + reporter land.
 
+// `flush` remains ONLY as a short bounded grace AFTER a terminal condition has been reached
+// (single-settlement negative assertions need some window for a hypothetical double-fire).
 const flush = (ms = 40) => new Promise<void>((r) => setTimeout(r, ms));
+
+// Gate-review finding: fixed sleeps are load-sensitive - under workspace concurrency a first
+// commit can land after its test's window and bleed into the NEXT test's global hook. Every test
+// now waits for ITS OWN terminal condition, so nothing is left pending when the test ends.
+const waitFor = async (cond: () => boolean, what: string, timeoutMs = 5_000): Promise<void> => {
+  const t0 = Date.now();
+  while (!cond()) {
+    if (Date.now() - t0 > timeoutMs) throw new Error(`waitFor timed out after ${timeoutMs}ms: ${what}`);
+    await new Promise<void>((r) => setTimeout(r, 10));
+  }
+};
 
 type Beacon = 'hydration:start' | 'hydration:success' | 'hydration:error';
 
@@ -49,6 +62,10 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // Belt for the cross-test bleed class: `hydrateApp` returns no root handle (Q2, by design), so
+  // a root cannot be unmounted here - instead any not-yet-drained emission from a stray root
+  // lands in a dead sink, never a later test's harness. Each test's `harness()` replaces it.
+  (window as unknown as { __TAUJS_DEVTOOLS_HOOK__?: unknown }).__TAUJS_DEVTOOLS_HOOK__ = { emit: () => {} };
   document.body.innerHTML = '';
   delete (globalThis as { reportError?: unknown }).reportError;
 });
@@ -68,7 +85,7 @@ describe('R2-01 hydration observability (real react-dom/client)', () => {
     expect(beacons).not.toContain('hydration:success');
     expect(onSuccess).not.toHaveBeenCalled();
 
-    await flush();
+    await waitFor(() => onSuccess.mock.calls.length > 0, 'onSuccess after first commit');
 
     expect(onSuccess).toHaveBeenCalledTimes(1);
     expect(beacons.filter((b) => b === 'hydration:success')).toHaveLength(1);
@@ -85,7 +102,7 @@ describe('R2-01 hydration observability (real react-dom/client)', () => {
 
     hydrateApp({ appComponent: <Boom />, logger: { error: vi.fn() }, onHydrationError, onSuccess });
 
-    await flush();
+    await waitFor(() => onHydrationError.mock.calls.length > 0, 'onHydrationError after hydrate throw');
 
     expect(onHydrationError).toHaveBeenCalledTimes(1);
     expect(onHydrationError.mock.calls[0]![0]).toBeInstanceOf(Error);
@@ -102,7 +119,7 @@ describe('R2-01 hydration observability (real react-dom/client)', () => {
 
     hydrateApp({ appComponent: <Boom />, logger: { error: vi.fn(), warn: vi.fn() }, onHydrationError });
 
-    await flush();
+    await waitFor(() => onHydrationError.mock.calls.length > 0, 'onHydrationError after CSR throw');
 
     expect(onHydrationError).toHaveBeenCalledTimes(1);
     expect(beacons).toHaveLength(0); // CSR emits NO beacon events (vue parity)
@@ -118,7 +135,7 @@ describe('R2-01 hydration observability (real react-dom/client)', () => {
 
     hydrateApp({ appComponent: <div>CLIENT</div>, logger: { warn }, onSuccess, onHydrationError });
 
-    await flush();
+    await waitFor(() => onSuccess.mock.calls.length > 0, 'onSuccess after recoverable mismatch');
 
     expect(onSuccess).toHaveBeenCalledTimes(1);
     expect(beacons).toContain('hydration:success');
@@ -135,7 +152,7 @@ describe('R2-01 hydration observability (real react-dom/client)', () => {
 
     hydrateApp({ appComponent: <div>app</div>, logger: { error: vi.fn() }, onHydrationError });
 
-    await flush();
+    await waitFor(() => onHydrationError.mock.calls.length > 0, 'onHydrationError for missing root');
 
     expect(onHydrationError).toHaveBeenCalledTimes(1);
     expect((onHydrationError.mock.calls[0]![0] as Error).message).toContain('not found');
@@ -151,7 +168,8 @@ describe('R2-01 hydration observability (real react-dom/client)', () => {
 
     hydrateApp({ appComponent: <Boom />, logger: { error: vi.fn() }, onHydrationError, onSuccess });
 
-    await flush(80); // give StrictMode's double-invoke + any late ticks time
+    await waitFor(() => onHydrationError.mock.calls.length > 0, 'first failure settlement');
+    await flush(40); // bounded grace: give StrictMode's double-invoke + any late ticks time
 
     expect(onHydrationError).toHaveBeenCalledTimes(1);
     expect(beacons.filter((b) => b === 'hydration:error')).toHaveLength(1);
@@ -184,7 +202,8 @@ describe('R2-01 hydration observability (real react-dom/client)', () => {
     try {
       hydrateApp({ appComponent: <Later />, logger: { error: vi.fn() }, onSuccess, onHydrationError });
 
-      await flush(90); // first commit (success) + the 10ms delayed throw
+      await waitFor(() => onSuccess.mock.calls.length > 0, 'success settlement (first commit)');
+      await waitFor(() => reportErrorSpy.mock.calls.length > 0, 'post-settlement error surfaced globally');
 
       expect(onSuccess).toHaveBeenCalledTimes(1); // settled on first commit
       expect(onHydrationError).not.toHaveBeenCalled(); // NOT re-fired post-settlement (log-only)
@@ -210,10 +229,11 @@ describe('R2-01 hydration observability (real react-dom/client)', () => {
     setRoot('root', appHtml);
     (window as unknown as Record<string, unknown>).__INITIAL_DATA__ = { a: 1 };
     const warn = vi.fn();
+    const onSuccess = vi.fn();
 
-    hydrateApp({ appComponent: <IdApp />, logger: { warn } });
+    hydrateApp({ appComponent: <IdApp />, logger: { warn }, onSuccess });
 
-    await flush();
+    await waitFor(() => onSuccess.mock.calls.length > 0, 'useId app committed');
 
     // No recoverable hydration mismatch: the app's useId is identical on server and client.
     expect(warn.mock.calls.filter((c) => String(c[0]).includes('Recoverable'))).toHaveLength(0);
@@ -230,10 +250,11 @@ describe('R2-01 hydration observability (real react-dom/client)', () => {
     setRoot('root', appHtml);
     (window as unknown as Record<string, unknown>).__INITIAL_DATA__ = { a: 1 };
     const warn = vi.fn();
+    const onSuccess = vi.fn();
 
-    hydrateApp({ appComponent: <IdApp />, identifierPrefix: 'app1-', logger: { warn } });
+    hydrateApp({ appComponent: <IdApp />, identifierPrefix: 'app1-', logger: { warn }, onSuccess });
 
-    await flush();
+    await waitFor(() => onSuccess.mock.calls.length > 0, 'prefixed app committed');
 
     // Client used the matching prefix -> ids equal the server render -> no recoverable mismatch.
     expect(warn.mock.calls.filter((c) => String(c[0]).includes('Recoverable'))).toHaveLength(0);
@@ -251,7 +272,8 @@ describe('R2-01 hydration observability (real react-dom/client)', () => {
 
     hydrateApp({ appComponent: <div>csr</div>, onStart, onSuccess });
 
-    await flush(80);
+    await waitFor(() => onSuccess.mock.calls.length > 0, 'CSR first commit');
+    await flush(40); // bounded grace for StrictMode's double-invoked reporter effect
 
     expect(onSuccess).toHaveBeenCalledTimes(1);
     expect(onStart).not.toHaveBeenCalled();
@@ -266,7 +288,8 @@ describe('R2-01 hydration observability (real react-dom/client)', () => {
 
     hydrateApp({ appComponent: <div>app</div>, onSuccess });
 
-    await flush(80);
+    await waitFor(() => onSuccess.mock.calls.length > 0, 'hydrate first commit');
+    await flush(40); // bounded grace: prove no double settlement
 
     expect(onSuccess).toHaveBeenCalledTimes(1);
     expect(beacons.filter((b) => b === 'hydration:success')).toHaveLength(1);
@@ -290,7 +313,8 @@ describe('R2-01 hydration observability (real react-dom/client)', () => {
 
     hydrateApp({ appComponent: <div>app</div>, logger: { error: errorLog }, onSuccess, onHydrationError });
 
-    await flush(90);
+    await waitFor(() => successCalls > 0, 'throwing onSuccess invoked');
+    await flush(40); // bounded grace: the throw must not manufacture a late failure
 
     expect(successCalls).toBe(1); // fired once
     expect(onHydrationError).not.toHaveBeenCalled(); // the throw did NOT become a failure
@@ -320,7 +344,7 @@ describe('R2-01 hydration observability (real react-dom/client)', () => {
     try {
       hydrateApp({ appComponent: <Boom />, logger: { error: vi.fn() }, onHydrationError: vi.fn() });
 
-      await flush();
+      await waitFor(() => globalErrors.length > 0, 'ErrorEvent reached window.onerror');
 
       expect(globalErrors.length).toBeGreaterThanOrEqual(1);
       expect(globalErrors[0]).toBeInstanceOf(Error);
@@ -345,7 +369,8 @@ describe('R2-01 hydration observability (real react-dom/client)', () => {
 
     hydrateApp({ appComponent: <Boom />, logger: { error: vi.fn() }, onHydrationError });
 
-    await flush(90);
+    await waitFor(() => errCalls > 0, 'throwing onHydrationError invoked');
+    await flush(40); // bounded grace: prove single settlement
 
     expect(errCalls).toBe(1); // called once, its throw swallowed
     expect(beacons.filter((b) => b === 'hydration:error')).toHaveLength(1); // single settlement

--- a/packages/react/src/test/SSRRender.integration.test.tsx
+++ b/packages/react/src/test/SSRRender.integration.test.tsx
@@ -150,6 +150,36 @@ describe('React behaviour facts (pure react-dom/server)', () => {
 });
 
 describe('R1-01 integration (real react-dom/server)', () => {
+  it('RFC 0004 (H2): opts.headData reaches headContent at shell-ready; undefined when the host passes none', async () => {
+    const heads: string[] = [];
+    const make = () =>
+      createRenderer<Data, unknown, { ogTitle: string }>({
+        appComponent: () => <div>app</div>,
+        headContent: ({ headData }) => `<title>${headData?.ogTitle ?? 'fallback'}</title>`,
+      });
+
+    // With headData: the host-resolved payload is visible in the PRE-SHELL head bytes.
+    {
+      const { writable } = driveServerSide();
+      const { done } = make().renderStream(writable, { onHead: (h) => heads.push(h) }, { value: 1 }, '/with-head', undefined, {}, undefined, undefined, {
+        headData: { ogTitle: 'Dynamic OG' },
+      });
+      await done.catch(() => {});
+      await settle();
+    }
+
+    // Without headData: the callback's own undefined-handling branch runs.
+    {
+      const { writable } = driveServerSide();
+      const { done } = make().renderStream(writable, { onHead: (h) => heads.push(h) }, { value: 2 }, '/no-head');
+      await done.catch(() => {});
+      await settle();
+    }
+
+    expect(heads[0]).toBe('<title>Dynamic OG</title>');
+    expect(heads[1]).toBe('<title>fallback</title>');
+  });
+
   it('R2: late-resolving data with NO store consumer — finish must serialize the RESOLVED data, not {}', async () => {
     const { writable, state } = driveServerSide();
 

--- a/packages/react/src/test/SSRRender.prerender.test.tsx
+++ b/packages/react/src/test/SSRRender.prerender.test.tsx
@@ -83,6 +83,26 @@ describe('R3-06 output equivalence with renderToString (non-suspending trees)', 
   }
 });
 
+describe('RFC 0004 (H2): renderSSR headData seam', () => {
+  it('opts.headData reaches headContent typed as H; undefined when the host passes none', async () => {
+    const seen: Array<{ ogTitle: string } | undefined> = [];
+    const renderer = createRenderer<{ k: string }, unknown, { ogTitle: string }>({
+      appComponent: () => <div>x</div>,
+      headContent: ({ data, headData }) => {
+        seen.push(headData);
+        return `<title>${headData?.ogTitle ?? data.k}</title>`;
+      },
+    });
+
+    const withHead = await renderer.renderSSR({ k: 'v' }, '/h', {}, undefined, { headData: { ogTitle: 'OG' } });
+    const withoutHead = await renderer.renderSSR({ k: 'v' }, '/h', {});
+
+    expect(withHead.headContent).toBe('<title>OG</title>');
+    expect(withoutHead.headContent).toBe('<title>v</title>');
+    expect(seen).toEqual([{ ogTitle: 'OG' }, undefined]);
+  });
+});
+
 describe('R3-06 Policy A degrade matrix (real react-dom)', () => {
   it('deadline with a suspending child INSIDE a boundary: serves fallback-state HTML + advisory warn, no throw', async () => {
     const warn = vi.fn();

--- a/packages/react/src/test/contract.test-d.ts
+++ b/packages/react/src/test/contract.test-d.ts
@@ -48,3 +48,26 @@ void _contractSatisfiedByHandle;
 //    Pin it on the ACTUAL return type, not on the contract alias.
 const _done: Promise<void> = null as unknown as ReactStreamHandle['done'];
 void _done;
+
+// ---------------------------------------------------------------------------------------------
+// RFC 0004 (H2) - HARD GATE (ruling 7): a renderer instantiated with NON-DEFAULT generics must
+// remain assignable to the host's broad contracts. The default-only assertions above masked a
+// strictFunctionTypes gap: narrow parameter types are not assignable to broad ones, so this only
+// holds because the renderer's contract-facing signatures are BROAD with internal narrowing seams
+// (the RFC's chosen model). If someone re-narrows a signature, THESE lines fail, not production.
+type PageData = { title: string; body: string };
+type Ctx = { name: 'home' | 'article' };
+type Head = { ogTitle: string; ogImage?: string };
+
+const _typedRenderer = createRenderer<PageData, Ctx, Head>({
+  appComponent: () => createElement('div'),
+  // The app-facing callback stays fully narrow-typed: data is PageData, headData is Head | undefined.
+  headContent: ({ data, headData, meta, routeContext }) => `${data.title}${headData?.ogTitle ?? ''}${String(meta)}${routeContext?.name ?? ''}`,
+});
+
+const _typedModule: RenderModule = _typedRenderer;
+const _typedSSR: RenderSSR = _typedRenderer.renderSSR;
+const _typedStream: RenderStream = _typedRenderer.renderStream;
+void _typedModule;
+void _typedSSR;
+void _typedStream;

--- a/packages/server/src/Config.ts
+++ b/packages/server/src/Config.ts
@@ -53,6 +53,11 @@ export type { ServiceDataMetadata } from './core/services/ServiceData';
 export type RouteContext = CoreRouteContext<TaujsConfig>;
 export type RouteData<C extends TaujsConfig = TaujsConfig, P extends string = string> = CoreRouteData<C, P>;
 
+// RFC 0004 (H1): the config-side head-data surface. `HeadDataOf<R>` infers what `headContent`
+// receives as `headData` for a route (the phantom-branded service result for `serviceData()`
+// loaders); `ServiceDataHandler` is `serviceData()`'s branded return type.
+export type { HeadAttributes, HeadDataOf, ServiceDataHandler } from './core/config/types';
+
 export { AppError } from './core/errors/AppError';
 
 export function defineConfig<const C extends TaujsConfig>(config: C): C {

--- a/packages/server/src/core/config/Setup.ts
+++ b/packages/server/src/core/config/Setup.ts
@@ -36,6 +36,21 @@ export const extractRoutes = (taujsConfig: CoreTaujsConfig): ExtractRoutesResult
 
   for (const app of taujsConfig.apps) {
     const appRoutes = (app.routes ?? []).map((route) => {
+      // RFC 0004 (H1): validate `attr.head` at BOOT - misconfiguration fails fast, before any
+      // request depends on it. `timeoutMs` must be POSITIVE FINITE (ruling 3: the head blocks
+      // the shell, so there is deliberately no 0/Infinity wait-forever sentinel).
+      const head = (route.attr as { head?: { data?: unknown; timeoutMs?: unknown; optional?: unknown } } | undefined)?.head;
+      if (head !== undefined) {
+        const at = `Route "${route.path}" (app "${app.appId}")`;
+        if (typeof head.data !== 'function') throw new Error(`${at}: attr.head.data must be a function (a data handler or serviceData(...) sugar)`);
+        if (head.timeoutMs !== undefined && !(typeof head.timeoutMs === 'number' && Number.isFinite(head.timeoutMs) && head.timeoutMs > 0)) {
+          throw new Error(`${at}: attr.head.timeoutMs must be a positive finite number of milliseconds (received ${String(head.timeoutMs)})`);
+        }
+        if (head.optional !== undefined && typeof head.optional !== 'boolean') {
+          throw new Error(`${at}: attr.head.optional must be a boolean (received ${String(head.optional)})`);
+        }
+      }
+
       const fullRoute: Route<PathToRegExpParams> = { ...route, appId: app.appId };
 
       if (!pathTracker.has(route.path)) pathTracker.set(route.path, []);

--- a/packages/server/src/core/config/test/HeadDataOf.test-d.ts
+++ b/packages/server/src/core/config/test/HeadDataOf.test-d.ts
@@ -51,10 +51,29 @@ const closureRoute = {
 
 type _ClosureArm = Expect<Equal<HeadDataOf<typeof closureRoute>, { note: string }>>;
 
+// --- Arm 2b (gate-recheck): a MIXED closure return must keep the descriptor branch as
+// Record<string, unknown> - never be silently narrowed to the direct-object member alone
+// (the dispatched descriptor may resolve to any record). ---
+const mixedRoute = {
+  path: '/mixed',
+  attr: {
+    render: 'ssr',
+    head: {
+      data: async (params: { premium?: string }) =>
+        params.premium ? { title: 'direct' } : ({ serviceName: 'catalog', serviceMethod: 'getProductHead', args: {} } as ServiceDescriptor),
+    },
+  },
+} as const;
+
+type _MixedArm = Expect<Equal<HeadDataOf<typeof mixedRoute>, { title: string } | Record<string, unknown>>>;
+
+// And explicitly NOT the direct-object member alone:
+type _MixedNotNarrowed = Expect<Equal<HeadDataOf<typeof mixedRoute> extends { title: string } ? true : false, false>>;
+
 // --- Arm 3: no `attr.head` -> undefined. ---
 const plainRoute = { path: '/', attr: { render: 'ssr' } } as const;
 
 type _NoHeadArm = Expect<Equal<HeadDataOf<typeof plainRoute>, undefined>>;
 
 // Keep tsc's noUnusedLocals honest.
-export type _Proof = [_ServiceArm, _ClosureArm, _NoHeadArm];
+export type _Proof = [_ServiceArm, _ClosureArm, _MixedArm, _MixedNotNarrowed, _NoHeadArm];

--- a/packages/server/src/core/config/test/HeadDataOf.test-d.ts
+++ b/packages/server/src/core/config/test/HeadDataOf.test-d.ts
@@ -1,0 +1,60 @@
+// RFC 0004 (H1) - HARD GATE (ruling 7): `HeadDataOf<R>` must infer the ACTUAL selected service
+// method result through `serviceData()` sugar - never the service DESCRIPTOR (the handler's
+// honest runtime return), never `DataResult`, never a bare `Record<string, unknown>`.
+//
+// Type-level test in the vue contract.test-d.ts idiom: enforced by `pnpm --filter @taujs/server
+// typecheck` (tsc); the `.test-d.ts` suffix is outside vitest's test glob so it never runs as a
+// spec. Uses invariant-Equal (not mere assignability) so width-subtyping cannot fake a pass.
+import { createServiceData } from '../../services/ServiceData';
+
+import type { HeadDataOf } from '../types';
+import type { ServiceDescriptor } from '../../services/DataServices';
+
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+type ProductHead = { sku: string; title: string };
+
+type Registry = Readonly<{
+  catalog: Readonly<{
+    getProductHead: (params: { id: string }, ctx: any) => Promise<ProductHead>;
+  }>;
+}>;
+
+const serviceData = createServiceData<Registry>();
+
+// --- Arm 1: serviceData() sugar infers the SELECTED METHOD's resolved result (the brand). ---
+const headRoute = {
+  path: '/product/:id',
+  attr: {
+    render: 'streaming',
+    meta: { title: 'static' },
+    head: { data: serviceData('catalog', 'getProductHead', (p) => ({ id: String(p.id) })), timeoutMs: 3000 },
+  },
+} as const;
+
+type _ServiceArm = Expect<Equal<HeadDataOf<typeof headRoute>, ProductHead>>;
+
+// And explicitly NOT the descriptor (the callable's honest runtime return):
+// @ts-expect-error - headData is the dispatched result, never the ServiceDescriptor
+const _neverDescriptor: ServiceDescriptor = {} as HeadDataOf<typeof headRoute>;
+void _neverDescriptor;
+
+// --- Arm 2: a closure handler infers its own resolved return type. ---
+const closureRoute = {
+  path: '/legacy',
+  attr: {
+    render: 'ssr',
+    head: { data: async () => ({ note: 'hand-written' }) },
+  },
+} as const;
+
+type _ClosureArm = Expect<Equal<HeadDataOf<typeof closureRoute>, { note: string }>>;
+
+// --- Arm 3: no `attr.head` -> undefined. ---
+const plainRoute = { path: '/', attr: { render: 'ssr' } } as const;
+
+type _NoHeadArm = Expect<Equal<HeadDataOf<typeof plainRoute>, undefined>>;
+
+// Keep tsc's noUnusedLocals honest.
+export type _Proof = [_ServiceArm, _ClosureArm, _NoHeadArm];

--- a/packages/server/src/core/config/test/Setup.test.ts
+++ b/packages/server/src/core/config/test/Setup.test.ts
@@ -177,3 +177,28 @@ describe('extractSecurity', () => {
     expect(out.summary.reportOnly).toBe(false);
   });
 });
+
+describe('extractRoutes attr.head validation (RFC 0004 H1)', () => {
+  const withHead = (head: unknown) => ({ apps: [{ appId: 'shop', entryPoint: '', routes: [{ path: '/product/:id', attr: { render: 'ssr', head } }] }] }) as any;
+
+  it('accepts a valid head declaration (and routes without head are untouched)', () => {
+    expect(() => extractRoutes(withHead({ data: async () => ({}), timeoutMs: 3000, optional: true }))).not.toThrow();
+    expect(() => extractRoutes(withHead(undefined))).not.toThrow();
+  });
+
+  it('rejects a non-function data', () => {
+    expect(() => extractRoutes(withHead({ data: 42 }))).toThrow(/attr\.head\.data must be a function/);
+  });
+
+  it.each([[0], [-1], [Number.NaN], [Infinity], ['5000']])('rejects timeoutMs %s (positive finite only - RFC 0004 ruling 3)', (v) => {
+    expect(() => extractRoutes(withHead({ data: async () => ({}), timeoutMs: v }))).toThrow(/attr\.head\.timeoutMs must be a positive finite number/);
+  });
+
+  it('rejects a non-boolean optional', () => {
+    expect(() => extractRoutes(withHead({ data: async () => ({}), optional: 'yes' }))).toThrow(/attr\.head\.optional must be a boolean/);
+  });
+
+  it('names the offending route and app', () => {
+    expect(() => extractRoutes(withHead({ data: 42 }))).toThrow(/Route "\/product\/:id" \(app "shop"\)/);
+  });
+});

--- a/packages/server/src/core/config/types.ts
+++ b/packages/server/src/core/config/types.ts
@@ -37,6 +37,45 @@ export type DataHandler<Params extends PathToRegExpParams, L extends Logs = Logs
   ctx: (RequestServiceContext<L> & { call: RegistryCaller<ServiceRegistry> }) & { [key: string]: unknown },
 ) => Promise<DataResult>;
 
+// RFC 0004 (H1): TYPE-ONLY brand symbol - `declare` means it never exists at runtime, and
+// `serviceData()` stamps no such property on the handler it returns.
+declare const SERVICE_RESULT: unique symbol;
+
+/**
+ * RFC 0004 (H1): a `DataHandler` produced by `serviceData()`, carrying the selected service
+ * method's eventual (post-dispatch) result as a PHANTOM type brand. The callable's declared
+ * return stays the honest service DESCRIPTOR - the runtime value really is the descriptor, and
+ * the server dispatches it - while the brand tells the type system what that dispatch resolves
+ * to, so `HeadDataOf` (and future `RouteDataOf` work) can infer the real payload instead of the
+ * descriptor shape.
+ */
+export type ServiceDataHandler<Result, Params extends PathToRegExpParams = PathToRegExpParams, L extends Logs = Logs> = DataHandler<Params, L> & {
+  readonly [SERVICE_RESULT]: Result;
+};
+
+/**
+ * RFC 0004 (H1): per-route dynamic head data, resolved BEFORE the renderer starts on BOTH
+ * strategies and delivered to the renderer as `opts.headData` (never serialised into
+ * `__INITIAL_DATA__` - ruling 1). `attr.meta` remains the static layer (ruling 5).
+ */
+export type HeadAttributes<Params extends PathToRegExpParams = PathToRegExpParams, L extends Logs = Logs> = {
+  /** Head data loader - same shape as `attr.data` (plain object or `ServiceDescriptor`, incl. `serviceData()` sugar). */
+  data: DataHandler<Params, L>;
+  /**
+   * Head loader deadline in ms - POSITIVE FINITE only, validated at boot (default 3000). On
+   * expiry with the request still live, the render proceeds with `headData: undefined` plus an
+   * advisory log (RFC 0004 Policy ii). There is deliberately no wait-forever sentinel: the head
+   * blocks the shell, so its deadline stays bounded.
+   */
+  timeoutMs?: number;
+  /**
+   * Opt-in recoverability for ORDINARY loader rejection: `true` degrades a rejection like a
+   * deadline expiry (undefined + advisory) instead of failing the request. Default `false` -
+   * real application defects stay visible on the existing error path.
+   */
+  optional?: boolean;
+};
+
 export type RouteAttributes<Params extends PathToRegExpParams = PathToRegExpParams, Middleware = BaseMiddleware, L extends Logs = Logs> =
   | {
       render: 'ssr';
@@ -44,6 +83,7 @@ export type RouteAttributes<Params extends PathToRegExpParams = PathToRegExpPara
       meta?: Record<string, unknown>;
       middleware?: Middleware;
       data?: DataHandler<Params, L>;
+      head?: HeadAttributes<Params, L>;
     }
   | {
       render: 'streaming';
@@ -51,6 +91,7 @@ export type RouteAttributes<Params extends PathToRegExpParams = PathToRegExpPara
       meta: Record<string, unknown>;
       middleware?: Middleware;
       data?: DataHandler<Params, L>;
+      head?: HeadAttributes<Params, L>;
     };
 
 export type Route<Params extends PathToRegExpParams = PathToRegExpParams> = {
@@ -70,6 +111,27 @@ export type RoutesOfApp<C extends { apps: readonly any[] }, A extends AppId<C>> 
   : never;
 
 export type RouteDataOf<R> = R extends { attr?: { data?: (...args: any) => infer Ret } } ? Awaited<Ret> : unknown;
+
+/**
+ * RFC 0004 (H1): the type `headContent` receives as `headData` for a route. Three arms, pinned
+ * by `test/HeadDataOf.test-d.ts` (a signed hard gate):
+ * - `serviceData()` sugar: the SELECTED METHOD's resolved result, read from the phantom brand -
+ *   never the descriptor, never `Record<string, unknown>`;
+ * - closure handler: its resolved return type (descriptor returns collapse to
+ *   `Record<string, unknown>` - the dispatch result is untyped for hand-built descriptors);
+ * - no `attr.head`: `undefined`.
+ */
+export type HeadDataOf<R> = R extends { attr?: infer A }
+  ? A extends { head: { data: infer H } }
+    ? H extends { readonly [SERVICE_RESULT]: infer Res }
+      ? Res
+      : H extends (...args: any) => infer Ret
+        ? Exclude<Awaited<Ret>, ServiceDescriptor> extends never
+          ? Record<string, unknown>
+          : Exclude<Awaited<Ret>, ServiceDescriptor>
+        : unknown
+    : undefined
+  : undefined;
 
 export type RoutePathOf<R> = R extends { path: infer P } ? P : never;
 

--- a/packages/server/src/core/config/types.ts
+++ b/packages/server/src/core/config/types.ts
@@ -126,12 +126,19 @@ export type HeadDataOf<R> = R extends { attr?: infer A }
     ? H extends { readonly [SERVICE_RESULT]: infer Res }
       ? Res
       : H extends (...args: any) => infer Ret
-        ? Exclude<Awaited<Ret>, ServiceDescriptor> extends never
-          ? Record<string, unknown>
-          : Exclude<Awaited<Ret>, ServiceDescriptor>
+        ? DescriptorMemberToRecord<Awaited<Ret>>
         : unknown
     : undefined
   : undefined;
+
+/**
+ * Distributes over a closure handler's return union: a descriptor MEMBER resolves (via service
+ * dispatch) to an untyped record, so it contributes `Record<string, unknown>` to the union - it
+ * must never be EXCLUDED, which would falsely narrow a mixed `{ title } | ServiceDescriptor`
+ * return to `{ title }` alone (gate-recheck finding: the dispatched branch may resolve to any
+ * record). Pure-object returns stay precise; pure-descriptor returns collapse to the record.
+ */
+type DescriptorMemberToRecord<V> = V extends ServiceDescriptor ? Record<string, unknown> : V;
 
 export type RoutePathOf<R> = R extends { path: infer P } ? P : never;
 

--- a/packages/server/src/core/routes/DataRoutes.ts
+++ b/packages/server/src/core/routes/DataRoutes.ts
@@ -142,6 +142,48 @@ export const matchAllRoutes = <Params extends PathToRegExpParams>(url: string, r
   return matches;
 };
 
+/**
+ * RFC 0004 (H1): resolve `attr.head.data` - the same dispatch shape as `fetchInitialData`
+ * (handler -> `ServiceDescriptor` ? service call : plain object), returning `undefined` when the
+ * route declares no head. Deliberately NO logging or error classification here: the caller
+ * (`HandleRender`'s head resolution) owns the signed abort/deadline/rejection taxonomy, so raw
+ * rejections propagate untouched.
+ */
+export const fetchHeadData = async <Params extends PathToRegExpParams, R extends ServiceRegistry, L extends Logs = Logs>(
+  attr: RouteAttributes<Params> | undefined,
+  params: Params,
+  serviceRegistry: R,
+  ctx: RequestContext<L>,
+  callServiceMethodImpl: CallServiceOn<R> = callServiceMethod as CallServiceOn<R>,
+): Promise<Record<string, unknown> | undefined> => {
+  const headHandler = attr?.head?.data;
+  if (!headHandler || typeof headHandler !== 'function') return undefined;
+
+  const ctxForData: RequestServiceContext<L> = {
+    ...ctx,
+    headers: ctx.headers ?? {},
+  } as const;
+
+  ensureServiceCaller(serviceRegistry, ctxForData as ServiceContext & Partial<{ call: typeof ctxForData.call }>);
+
+  const result = await headHandler(
+    params,
+    ctxForData as unknown as RequestServiceContext<L> & {
+      call: NonNullable<RequestServiceContext<L>['call']>;
+    } & { [key: string]: unknown },
+  );
+
+  if (isServiceDescriptor(result)) {
+    const { serviceName, serviceMethod, args } = result;
+
+    return callServiceMethodImpl(serviceRegistry, serviceName, serviceMethod, args ?? {}, ctxForData);
+  }
+
+  if (isPlainObject(result)) return result;
+
+  throw AppError.badRequest('attr.head.data must return a plain object or a ServiceDescriptor');
+};
+
 export const fetchInitialData = async <Params extends PathToRegExpParams, R extends ServiceRegistry, L extends Logs = Logs>(
   attr: RouteAttributes<Params> | undefined,
   params: Params,

--- a/packages/server/src/core/routes/test/DataRoutes.test.ts
+++ b/packages/server/src/core/routes/test/DataRoutes.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import { createRouteMatchers, matchRoute, matchAllRoutes, extractRouteParams, getRouteStats, fetchInitialData } from '../DataRoutes';
+import { createRouteMatchers, matchRoute, matchAllRoutes, extractRouteParams, getRouteStats, fetchHeadData, fetchInitialData } from '../DataRoutes';
 import { AppError } from '../../errors/AppError';
 
 const mkRoute = (path: string, appId = 'app', attr: any = {}) => ({ path, appId, attr }) as any;
@@ -448,5 +448,50 @@ describe('fetchInitialData', () => {
         logged: true,
       }),
     );
+  });
+});
+
+describe('fetchHeadData (RFC 0004 H1)', () => {
+  const registry = {
+    svc: {
+      head: { handler: vi.fn(async () => ({ t: 'x' })) },
+    },
+  } as any;
+
+  const mkCtx = () => ({ traceId: 'test-trace', headers: {}, logger: { error: vi.fn(), warn: vi.fn() } });
+
+  it('returns undefined when the route declares no head', async () => {
+    expect(await fetchHeadData(undefined as any, {} as any, registry, mkCtx() as any)).toBeUndefined();
+    expect(await fetchHeadData({ render: 'ssr' } as any, {} as any, registry, mkCtx() as any)).toBeUndefined();
+    expect(await fetchHeadData({ head: { data: null } } as any, {} as any, registry, mkCtx() as any)).toBeUndefined();
+  });
+
+  it('returns a plain object from the head handler', async () => {
+    const attr = { head: { data: vi.fn(async () => ({ title: 'T' })) } } as any;
+    expect(await fetchHeadData(attr, {} as any, registry, mkCtx() as any)).toEqual({ title: 'T' });
+  });
+
+  it('dispatches a ServiceDescriptor via callServiceMethodImpl', async () => {
+    const attr = {
+      head: { data: vi.fn(async () => ({ serviceName: 'svc', serviceMethod: 'head', args: { id: '1' } })) },
+    } as any;
+    const impl = vi.fn(async () => ({ title: 'from-service' }));
+
+    const out = await fetchHeadData(attr, {} as any, registry, mkCtx() as any, impl as any);
+    expect(impl).toHaveBeenCalledWith(registry, 'svc', 'head', { id: '1' }, expect.any(Object));
+    expect(out).toEqual({ title: 'from-service' });
+  });
+
+  it('throws badRequest for non-object non-descriptor returns', async () => {
+    const attr = { head: { data: vi.fn(async () => 42 as any) } } as any;
+    await expect(fetchHeadData(attr, {} as any, registry, mkCtx() as any)).rejects.toThrow(
+      /attr\.head\.data must return a plain object or a ServiceDescriptor/,
+    );
+  });
+
+  it('propagates raw rejections unclassified - the caller owns the taxonomy', async () => {
+    const boom = new Error('head boom');
+    const attr = { head: { data: vi.fn(async () => Promise.reject(boom)) } } as any;
+    await expect(fetchHeadData(attr, {} as any, registry, mkCtx() as any)).rejects.toBe(boom);
   });
 });

--- a/packages/server/src/core/services/ServiceData.ts
+++ b/packages/server/src/core/services/ServiceData.ts
@@ -1,4 +1,4 @@
-import type { DataHandler, PathToRegExpParams } from '../config/types';
+import type { DataHandler, PathToRegExpParams, ServiceDataHandler } from '../config/types';
 import type { JsonObject, ServiceMethodParams, ServiceRegistry } from './DataServices';
 
 // Module-private: graph code reads via getServiceDataMetadata, never the symbol itself.
@@ -21,10 +21,13 @@ type ServiceDataArgs<R extends ServiceRegistry, S extends keyof R & string, M ex
 // builds the descriptor at request time — dispatch stays in fetchInitialData — and stamps
 // non-enumerable metadata so createRequestGraph can read the declared route → service edge
 // without executing the handler.
+// RFC 0004 (H1): the eventual result of dispatching the selected method's descriptor.
+type ServiceMethodResult<F> = F extends (...args: any[]) => infer P ? Awaited<P> : never;
+
 export function createServiceData<R extends ServiceRegistry>() {
   return function serviceData<S extends keyof R & string, M extends keyof R[S] & string>(
     ...[serviceName, serviceMethod, mapper]: ServiceDataArgs<R, S, M>
-  ): DataHandler<PathToRegExpParams> {
+  ): ServiceDataHandler<ServiceMethodResult<R[S][M]>> {
     const handler: DataHandler<PathToRegExpParams> = async (params) => ({
       serviceName,
       serviceMethod,
@@ -36,7 +39,9 @@ export function createServiceData<R extends ServiceRegistry>() {
       enumerable: false,
     });
 
-    return handler;
+    // RFC 0004 (H1): the ONLY brand seam. The cast is type-level - no property is added; the
+    // handler still returns the honest descriptor at runtime (see ServiceDataHandler's JSDoc).
+    return handler as ServiceDataHandler<ServiceMethodResult<R[S][M]>>;
   };
 }
 

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -100,7 +100,11 @@ export type RenderSSR = (
   location: string,
   meta?: Record<string, unknown>,
   signal?: AbortSignal,
-  opts?: { logger?: RendererLogger; routeContext?: unknown },
+  // RFC 0004 (H1): `headData` is the route's resolved `attr.head` payload (undefined when the
+  // route declares none, or when the head degraded under the signed policy). BROAD at this
+  // boundary by design - the host stores heterogeneous render modules and cannot know a route's
+  // `H`; the renderer narrows at its own internal seam (the same trust model as the body data).
+  opts?: { logger?: RendererLogger; routeContext?: unknown; headData?: Record<string, unknown> },
 ) => Promise<{
   headContent: string;
   appHtml: string;
@@ -136,7 +140,8 @@ export type RenderStream = (
   meta?: Record<string, unknown>,
   cspNonce?: string,
   signal?: AbortSignal,
-  opts?: { logger?: RendererLogger; routeContext?: unknown },
+  // RFC 0004 (H1): see RenderSSR's `headData` note - resolved pre-shell, broad at this boundary.
+  opts?: { logger?: RendererLogger; routeContext?: unknown; headData?: Record<string, unknown> },
 ) => RenderStreamHandle;
 
 export type RenderModule = {

--- a/packages/server/src/utils/HandleRender.ts
+++ b/packages/server/src/utils/HandleRender.ts
@@ -3,7 +3,7 @@ import { PassThrough } from 'node:stream';
 
 import { RENDERTYPE } from '../core/constants';
 import { AppError, normaliseError, toReason } from '../core/errors/AppError';
-import { fetchInitialData, matchRoute } from '../core/routes/DataRoutes';
+import { fetchHeadData, fetchInitialData, matchRoute } from '../core/routes/DataRoutes';
 import { now } from '../core/telemetry/Telemetry';
 import { resolveEntryFile } from '../Build';
 import { createLogger } from '../logging/Logger';
@@ -246,6 +246,64 @@ export const handleRender = async (
       }
     };
 
+    // RFC 0004 (H1): resolve `attr.head` BEFORE the renderer starts, on both strategies. Signed
+    // taxonomy, tracked by WHICH source fired (never inferred from error shape - R0-02 doctrine):
+    // - caller abort  -> { aborted: true }; the branch returns through its existing abort path -
+    //                    a dead request never proceeds into the renderer with degraded head data;
+    // - deadline      -> Policy ii: proceed with headData undefined + an advisory warn. The
+    //                    deadline WINS THE AWAIT via a race (a loader that ignores ctx.signal
+    //                    cannot hold the shell hostage); the loser's eventual settlement is
+    //                    pre-observed so it can never raise unhandledRejection (R0-01 class);
+    // - rejection     -> rethrow into the branch's existing error path, unless the route opted in
+    //                    with `head.optional`, which degrades like the deadline.
+    // No recorder events here - request-graph/trace support is the rule-11 escalation (H4).
+    const resolveHeadData = async (requestSignal: AbortSignal): Promise<{ aborted: boolean; headData?: Record<string, unknown> }> => {
+      const head = attr?.head;
+      if (!head) return { aborted: false, headData: undefined };
+      if (requestSignal.aborted) return { aborted: true };
+
+      const timeoutMs = head.timeoutMs ?? 3_000;
+      const headAbort = new AbortController();
+      let deadlineHit = false;
+      const onRequestAbort = () => headAbort.abort((requestSignal as { reason?: unknown }).reason ?? new Error('request aborted'));
+      requestSignal.addEventListener('abort', onRequestAbort, { once: true });
+      const timer = setTimeout(() => {
+        deadlineHit = true;
+        headAbort.abort(new Error(`head data deadline (${timeoutMs}ms) reached`));
+      }, timeoutMs);
+
+      const abortRace = new Promise<never>((_, rejectRace) => {
+        headAbort.signal.addEventListener('abort', () => rejectRace(headAbort.signal.reason ?? new Error('head data aborted')), { once: true });
+      });
+      abortRace.catch(() => {}); // pre-observed: the race loser must never be an unhandled rejection
+
+      try {
+        // Same shape as the body-data ctx, but with the HEAD controller's signal: loaders that
+        // honour ctx.signal stop on the head deadline as well as on client disconnect.
+        const headCtx = { ...ctx, signal: headAbort.signal };
+        const fetchPromise = fetchHeadData(attr, params, serviceRegistry, headCtx);
+        fetchPromise.catch(() => {}); // pre-observed for the same reason (a late loser settlement is discarded)
+
+        const headData = await Promise.race([fetchPromise, abortRace]);
+        return { aborted: false, headData };
+      } catch (err) {
+        if (requestSignal.aborted) return { aborted: true };
+        if (deadlineHit || head.optional === true) {
+          logger.warn(
+            { url: req.url, timeoutMs, optional: head.optional === true, reason: safeErrorMessage(err) },
+            'Head data degraded; rendering with headData undefined',
+          );
+          return { aborted: false, headData: undefined };
+        }
+        throw err;
+      } finally {
+        clearTimeout(timer);
+        try {
+          requestSignal.removeEventListener('abort', onRequestAbort);
+        } catch {}
+      }
+    };
+
     if (renderType === RENDERTYPE.ssr) {
       const { renderSSR } = renderModule;
       if (!renderSSR) {
@@ -279,10 +337,23 @@ export const handleRender = async (
 
       const initialDataResolved = await initialDataInput();
 
+      // RFC 0004 (H1): head data resolves after the body data (both are pre-render on this
+      // strategy); a caller abort during either returns through the same abort path.
+      const headResolution = await resolveHeadData(ac.signal);
+      if (headResolution.aborted) {
+        logger.warn({ url: req.url }, 'SSR skipped; client disconnected during head data');
+        recorder?.aborted({ traceId, phase: 'pre-render' });
+        return;
+      }
+
       let headContent = '';
       let appHtml = '';
       try {
-        const res = await renderSSR(initialDataResolved, req.url!, attr?.meta, ac.signal, { logger: reqLogger, routeContext });
+        const res = await renderSSR(initialDataResolved, req.url!, attr?.meta, ac.signal, {
+          logger: reqLogger,
+          routeContext,
+          headData: headResolution.headData,
+        });
         headContent = res.headContent;
         appHtml = res.appHtml;
 
@@ -428,6 +499,36 @@ export const handleRender = async (
       let finalData: unknown = undefined;
       let pipedToReply = false;
 
+      // RFC 0004 (H1): head data resolves BEFORE the stream starts - the only pre-shell await on
+      // this strategy (body data streams as always). Placed AFTER the socket/writable guard
+      // wiring so those handlers observe errors during the head fetch too. The reply is already
+      // HIJACKED, so every arm must settle the raw socket itself - the outer catch rethrows into
+      // Fastify, which no longer owns this response and would leave the socket hanging.
+      let headResolution: { aborted: boolean; headData?: Record<string, unknown> };
+      try {
+        headResolution = await resolveHeadData(ac.signal);
+      } catch (err) {
+        // Non-optional head rejection: terminate deterministically (the finish-listener
+        // serialize-failure idiom) - 500 if the head has not been committed, destroy otherwise.
+        logger.error({ error: safeNormaliseError(err), url: req.url }, 'Head data failed; terminating streaming request');
+        recorder?.failed({ traceId, error: { kind: safeErrorKind(err), message: safeErrorMessage(err) } });
+        try {
+          if (!reply.raw.headersSent) {
+            reply.raw.writeHead(500, { 'Content-Type': 'text/html; charset=utf-8' });
+            reply.raw.end('Internal Server Error');
+          } else if (!reply.raw.writableEnded && !reply.raw.destroyed) {
+            reply.raw.destroy();
+          }
+        } catch {}
+        return;
+      }
+      if (headResolution.aborted) {
+        try {
+          if (!reply.raw.writableEnded && !reply.raw.destroyed) reply.raw.destroy();
+        } catch {}
+        return;
+      }
+
       const { done } = renderStream(
         writable,
         {
@@ -539,7 +640,7 @@ export const handleRender = async (
         attr?.meta,
         cspNonce,
         ac.signal,
-        { logger: reqLogger, routeContext },
+        { logger: reqLogger, routeContext, headData: headResolution.headData },
       );
 
       // R0-01: observe the stream handle's `done`. Fatal stream errors are already fully handled

--- a/packages/server/src/utils/HandleRender.ts
+++ b/packages/server/src/utils/HandleRender.ts
@@ -349,10 +349,12 @@ export const handleRender = async (
       let headContent = '';
       let appHtml = '';
       try {
+        // RFC 0004: `headData` is present only when the route's head RESOLVED to a value -
+        // conditional spread so no-head (and degraded) routes show no observable key.
         const res = await renderSSR(initialDataResolved, req.url!, attr?.meta, ac.signal, {
           logger: reqLogger,
           routeContext,
-          headData: headResolution.headData,
+          ...(headResolution.headData !== undefined ? { headData: headResolution.headData } : {}),
         });
         headContent = res.headContent;
         appHtml = res.appHtml;
@@ -510,8 +512,13 @@ export const handleRender = async (
       } catch (err) {
         // Non-optional head rejection: terminate deterministically (the finish-listener
         // serialize-failure idiom) - 500 if the head has not been committed, destroy otherwise.
-        logger.error({ error: safeNormaliseError(err), url: req.url }, 'Head data failed; terminating streaming request');
-        recorder?.failed({ traceId, error: { kind: safeErrorKind(err), message: safeErrorMessage(err) } });
+        // Telemetry is BELTED INDEPENDENTLY of the teardown (gate-review finding 1, same rule as
+        // the fatal-stream path): a throwing host logger/recorder must never skip the raw-socket
+        // settlement - the outer catch rethrows into Fastify, which no longer owns this response.
+        try {
+          logger.error({ error: safeNormaliseError(err), url: req.url }, 'Head data failed; terminating streaming request');
+          recorder?.failed({ traceId, error: { kind: safeErrorKind(err), message: safeErrorMessage(err) } });
+        } catch {}
         try {
           if (!reply.raw.headersSent) {
             reply.raw.writeHead(500, { 'Content-Type': 'text/html; charset=utf-8' });
@@ -640,7 +647,8 @@ export const handleRender = async (
         attr?.meta,
         cspNonce,
         ac.signal,
-        { logger: reqLogger, routeContext, headData: headResolution.headData },
+        // RFC 0004: conditional inclusion - see the renderSSR call site.
+        { logger: reqLogger, routeContext, ...(headResolution.headData !== undefined ? { headData: headResolution.headData } : {}) },
       );
 
       // R0-01: observe the stream handle's `done`. Fatal stream errors are already fully handled

--- a/packages/server/src/utils/test/HandleRender.test.ts
+++ b/packages/server/src/utils/test/HandleRender.test.ts
@@ -3017,7 +3017,7 @@ describe('handleRender', () => {
       expect(renderSSR).toHaveBeenCalledWith({ body: 1 }, '/test-path', undefined, expect.anything(), expect.objectContaining({ headData: { ogTitle: 'X' } }));
     });
 
-    it('ssr: no attr.head -> fetchHeadData is never called and opts.headData is undefined (byte-identical guard)', async () => {
+    it('ssr: no attr.head -> fetchHeadData is never called and no headData key exists (byte-identical guard)', async () => {
       useRealAbortController();
       stubTemplate();
       vi.mocked(DataRoutes.matchRoute).mockReturnValue(createMockRouteMatch({ render: 'ssr' }));
@@ -3027,13 +3027,7 @@ describe('handleRender', () => {
       await handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps);
 
       expect(DataRoutes.fetchHeadData).not.toHaveBeenCalled();
-      expect(renderSSR).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.anything(),
-        undefined,
-        expect.anything(),
-        expect.objectContaining({ headData: undefined }),
-      );
+      expect(Object.hasOwn((renderSSR as Mock).mock.calls[0]![4], 'headData')).toBe(false);
     });
 
     it('ssr: deadline expiry degrades to undefined with an advisory warn (Policy ii)', async () => {
@@ -3050,13 +3044,7 @@ describe('handleRender', () => {
         expect.objectContaining({ timeoutMs: 20, optional: false }),
         'Head data degraded; rendering with headData undefined',
       );
-      expect(renderSSR).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.anything(),
-        undefined,
-        expect.anything(),
-        expect.objectContaining({ headData: undefined }),
-      );
+      expect(Object.hasOwn((renderSSR as Mock).mock.calls[0]![4], 'headData')).toBe(false);
     });
 
     it('ssr: a non-optional head rejection fails the request through the existing error path', async () => {
@@ -3087,13 +3075,7 @@ describe('handleRender', () => {
         expect.objectContaining({ optional: true, reason: 'flaky head service' }),
         'Head data degraded; rendering with headData undefined',
       );
-      expect(renderSSR).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.anything(),
-        undefined,
-        expect.anything(),
-        expect.objectContaining({ headData: undefined }),
-      );
+      expect(Object.hasOwn((renderSSR as Mock).mock.calls[0]![4], 'headData')).toBe(false);
     });
 
     it('ssr: caller abort during the head fetch skips the render (never proceeds degraded)', async () => {
@@ -3140,6 +3122,76 @@ describe('handleRender', () => {
       expect(mockReply.raw.writeHead).toHaveBeenCalledWith(500, expect.anything());
       expect(mockReply.raw.end).toHaveBeenCalledWith('Internal Server Error');
       expect(mockLogger.error).toHaveBeenCalledWith(expect.anything(), 'Head data failed; terminating streaming request');
+    });
+
+    it('streaming: deadline expiry degrades to an ABSENT headData key with an advisory warn (Policy ii)', async () => {
+      useRealAbortController();
+      stubTemplate();
+      vi.mocked(DataRoutes.matchRoute).mockReturnValue(
+        createMockRouteMatch({ render: 'streaming', meta: {}, head: { data: async () => ({}), timeoutMs: 20 } }),
+      );
+      vi.mocked(DataRoutes.fetchHeadData).mockImplementation(() => new Promise(() => {}));
+      const renderStream = streamModule();
+
+      await handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps);
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ timeoutMs: 20, optional: false }),
+        'Head data degraded; rendering with headData undefined',
+      );
+      expect(renderStream).toHaveBeenCalledTimes(1);
+      expect(Object.hasOwn((renderStream as Mock).mock.calls[0]![8], 'headData')).toBe(false);
+    });
+
+    it('streaming: head.optional degrades an ordinary rejection and the stream still starts', async () => {
+      useRealAbortController();
+      stubTemplate();
+      vi.mocked(DataRoutes.matchRoute).mockReturnValue(
+        createMockRouteMatch({ render: 'streaming', meta: {}, head: { data: async () => ({}), optional: true } }),
+      );
+      vi.mocked(DataRoutes.fetchHeadData).mockRejectedValue(new Error('flaky head service'));
+      const renderStream = streamModule();
+
+      await handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps);
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ optional: true, reason: 'flaky head service' }),
+        'Head data degraded; rendering with headData undefined',
+      );
+      expect(renderStream).toHaveBeenCalledTimes(1);
+      expect(Object.hasOwn((renderStream as Mock).mock.calls[0]![8], 'headData')).toBe(false);
+      expect(mockReply.raw.writeHead).not.toHaveBeenCalledWith(500, expect.anything());
+    });
+
+    it('streaming: no attr.head -> fetchHeadData never called and no headData key (byte-identical parity)', async () => {
+      useRealAbortController();
+      stubTemplate();
+      vi.mocked(DataRoutes.matchRoute).mockReturnValue(createMockRouteMatch({ render: 'streaming', meta: {} }));
+      const renderStream = streamModule();
+
+      await handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps);
+
+      expect(DataRoutes.fetchHeadData).not.toHaveBeenCalled();
+      expect(renderStream).toHaveBeenCalledTimes(1);
+      expect(Object.hasOwn((renderStream as Mock).mock.calls[0]![8], 'headData')).toBe(false);
+    });
+
+    it('streaming: a THROWING host logger cannot skip the hijacked-socket teardown on head failure (belted telemetry)', async () => {
+      useRealAbortController();
+      stubTemplate();
+      vi.mocked(DataRoutes.matchRoute).mockReturnValue(createMockRouteMatch({ render: 'streaming', meta: {}, head: { data: async () => ({}) } }));
+      vi.mocked(DataRoutes.fetchHeadData).mockRejectedValue(new Error('head boom'));
+      mockLogger.error.mockImplementation(() => {
+        throw new Error('hostile logger');
+      });
+      const renderStream = streamModule();
+
+      // Must resolve (no escape into the outer catch) AND still terminate the response.
+      await handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps);
+
+      expect(renderStream).not.toHaveBeenCalled();
+      expect(mockReply.raw.writeHead).toHaveBeenCalledWith(500, expect.anything());
+      expect(mockReply.raw.end).toHaveBeenCalledWith('Internal Server Error');
     });
 
     it('streaming: caller abort during the head fetch destroys the hijacked socket without starting the stream', async () => {

--- a/packages/server/src/utils/test/HandleRender.test.ts
+++ b/packages/server/src/utils/test/HandleRender.test.ts
@@ -2967,4 +2967,195 @@ describe('handleRender', () => {
       expect(mockRenderModule.renderSSR).toHaveBeenCalled();
     });
   });
+  describe('RFC 0004 (H1): head data resolution', () => {
+    // resolveHeadData needs REAL AbortController/AbortSignal semantics (listeners + race); the
+    // suite default is a no-op mock, so every test here restores the real one (the faithful-AC
+    // precedent from the R1 gate coverage work).
+    const useRealAbortController = () => {
+      (globalThis as any).AbortController = OriginalAbortController;
+    };
+
+    const stubTemplate = () => {
+      vi.mocked(Templates.ensureNonNull).mockReturnValue('<html></html>');
+      vi.mocked(Templates.processTemplate).mockReturnValue({
+        beforeHead: '<html><head>',
+        afterHead: '</head>',
+        beforeBody: '<body>',
+        afterBody: '</body></html>',
+      } as any);
+      vi.mocked(Templates.rebuildTemplate).mockReturnValue('<html>full</html>');
+    };
+
+    const ssrModule = () => {
+      const renderSSR = vi.fn(async () => ({ headContent: '<title>t</title>', appHtml: '<div></div>' }));
+      mockMaps.renderModules.set('/test/client', { renderSSR });
+      return renderSSR;
+    };
+
+    const streamModule = () => {
+      const renderStream = vi.fn(() => ({ abort: vi.fn(), done: Promise.resolve() }));
+      mockMaps.renderModules.set('/test/client', { renderStream });
+      return renderStream;
+    };
+
+    const firedAbortedHandler = () => {
+      const call = (mockReq.raw.on as Mock).mock.calls.find((c: any[]) => c[0] === 'aborted');
+      expect(call).toBeDefined();
+      call![1]();
+    };
+
+    it('ssr: resolved head data reaches renderSSR opts.headData', async () => {
+      useRealAbortController();
+      stubTemplate();
+      vi.mocked(DataRoutes.matchRoute).mockReturnValue(createMockRouteMatch({ render: 'ssr', head: { data: async () => ({}) } }));
+      vi.mocked(DataRoutes.fetchInitialData).mockResolvedValue({ body: 1 });
+      vi.mocked(DataRoutes.fetchHeadData).mockResolvedValue({ ogTitle: 'X' });
+      const renderSSR = ssrModule();
+
+      await handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps);
+
+      expect(renderSSR).toHaveBeenCalledWith({ body: 1 }, '/test-path', undefined, expect.anything(), expect.objectContaining({ headData: { ogTitle: 'X' } }));
+    });
+
+    it('ssr: no attr.head -> fetchHeadData is never called and opts.headData is undefined (byte-identical guard)', async () => {
+      useRealAbortController();
+      stubTemplate();
+      vi.mocked(DataRoutes.matchRoute).mockReturnValue(createMockRouteMatch({ render: 'ssr' }));
+      vi.mocked(DataRoutes.fetchInitialData).mockResolvedValue({});
+      const renderSSR = ssrModule();
+
+      await handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps);
+
+      expect(DataRoutes.fetchHeadData).not.toHaveBeenCalled();
+      expect(renderSSR).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        undefined,
+        expect.anything(),
+        expect.objectContaining({ headData: undefined }),
+      );
+    });
+
+    it('ssr: deadline expiry degrades to undefined with an advisory warn (Policy ii)', async () => {
+      useRealAbortController();
+      stubTemplate();
+      vi.mocked(DataRoutes.matchRoute).mockReturnValue(createMockRouteMatch({ render: 'ssr', head: { data: async () => ({}), timeoutMs: 20 } }));
+      vi.mocked(DataRoutes.fetchInitialData).mockResolvedValue({});
+      vi.mocked(DataRoutes.fetchHeadData).mockImplementation(() => new Promise(() => {}));
+      const renderSSR = ssrModule();
+
+      await handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps);
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ timeoutMs: 20, optional: false }),
+        'Head data degraded; rendering with headData undefined',
+      );
+      expect(renderSSR).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        undefined,
+        expect.anything(),
+        expect.objectContaining({ headData: undefined }),
+      );
+    });
+
+    it('ssr: a non-optional head rejection fails the request through the existing error path', async () => {
+      useRealAbortController();
+      stubTemplate();
+      vi.mocked(DataRoutes.matchRoute).mockReturnValue(createMockRouteMatch({ render: 'ssr', head: { data: async () => ({}) } }));
+      vi.mocked(DataRoutes.fetchInitialData).mockResolvedValue({});
+      vi.mocked(DataRoutes.fetchHeadData).mockRejectedValue(new Error('head boom'));
+      const renderSSR = ssrModule();
+
+      await expect(handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps)).rejects.toThrow(
+        /handleRender failed/,
+      );
+      expect(renderSSR).not.toHaveBeenCalled();
+    });
+
+    it('ssr: head.optional degrades an ordinary rejection instead of failing', async () => {
+      useRealAbortController();
+      stubTemplate();
+      vi.mocked(DataRoutes.matchRoute).mockReturnValue(createMockRouteMatch({ render: 'ssr', head: { data: async () => ({}), optional: true } }));
+      vi.mocked(DataRoutes.fetchInitialData).mockResolvedValue({});
+      vi.mocked(DataRoutes.fetchHeadData).mockRejectedValue(new Error('flaky head service'));
+      const renderSSR = ssrModule();
+
+      await handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps);
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ optional: true, reason: 'flaky head service' }),
+        'Head data degraded; rendering with headData undefined',
+      );
+      expect(renderSSR).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        undefined,
+        expect.anything(),
+        expect.objectContaining({ headData: undefined }),
+      );
+    });
+
+    it('ssr: caller abort during the head fetch skips the render (never proceeds degraded)', async () => {
+      useRealAbortController();
+      stubTemplate();
+      vi.mocked(DataRoutes.matchRoute).mockReturnValue(createMockRouteMatch({ render: 'ssr', head: { data: async () => ({}) } }));
+      vi.mocked(DataRoutes.fetchInitialData).mockResolvedValue({});
+      vi.mocked(DataRoutes.fetchHeadData).mockImplementation(() => new Promise(() => {}));
+      const renderSSR = ssrModule();
+
+      const p = handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps);
+      await new Promise((r) => setTimeout(r, 10));
+      firedAbortedHandler();
+      await p;
+
+      expect(renderSSR).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledWith({ url: '/test-path' }, 'SSR skipped; client disconnected during head data');
+    });
+
+    it('streaming: resolved head data reaches renderStream opts', async () => {
+      useRealAbortController();
+      stubTemplate();
+      vi.mocked(DataRoutes.matchRoute).mockReturnValue(createMockRouteMatch({ render: 'streaming', meta: {}, head: { data: async () => ({}) } }));
+      vi.mocked(DataRoutes.fetchHeadData).mockResolvedValue({ t: 1 });
+      const renderStream = streamModule();
+
+      await handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps);
+
+      expect(renderStream).toHaveBeenCalledTimes(1);
+      const opts = (renderStream as Mock).mock.calls[0]![8];
+      expect(opts).toEqual(expect.objectContaining({ headData: { t: 1 } }));
+    });
+
+    it('streaming: a non-optional head rejection terminates with a 500 on the hijacked reply - never a rethrow', async () => {
+      useRealAbortController();
+      stubTemplate();
+      vi.mocked(DataRoutes.matchRoute).mockReturnValue(createMockRouteMatch({ render: 'streaming', meta: {}, head: { data: async () => ({}) } }));
+      vi.mocked(DataRoutes.fetchHeadData).mockRejectedValue(new Error('head boom'));
+      const renderStream = streamModule();
+
+      await handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps);
+
+      expect(renderStream).not.toHaveBeenCalled();
+      expect(mockReply.raw.writeHead).toHaveBeenCalledWith(500, expect.anything());
+      expect(mockReply.raw.end).toHaveBeenCalledWith('Internal Server Error');
+      expect(mockLogger.error).toHaveBeenCalledWith(expect.anything(), 'Head data failed; terminating streaming request');
+    });
+
+    it('streaming: caller abort during the head fetch destroys the hijacked socket without starting the stream', async () => {
+      useRealAbortController();
+      stubTemplate();
+      vi.mocked(DataRoutes.matchRoute).mockReturnValue(createMockRouteMatch({ render: 'streaming', meta: {}, head: { data: async () => ({}) } }));
+      vi.mocked(DataRoutes.fetchHeadData).mockImplementation(() => new Promise(() => {}));
+      const renderStream = streamModule();
+
+      const p = handleRender(mockReq, mockReply, mockRouteMatchers, mockProcessedConfigs, mockServiceRegistry, mockMaps);
+      await new Promise((r) => setTimeout(r, 10));
+      firedAbortedHandler();
+      await p;
+
+      expect(renderStream).not.toHaveBeenCalled();
+      expect(mockReply.raw.destroy).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/vue/src/SSRRender.ts
+++ b/packages/vue/src/SSRRender.ts
@@ -40,8 +40,21 @@ export type StreamOptions = {
  * value interpolated from `data` (or other services/user input) must be escaped with `escapeHtml`
  * (see the `headContent` option's docs).
  */
-export type HeadContext<T extends Record<string, unknown> = Record<string, unknown>, R = unknown> = {
+/**
+ * RFC 0004 (H6): `headData` is the route's `attr.head` payload, resolved by the host BEFORE the
+ * render and delivered via `opts.headData`. Optional by contract: `undefined` when the route
+ * declares no `attr.head` and when the head loader degraded under the server's signed policy -
+ * handle it (typically by falling back to `meta`). Vue's head stays SINGLE-BUILD, pre-render
+ * (signed: no timing change); `headData` simply widens what that one build can see. Escape
+ * `headData`-derived values with `escapeHtml` like any other dynamic head value.
+ */
+export type HeadContext<
+  T extends Record<string, unknown> = Record<string, unknown>,
+  R = unknown,
+  H extends Record<string, unknown> = Record<string, unknown>,
+> = {
   data: T;
+  headData?: H;
   meta: Record<string, unknown>;
   routeContext?: R;
 };
@@ -61,7 +74,9 @@ type SSRResult = {
 
 type StreamCallOptions<R> = StreamOptions & {
   logger?: LoggerLike;
-  routeContext?: R;
+  // RFC 0004 (H6): broad at the contract boundary; narrowed to R/H at the internal seams.
+  routeContext?: unknown;
+  headData?: Record<string, unknown>;
 };
 
 const NOOP = () => {};
@@ -97,7 +112,11 @@ function createAppWithStore<T>(store: SSRStore<T>, root: Component | ((props: an
  * server consumes only `headContent`/`appHtml` today, so splicing `teleports` into a page
  * is a standalone-consumer concern.
  */
-export function createRenderer<T extends Record<string, unknown> = Record<string, unknown>, R = unknown>({
+export function createRenderer<
+  T extends Record<string, unknown> = Record<string, unknown>,
+  R = unknown,
+  H extends Record<string, unknown> = Record<string, unknown>,
+>({
   appComponent,
   headContent,
   streamOptions = {},
@@ -118,7 +137,7 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
    * `` `<meta property="og:image" content="${escapeHtml(data.ogImage)}">` ``. See the head-management
    * guide, "Best Practices — Escape User Content".
    */
-  headContent: (ctx: HeadContext<T, R>) => string;
+  headContent: (ctx: HeadContext<T, R, H>) => string;
   enableDebug?: boolean;
   logger?: LoggerLike;
   streamOptions?: StreamOptions;
@@ -138,12 +157,15 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
 }) {
   const { shellTimeoutMs = 10_000 } = streamOptions;
 
+  // RFC 0004 (H6): contract-facing parameter types are BROAD (the H2 regularisation model) so a
+  // renderer instantiated with non-default generics stays assignable to the host contracts under
+  // strictFunctionTypes; values are trusted as T/H/R at one internal seam each.
   const renderSSR = async (
-    initialData: T,
+    initialData: Record<string, unknown>,
     location: string,
     meta: Record<string, unknown> = {},
     signal?: AbortSignal,
-    opts?: { logger?: LoggerLike; routeContext?: R },
+    opts?: { logger?: LoggerLike; routeContext?: unknown; headData?: Record<string, unknown> },
   ): Promise<SSRResult> => {
     const { log, warn } = createUILogger(opts?.logger ?? logger, {
       debugCategory: 'ssr',
@@ -160,17 +182,20 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
     const onAbort = () => (aborted = true);
     signal?.addEventListener('abort', onAbort, { once: true });
 
-    const routeContext = opts?.routeContext;
+    // The R narrowing seam (RFC 0004 H6).
+    const routeContext = opts?.routeContext as R | undefined;
 
     try {
       log('Starting SSR:', location);
 
+      // The T/H narrowing seam for this strategy.
       const dynamicHead = headContent({
-        data: initialData,
+        data: initialData as T,
+        headData: opts?.headData as H | undefined,
         meta,
         routeContext,
       });
-      const store = createSSRStore(initialData);
+      const store = createSSRStore(initialData as T);
 
       const app = createAppWithStore(store, appComponent, {
         location,
@@ -202,7 +227,7 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
   const renderStream = (
     writable: Writable,
     callbacks: RenderCallbacks<T>,
-    initialData: T | Promise<T> | (() => Promise<T>),
+    initialData: Record<string, unknown> | Promise<Record<string, unknown>> | (() => Promise<Record<string, unknown>>),
     location: string,
     bootstrapModules?: string,
     meta: Record<string, unknown> = {},
@@ -224,7 +249,8 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
       enableDebug,
     });
 
-    const routeContext = opts?.routeContext;
+    // The R narrowing seam (RFC 0004 H6).
+    const routeContext = opts?.routeContext as R | undefined;
     const effectiveShellTimeout = opts?.shellTimeoutMs ?? shellTimeoutMs;
 
     const controller = createStreamController(writable, { log, warn, error });
@@ -375,8 +401,9 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
 
     try {
       // `store` (the outer let) is what the sink's completion handler reads; `s` is a
-      // non-nullable alias for use within this synchronous+async block.
-      const s = createSSRStore(initialData);
+      // non-nullable alias for use within this synchronous+async block. This is the streaming
+      // strategy's T narrowing seam (RFC 0004 H6).
+      const s = createSSRStore(initialData as T | Promise<T> | (() => Promise<T>));
       store = s;
       const app = createAppWithStore(s, appComponent, { location, routeContext });
 
@@ -387,8 +414,11 @@ export function createRenderer<T extends Record<string, unknown> = Record<string
       // Head is built once from the current snapshot and delivered ONLY via onHead. In
       // streaming strategy the snapshot is usually still pending, so heads must be
       // derivable from meta/routeContext.
+      // RFC 0004 (H6): the H narrowing seam for this strategy - headData rides alongside the
+      // snapshot; the single pre-render build timing is unchanged (signed).
       const head = headContent({
         data: (s.getSnapshot() ?? {}) as T,
+        headData: opts?.headData as H | undefined,
         meta,
         routeContext,
       });

--- a/packages/vue/src/test/SSRRender.integration.test.ts
+++ b/packages/vue/src/test/SSRRender.integration.test.ts
@@ -341,6 +341,55 @@ describe('renderStream — server integration (byte order)', () => {
   });
 });
 
+describe('RFC 0004 (H6): headData reaches the single pre-render head build', () => {
+  it('renderSSR: opts.headData arrives typed as H; undefined when the host passes none', async () => {
+    const seen: Array<{ ogTitle: string } | undefined> = [];
+    const { renderSSR } = createRenderer<{ msg: string }, unknown, { ogTitle: string }>({
+      appComponent: defineComponent({
+        setup: () => () => h('div', 'x'),
+      }),
+      headContent: ({ data, headData }) => {
+        seen.push(headData);
+        return `<title>${headData?.ogTitle ?? data.msg}</title>`;
+      },
+    });
+
+    const withHead = await renderSSR({ msg: 'fallback' }, '/h', {}, undefined, { headData: { ogTitle: 'OG' } });
+    const withoutHead = await renderSSR({ msg: 'fallback' }, '/h', {});
+
+    expect(withHead.headContent).toBe('<title>OG</title>');
+    expect(withoutHead.headContent).toBe('<title>fallback</title>');
+    expect(seen).toEqual([{ ogTitle: 'OG' }, undefined]);
+  });
+
+  it('renderStream: opts.headData is visible in the head bytes written BEFORE the app bytes', async () => {
+    const { renderStream } = createRenderer<{ msg: string }, unknown, { ogTitle: string }>({
+      appComponent: defineComponent({
+        setup: () => () => h('div', 'app-bytes'),
+      }),
+      headContent: ({ headData }) => `<title>${headData?.ogTitle ?? 'fallback'}</title>`,
+    });
+
+    const collector = new Collector();
+    const { done } = renderStream(
+      collector as any,
+      { onHead: (headContent: string) => collector.chunks.push(`${TEMPLATE.beforeHead}${headContent}${TEMPLATE.afterHead}${TEMPLATE.beforeBody}`) },
+      { msg: 'x' },
+      '/stream-head',
+      undefined,
+      {},
+      undefined,
+      undefined,
+      { headData: { ogTitle: 'Dynamic OG' } },
+    );
+    await done;
+    const doc = collector.chunks.join('');
+
+    expect(doc.indexOf('<title>Dynamic OG</title>')).toBeGreaterThan(-1);
+    expect(doc.indexOf('<title>Dynamic OG</title>')).toBeLessThan(doc.indexOf('app-bytes'));
+  });
+});
+
 describe('renderStream — server-join regressions (gate review R2-03/R2-04)', () => {
   // Faithful reproduction of the server's streaming failure-path wiring (HandleRender.ts:419-602),
   // which driveLikeServer (happy-path byte order) deliberately omits: the head commit that connects

--- a/packages/vue/src/test/contract.test-d.ts
+++ b/packages/vue/src/test/contract.test-d.ts
@@ -44,3 +44,24 @@ void _contractSatisfiedByHandle;
 // 3. `done` is the load-bearing member (R0-01: an unobserved rejection is the process-crash class).
 const _done: Promise<void> = null as unknown as VueStreamHandle['done'];
 void _done;
+
+// ---------------------------------------------------------------------------------------------
+// RFC 0004 (H6) - HARD GATE (ruling 7, vue twin of react's): a renderer instantiated with
+// NON-DEFAULT generics must remain assignable to the host's broad contracts. Holds because the
+// contract-facing signatures are BROAD with internal narrowing seams (the H2 regularisation
+// model); re-narrowing any signature fails THESE lines, not production.
+type PageData = { title: string; body: string };
+type Ctx = { name: 'home' | 'article' };
+type Head = { ogTitle: string; ogImage?: string };
+
+const _typedRenderer = createRenderer<PageData, Ctx, Head>({
+  appComponent: () => h('div'),
+  headContent: ({ data, headData, meta, routeContext }) => `${data.title}${headData?.ogTitle ?? ''}${String(meta)}${routeContext?.name ?? ''}`,
+});
+
+const _typedModule: RenderModule = _typedRenderer;
+const _typedSSR: RenderSSR = _typedRenderer.renderSSR;
+const _typedStream: RenderStream = _typedRenderer.renderStream;
+void _typedModule;
+void _typedSSR;
+void _typedStream;

--- a/website/src/content/docs/guides/head-management.md
+++ b/website/src/content/docs/guides/head-management.md
@@ -282,8 +282,8 @@ const title = data.title || meta.title || "Default Title";
 ### 3. Escape User Content
 
 `headContent` returns **raw HTML** written verbatim into `<head>`, so any value that could carry
-service data or user input - from **`data` or `meta`** - must be escaped at the point it enters the
-string. Escape by output **context**, not by property name:
+service data or user input - from **`data`, `headData` or `meta`** - must be escaped at the point
+it enters the string. Escape by output **context**, not by property name:
 
 - **HTML text and quoted attributes** → `escapeHtml` (exported by both renderers; escapes
   `& < > " '`, so it is safe in single- and double-quoted attributes):
@@ -316,9 +316,13 @@ function escapeHtml(value: unknown): string {
 }
 ```
 
-### 4. Use SSR for Data-Dependent Head
+### 4. Data-Dependent Heads: SSR Has It Built In; Streaming Declares `attr.head`
 
-If your head content critically depends on fetched data, use `render: 'ssr'`.
+On `render: 'ssr'` the route data is fully resolved before the head is built, so `data` is always
+real. On `render: 'streaming'` the data snapshot is usually still pending at head time - declare
+`attr.head` with a head-critical loader and read `headData` in `headContent` instead (resolved
+before the render, bounded by `head.timeoutMs`; `undefined` on degrade - handle it and fall back
+to `meta`).
 
 <!--
 ## What's Next?

--- a/website/src/content/docs/guides/head-management.md
+++ b/website/src/content/docs/guides/head-management.md
@@ -109,6 +109,42 @@ From your route's `attr.meta` configuration:
 }
 ```
 
+### headData
+
+From your route's `attr.head` loader - dynamic head data resolved BEFORE the render starts, on
+both strategies. This is how STREAMED pages get real data into `<head>`:
+
+```typescript
+// Route config
+{
+  path: '/products/:id',
+  attr: {
+    render: 'streaming',
+    meta: { title: 'Products' },            // static fallback layer
+    data: serviceData('catalog', 'getProduct', mapper),          // streams as usual
+    head: {
+      data: serviceData('catalog', 'getProductHead', mapper),    // resolved pre-shell
+      timeoutMs: 3000,   // optional; positive finite only (default 3000)
+      optional: false,   // optional; true degrades loader failures instead of failing the request
+    }
+  }
+}
+```
+
+```typescript
+headContent: ({ headData, meta }) => `
+  <title>${escapeHtml(headData?.ogTitle ?? meta?.title ?? "Products")}</title>
+`;
+```
+
+`headData` is OPTIONAL in the type, and your callback must handle `undefined`: routes without
+`attr.head` pass nothing, and the loader DEGRADES to `undefined` (with a server-side advisory
+log) when its deadline expires on a live request, or when it fails and the route declared
+`optional: true`. A failing non-optional head loader fails the request through the normal error
+path - real defects stay visible - and a client that disconnects mid-fetch never proceeds into
+the render at all. Head data is never serialised into `__INITIAL_DATA__`; it exists for the
+server-rendered `<head>` only. Keep head loaders cheap - they block the shell.
+
 ## Data Availability by Mode
 
 ### SSR Mode
@@ -141,8 +177,9 @@ headContent: ({ data, meta }) => {
 };
 ```
 
-> Because `headContent` runs before all data is available in streaming mode,
-> SEO-critical values should come from route `meta`, not fetched data.
+> Because `headContent` runs before route data is available in streaming mode, SEO-critical
+> values should come from route `meta` - or, for DYNAMIC values, from an `attr.head` loader
+> (see the `headData` source above), which the server resolves before the shell is sent.
 
 ## Common Patterns
 

--- a/website/src/content/docs/guides/head-management.md
+++ b/website/src/content/docs/guides/head-management.md
@@ -8,7 +8,8 @@ description: How τjs manages document head content
 :::caution[headContent is a raw-HTML sink]
 Whatever `headContent` returns is written into `<head>` **verbatim** - it is not auto-escaped. Escape
 every value you interpolate that could carry service data, user input, or other untrusted content
-(from **either** `data` **or** `meta` - route meta is often built from application data too). Use the
+(from **`data`, `headData` or `meta`** - route meta is often built from application data too, and
+`headData` is loader output like any other). Use the
 `escapeHtml` helper exported by `@taujs/react` / `@taujs/vue` for HTML text and quoted attributes; see
 [Escape User Content](#3-escape-user-content) for the important exceptions (JSON-LD / `<script>`, URLs).
 :::
@@ -35,11 +36,14 @@ every value you interpolate that could carry service data, user input, or other 
    - Always available, including in streaming routes.
 
 3. **Renderer Head (`headContent` in `entry-server.tsx`)**
-   - Converts `meta` and (optionally) `data` into actual HTML tags.
+   - Converts `meta`, (optionally) `data`, and (when the route declares `attr.head`) `headData`
+     into actual HTML tags.
    - Can enrich or override route meta.
    - Runs:
-     - after data resolution in SSR
-     - at shell-ready time in streaming
+     - after data resolution in SSR (`data` is real; `headData` is resolved when declared)
+     - on streaming routes, React builds the head at shell-ready (the `data` snapshot is usually
+       still pending - `headData` is the resolved-before-render exception); Vue performs its
+       single head build before rendering starts
 
 This separation ensures:
 

--- a/website/src/content/docs/reference/taujs-config.md
+++ b/website/src/content/docs/reference/taujs-config.md
@@ -215,6 +215,7 @@ Routes define URL patterns, rendering strategies, and data requirements.
 | `meta`       | `Record<string, unknown>` | `{}`        | Metadata for head   |
 | `middleware` | `Middleware`              | `undefined` | Auth and CSP        |
 | `data`       | `DataHandler`             | `undefined` | Data loader         |
+| `head`       | `HeadAttributes`          | `undefined` | Dynamic head data loader: `{ data, timeoutMs?, optional? }`, resolved before the render starts on both strategies and passed to `headContent` as `headData`. `timeoutMs` must be positive finite (default 3000 ms); `optional: true` degrades loader failures to `headData: undefined` instead of failing the request |
 
 ## Rendering Strategies
 
@@ -240,6 +241,7 @@ Complete HTML rendered before sending:
 - Data fully loaded before rendering
 - Complete HTML in single response
 - Guaranteed data in `headContent`
+- `attr.head` (if declared) resolves before the render and arrives as `headData`
 
 **React renderer semantics (`@taujs/react`):** the `ssr` strategy renders complete HTML with
 React's `prerenderToNodeStream`, so `React.lazy` and `use()` content is included in the response.
@@ -275,7 +277,8 @@ Progressive HTML delivery:
 
 - Shell sent immediately
 - Content streams as it renders
-- Data may not be ready when `headContent` runs
+- Route `data` may not be ready when `headContent` runs - declare `attr.head` for DYNAMIC head
+  data (resolved before the shell, delivered as `headData`); `meta` remains the static layer
 - **Requires `meta` property**
 
 ### Static (No Hydration)

--- a/website/src/content/docs/renderers/react.mdx
+++ b/website/src/content/docs/renderers/react.mdx
@@ -126,26 +126,38 @@ function createRenderer<
   }) => string;
   ...
 }): {
+  // NB the RETURNED functions' host-facing parameters are deliberately BROAD (a renderer must
+  // stay assignable to @taujs/server's renderer-agnostic contracts regardless of your generics):
+  // T, R and H apply INSIDE your callbacks (appComponent, headContent), not at this boundary.
   renderSSR: (
-    initialData: T,
+    initialData: Record<string, unknown>,
     location: string,
     meta?: Record<string, unknown>,
     signal?: AbortSignal,
-    opts?: { logger?: LoggerLike; routeContext?: R; headData?: Record<string, unknown> }
+    opts?: { logger?: LoggerLike; routeContext?: unknown; headData?: Record<string, unknown> }
   ) => Promise<SSRResult>;
   renderStream: (
     writable: Writable,
     callbacks: RenderCallbacks<T>,
-    initialData: T | Promise<T> | (() => Promise<T>),
+    initialData:
+      | Record<string, unknown>
+      | Promise<Record<string, unknown>>
+      | (() => Promise<Record<string, unknown>>),
     location: string,
     bootstrapModules?: string,
     meta?: Record<string, unknown>,
     cspNonce?: string,
     signal?: AbortSignal,
-    opts?: StreamOptions & { logger?: LoggerLike; routeContext?: R; headData?: Record<string, unknown> }
+    opts?: StreamOptions & { logger?: LoggerLike; routeContext?: unknown; headData?: Record<string, unknown> }
   ) => { abort: () => void; done: Promise<void> };
 }
 ```
+
+> **Typing model:** the generics narrow your OWN code - `appComponent` receives `routeContext` as
+> `R`, `headContent` receives `data: T` and `headData?: H`. The returned render functions accept
+> broad records at the host boundary, so standalone callers do not get compile-time narrowing on
+> the values they pass in; the route config (with `@taujs/server`) or your own call-site
+> discipline is the type authority for those.
 
 > `bootstrapModules`: URL to your client entry module. `@taujs/react` forwards it to React as a single-item `bootstrapModules` array.
 

--- a/website/src/content/docs/renderers/react.mdx
+++ b/website/src/content/docs/renderers/react.mdx
@@ -105,7 +105,7 @@ Client-side hydration automatically:
 
 ### Server-Side Rendering
 
-#### `createRenderer<T, R = unknown>(options)`
+#### `createRenderer<T, R = unknown, H = Record<string, unknown>>(options)`
 
 Creates a renderer instance with streaming and static SSR capabilities.
 
@@ -119,6 +119,7 @@ function createRenderer<
   appComponent: (props: { location: string; routeContext?: R }) => React.ReactElement;
   headContent: (ctx: {
     data: T;
+    headData?: H; // the route's attr.head payload, resolved by the host before the render
     meta: Record<string, unknown>;
     routeContext?: R;
   }) => string;
@@ -154,7 +155,7 @@ function createRenderer<
 **Parameters:**
 
 - `appComponent`: Function that returns your root React component, receives `{ location: string; routeContext?: R }`
-- `headContent`: Function that generates HTML head content, receives `{ data: T, meta: Record<string, unknown>, routeContext?: R }`. **Note:** In streaming mode, `data` may not be resolved when shell is ready - guard optional fields or rely on `meta`. **Security:** the return value is written into `<head>` verbatim as raw HTML - escape every value derived from data or user input with `escapeHtml` (exported from `@taujs/react`; see the [head management guide](/guides/head-management/)).
+- `headContent`: Function that generates HTML head content, receives `{ data: T, headData?: H, meta: Record<string, unknown>, routeContext?: R }`. **Note:** In streaming mode, `data` may not be resolved when shell is ready - guard optional fields, rely on `meta`, or declare `attr.head` on the route so the host resolves DYNAMIC head data before the shell and passes it as `headData` (typed by `createRenderer`'s third generic `H`; `undefined` when the route declares no head or the loader degraded - handle it). **Security:** the return value is written into `<head>` verbatim as raw HTML - escape every value derived from `data`, `headData` or user input with `escapeHtml` (exported from `@taujs/react`; see the [head management guide](/guides/head-management/)).
 - `enableDebug`: Enable detailed debug logging (default: `false`). `warn` and `error` always reach your logger (or the console) regardless - only debug-level logging is gated.
 - `logger`: Custom logger implementation
 - `streamOptions`: Streaming configuration

--- a/website/src/content/docs/renderers/react.mdx
+++ b/website/src/content/docs/renderers/react.mdx
@@ -114,7 +114,8 @@ Creates a renderer instance with streaming and static SSR capabilities.
 ```typescript
 function createRenderer<
   T extends Record<string, unknown>,
-  R = unknown
+  R = unknown,
+  H extends Record<string, unknown> = Record<string, unknown>
 >(options: {
   appComponent: (props: { location: string; routeContext?: R }) => React.ReactElement;
   headContent: (ctx: {
@@ -130,7 +131,7 @@ function createRenderer<
     location: string,
     meta?: Record<string, unknown>,
     signal?: AbortSignal,
-    opts?: { logger?: LoggerLike; routeContext?: R }
+    opts?: { logger?: LoggerLike; routeContext?: R; headData?: Record<string, unknown> }
   ) => Promise<SSRResult>;
   renderStream: (
     writable: Writable,
@@ -141,7 +142,7 @@ function createRenderer<
     meta?: Record<string, unknown>,
     cspNonce?: string,
     signal?: AbortSignal,
-    opts?: StreamOptions & { logger?: LoggerLike; routeContext?: R }
+    opts?: StreamOptions & { logger?: LoggerLike; routeContext?: R; headData?: Record<string, unknown> }
   ) => { abort: () => void; done: Promise<void> };
 }
 ```
@@ -178,8 +179,52 @@ Both methods accept a final `opts` argument:
 
 - `logger`: Optional per-call logger (overrides the one passed to `createRenderer`)
 - `routeContext`: Per-request route context value forwarded into `appComponent` and `headContent`.
+- `headData`: The route's resolved `attr.head` payload. With `@taujs/server` this is passed for
+  you (only when the route declares `attr.head` and its loader resolved); standalone hosts may
+  pass their own pre-resolved head data. Reaches `headContent` typed as `H`.
 - `renderStream` only: any `StreamOptions` field (`shellTimeoutMs`, `dataTimeoutMs`) may also be
   overridden per call.
+
+**Worked example: dynamic head data on a streamed route**
+
+```typescript
+// entry-server.tsx
+import { createRenderer, escapeHtml } from "@taujs/react";
+import { App } from "./App";
+
+type HeadData = { ogTitle?: string; ogDescription?: string };
+
+export const { renderSSR, renderStream } = createRenderer<
+  Record<string, unknown>,
+  unknown,
+  HeadData
+>({
+  appComponent: () => <App />,
+  // headData is undefined when the route declares no attr.head, and when the head loader
+  // degraded (deadline expiry, or an optional loader failure) - always handle it.
+  headContent: ({ headData, meta }) => `
+    <title>${escapeHtml(headData?.ogTitle ?? (meta.title as string | undefined) ?? "My App")}</title>
+    ${
+      headData?.ogDescription
+        ? `<meta name="description" content="${escapeHtml(headData.ogDescription)}">`
+        : ""
+    }
+  `,
+});
+```
+
+```typescript
+// taujs.config.ts - the route side (with @taujs/server)
+{
+  path: '/product/:id',
+  attr: {
+    render: 'streaming',
+    meta: { title: 'Products' },                                 // static fallback layer
+    data: serviceData('catalog', 'getProduct', mapper),          // streams as usual
+    head: { data: serviceData('catalog', 'getProductHead', mapper) }, // resolved pre-shell
+  },
+}
+```
 
 ---
 

--- a/website/src/content/docs/renderers/vue.mdx
+++ b/website/src/content/docs/renderers/vue.mdx
@@ -431,7 +431,7 @@ const { done, abort } = renderStream(
       console.error("Stream error:", err);
     },
   },
-  { msg: "hello" }, // initialData: T | Promise<T> | (() => Promise<T>)
+  { msg: "hello" }, // initialData: a record, a promise of one, or a lazy factory
   "/streaming", // location
   "/assets/entry-client.js", // bootstrapModules
   { requestId: "123" }, // meta

--- a/website/src/content/docs/renderers/vue.mdx
+++ b/website/src/content/docs/renderers/vue.mdx
@@ -194,7 +194,7 @@ This idiom is a good fit for `ssr` routes, where the server has already resolved
 
 ### Server-side rendering
 
-#### `createRenderer<T, R>(options)`
+#### `createRenderer<T, R, H>(options)`
 
 Creates a renderer instance with streaming and static SSR capabilities.
 
@@ -203,11 +203,12 @@ Creates a renderer instance with streaming and static SSR capabilities.
 ```typescript
 function createRenderer<
   T extends Record<string, unknown> = Record<string, unknown>,
-  R = unknown
+  R = unknown,
+  H extends Record<string, unknown> = Record<string, unknown>
 >(options: {
   /** A Vue component, or a function returning a VNode. Rendered with props { location, routeContext? }. */
   appComponent: Component | ((props: { location: string; routeContext?: R }) => VNode);
-  headContent: (ctx: HeadContext<T, R>) => string;
+  headContent: (ctx: HeadContext<T, R, H>) => string;
   streamOptions?: StreamOptions;
   logger?: LoggerLike;
   enableDebug?: boolean;
@@ -218,7 +219,7 @@ function createRenderer<
     location: string,
     meta?: Record<string, unknown>,
     signal?: AbortSignal,
-    opts?: { logger?: LoggerLike; routeContext?: R }
+    opts?: { logger?: LoggerLike; routeContext?: R; headData?: Record<string, unknown> }
   ) => Promise<{
     headContent: string;
     appHtml: string;
@@ -234,7 +235,7 @@ function createRenderer<
     meta?: Record<string, unknown>,
     cspNonce?: string,
     signal?: AbortSignal,
-    opts?: StreamOptions & { logger?: LoggerLike; routeContext?: R }
+    opts?: StreamOptions & { logger?: LoggerLike; routeContext?: R; headData?: Record<string, unknown> }
   ) => { abort: () => void; done: Promise<void> };
 };
 ```
@@ -242,7 +243,7 @@ function createRenderer<
 **Parameters:**
 
 - `appComponent`: Your Vue root. Pass the component directly (it receives `{ location, routeContext? }` as props) or a render function returning a VNode.
-- `headContent`: Generates HTML head content from `{ data, meta, routeContext? }`. **Note:** in streaming mode the data snapshot is usually still pending when the head is built, so heads must be derivable from `meta`/`routeContext` - guard optional `data` fields.
+- `headContent`: Generates HTML head content from `{ data, headData?, meta, routeContext? }`. **Note:** in streaming mode the data snapshot is usually still pending when the head is built - guard optional `data` fields, lean on `meta`/`routeContext`, or declare `attr.head` on the route so the host resolves DYNAMIC head data before the render and passes it as `headData` (typed by `createRenderer`'s third generic `H`). `headData` is `undefined` when the route declares no `attr.head` and when the head loader degraded (deadline expiry, or an `optional` loader failure) - always handle it. Vue's head stays SINGLE-BUILD, pre-render; `headData` widens what that one build can see. Escape every `headData`/`data`-derived value with `escapeHtml`.
 - `streamOptions.shellTimeoutMs`: Time-to-first-content watchdog in ms (default `10000`). See [Streaming semantics](#streaming-semantics).
 - `logger`: Custom logger implementation (`LoggerLike`).
 - `enableDebug`: Enable detailed logging (default `false`).
@@ -250,14 +251,61 @@ function createRenderer<
 
 **Returns** an object with two rendering methods: `renderSSR` (static, returns complete HTML plus teleports) and `renderStream` (streaming, pipes to a writable).
 
+**Per-call `opts.headData`:** the route's resolved `attr.head` payload. With `@taujs/server` this
+is passed for you (only when the route declares `attr.head` and its loader resolved); standalone
+hosts may pass their own pre-resolved head data. Reaches `headContent` typed as `H`.
+
+**Worked example: dynamic head data on a streamed route**
+
+```typescript
+// entry-server.ts
+import { createRenderer, escapeHtml } from "@taujs/vue";
+import App from "./App.vue";
+
+type HeadData = { ogTitle?: string; ogDescription?: string };
+
+export const { renderSSR, renderStream } = createRenderer<
+  Record<string, unknown>,
+  unknown,
+  HeadData
+>({
+  appComponent: App,
+  // headData is undefined when the route declares no attr.head, and when the head loader
+  // degraded (deadline expiry, or an optional loader failure) - always handle it.
+  headContent: ({ headData, meta }) => `
+    <title>${escapeHtml(headData?.ogTitle ?? (meta.title as string | undefined) ?? "My App")}</title>
+    ${
+      headData?.ogDescription
+        ? `<meta name="description" content="${escapeHtml(headData.ogDescription)}">`
+        : ""
+    }
+  `,
+});
+```
+
+```typescript
+// taujs.config.ts - the route side (with @taujs/server)
+{
+  path: '/streaming',
+  attr: {
+    render: 'streaming',
+    meta: { title: 'My App' },                                  // static fallback layer
+    data: serviceData('content', 'greet', () => ({ name: 'Vue' })),
+    head: { data: serviceData('content', 'greetHead', () => ({ name: 'Vue' })) }, // resolved pre-render
+  },
+}
+```
+
 The `HeadContext`, `RenderCallbacks` and `StreamOptions` types:
 
 ```typescript
 type HeadContext<
   T extends Record<string, unknown> = Record<string, unknown>,
-  R = unknown
+  R = unknown,
+  H extends Record<string, unknown> = Record<string, unknown>
 > = {
   data: T;
+  headData?: H; // the route's attr.head payload, resolved by the host before the render
   meta: Record<string, unknown>;
   routeContext?: R;
 };
@@ -964,7 +1012,7 @@ const setupApp = (app) => {
 
 1. **Prefer Suspense for data.** Reach for `await useSSRDataAsync<T>()` under `<Suspense>` first; fall back to `useSSRData<T>()` + `v-if` only when you specifically want a non-blocking render.
 2. **Streamed routes block on data.** Always use the blocking Suspense idiom on `streaming` routes so the data lands in the streamed HTML, not just in `__INITIAL_DATA__`.
-3. **Keep `headContent` derivable from `meta`.** In streaming mode the data snapshot is usually pending when the head is built - guard optional `data` fields and lean on `meta`/`routeContext`.
+3. **Head data: `meta` for static, `attr.head` for dynamic.** In streaming mode the data snapshot is usually pending when the head is built - guard optional `data` fields. Static values belong in `meta`; DYNAMIC head values belong in an `attr.head` loader, which the host resolves before the render and delivers as `headData` (handle `undefined` - it degrades on deadline or `optional` failure).
 4. **Share one `setupApp` across server and client.** Keep it synchronous, DOM-free and idempotent so the identical function runs on both sides; seed Pinia/state from SSR data rather than adding a serialisation channel.
 5. **Match `@vue/server-renderer` to `vue`.** Pin both to the same version.
 6. **Handle CSR fallback.** Provide `onHydrationError` so a hydration failure degrades gracefully; remember the CSR path emits no hydration callbacks by design.

--- a/website/src/content/docs/renderers/vue.mdx
+++ b/website/src/content/docs/renderers/vue.mdx
@@ -214,12 +214,15 @@ function createRenderer<
   enableDebug?: boolean;
   setupApp?: (app: App) => void;
 }): {
+  // NB the RETURNED functions' host-facing parameters are deliberately BROAD (a renderer must
+  // stay assignable to @taujs/server's renderer-agnostic contracts regardless of your generics):
+  // T, R and H apply INSIDE your callbacks (appComponent, headContent), not at this boundary.
   renderSSR: (
-    initialData: T,
+    initialData: Record<string, unknown>,
     location: string,
     meta?: Record<string, unknown>,
     signal?: AbortSignal,
-    opts?: { logger?: LoggerLike; routeContext?: R; headData?: Record<string, unknown> }
+    opts?: { logger?: LoggerLike; routeContext?: unknown; headData?: Record<string, unknown> }
   ) => Promise<{
     headContent: string;
     appHtml: string;
@@ -229,16 +232,25 @@ function createRenderer<
   renderStream: (
     writable: Writable,
     callbacks: RenderCallbacks<T>,
-    initialData: T | Promise<T> | (() => Promise<T>),
+    initialData:
+      | Record<string, unknown>
+      | Promise<Record<string, unknown>>
+      | (() => Promise<Record<string, unknown>>),
     location: string,
     bootstrapModules?: string,
     meta?: Record<string, unknown>,
     cspNonce?: string,
     signal?: AbortSignal,
-    opts?: StreamOptions & { logger?: LoggerLike; routeContext?: R; headData?: Record<string, unknown> }
+    opts?: StreamOptions & { logger?: LoggerLike; routeContext?: unknown; headData?: Record<string, unknown> }
   ) => { abort: () => void; done: Promise<void> };
 };
 ```
+
+> **Typing model:** the generics narrow your OWN code - `appComponent` receives `routeContext` as
+> `R`, `headContent` receives `data: T` and `headData?: H`. The returned render functions accept
+> broad records at the host boundary, so standalone callers do not get compile-time narrowing on
+> the values they pass in; the route config (with `@taujs/server`) or your own call-site
+> discipline is the type authority for those.
 
 **Parameters:**
 


### PR DESCRIPTION
Implements RFC 0004 (ACCEPTED): routes may declare `attr.head` - a head-critical data loader the
server resolves BEFORE rendering starts on both strategies - closing the gap where streamed pages
could only carry static `<head>` metadata.

This work is renderer-agnostic.

## The feature

- **Route config:** `attr.head = { data, timeoutMs?, optional? }` on `ssr` and `streaming` routes
  alike. `meta` remains the static layer; `attr.head` owns dynamic head loading.
- **Bounded and taxonomy-correct:** default 3000 ms deadline (positive finite overrides only,
  boot-validated); caller abort always aborts; deadline expiry degrades to `headData: undefined`
  with an advisory log; ordinary loader rejection follows the existing error path unless the
  route opts in via `head.optional`.
- **Typed end to end:** `serviceData()` now carries a phantom-branded result type, so
  `HeadDataOf<Route>` infers the actual service method's payload (mixed closure returns stay
  honest - descriptor branches distribute to `Record<string, unknown>`, never silently narrowed).
- **Renderers:** `createRenderer<T, R, H>` (defaulted - existing call sites compile unchanged);
  `headContent` receives `headData?: H` on both strategies. React builds the streamed head at
  shell-ready as before; Vue's single pre-render head build is unchanged in timing and simply
  sees more. Host-facing contracts stay deliberately broad with documented narrowing seams, and
  both conformance type tests now instantiate non-default generics.
- **Proven live:** both playgrounds serve dynamic `<title>`/description on their streaming
  routes, resolved before the shell.

## Hardening that rode along

- Streaming head-failure teardown belts its telemetry (a throwing host logger can no longer skip
  hijacked-socket settlement).
- `headData` is conditionally included - no observable key on routes without `attr.head`.
- The React hydration integration suite replaced load-sensitive fixed sleeps with
  terminal-condition waits (the workspace test gate was reproducibly flaky under concurrency).
- Docs: config reference, head-management guide, and both renderer references updated and made
  internally consistent (honest broad signatures, degrade semantics, worked examples,
  escape discipline throughout).

## Verification

- Full workspace check exit 0: server 723 / react 206 / vue 183 / mcp 28 / create-taujs 11
- Two type-test hard gates (phantom-brand inference; non-default T/H conformance) destructively
  verified; four independent review rounds, all findings fixed
- Astro site build clean; both playgrounds live-verified; tree clean at 0b0fe10

Changesets: `@taujs/server` minor, `@taujs/react` minor, `@taujs/vue` minor.
