### PR TITLE
docs(website): one head-data model everywhere - retire the pre-attr.h…

### DIFF
--- a/website/src/content/docs/guides/data-loading.md
+++ b/website/src/content/docs/guides/data-loading.md
@@ -129,10 +129,13 @@ Shell sent immediately, data may load progressively:
 **Characteristics:**
 
 - Faster Time to First Byte
-- Data may not be ready when `headContent` runs
-- Requires `meta` property for reliable SEO
+- Route `data` may not be ready when `headContent` runs - never depend on it for streamed heads
+- Static `meta` is required (the fallback layer that survives degradation)
+- For DYNAMIC head values, declare `attr.head` - its loader resolves before the shell and reaches
+  `headContent` as `headData`
 
-See [Head Management](/guides/head-management) for details on meta.
+See [Head Management](/guides/head-management) for the full model (`meta` static, `attr.head`
+dynamic) and the degradation taxonomy.
 
 ## Using Data on the Client
 
@@ -213,6 +216,8 @@ export const { renderSSR, renderStream } = createRenderer<
     <AppBootstrap location={location} routeContext={routeContext} />
   ),
   headContent: ({ data, meta, routeContext }) => {
+    // `data` is resolved on ssr routes; for STREAMED heads read `headData`/`meta` instead
+    // (see the head-management guide).
     const anyData = data as { title?: string; description?: string };
 
     const baseTitle =

--- a/website/src/content/docs/guides/head-management.md
+++ b/website/src/content/docs/guides/head-management.md
@@ -174,38 +174,42 @@ headContent: ({ data, meta }) => `
 
 ### Streaming Mode
 
-Data may not be ready when `headContent` runs. Use `meta` for reliable SEO:
+Route `data` may not be ready when `headContent` runs - do not read it here. Static values come
+from `meta`; DYNAMIC values come from the route's `attr.head` loader, delivered as `headData`
+(resolved before the shell is sent, `undefined` on degrade):
 
 ```typescript
-headContent: ({ data, meta }) => {
-  // Use meta for guaranteed values
+headContent: ({ headData, meta }) => {
   return `
-    <title>${escapeHtml(meta?.title || "Streaming page")}</title>
-    <meta name="description" content="${escapeHtml(meta.description)}">
+    <title>${escapeHtml(headData?.title ?? meta?.title ?? "Streaming page")}</title>
+    <meta name="description" content="${escapeHtml(headData?.description ?? meta.description)}">
     ${
-      data.ogImage
-        ? `<meta property="og:image" content="${escapeHtml(data.ogImage)}">`
+      headData?.ogImage
+        ? `<meta property="og:image" content="${escapeHtml(headData.ogImage)}">`
         : ""
     }
   `;
 };
 ```
 
-> Because `headContent` runs before route data is available in streaming mode, SEO-critical
-> values should come from route `meta` - or, for DYNAMIC values, from an `attr.head` loader
-> (see the `headData` source above), which the server resolves before the shell is sent.
+> The rule: `meta` for static defaults and degradation fallback; `attr.head` -> `headData` for
+> dynamic, head-critical values; `attr.data` for the page body - never depend on it for streamed
+> heads.
 
 ## Common Patterns
 
-Each interpolated value below is passed through `escapeHtml` at the point it enters the HTML string.
+Each interpolated value below is passed through `escapeHtml` at the point it enters the HTML
+string. The patterns read `headData` first with `meta` as the fallback, which is correct on BOTH
+strategies (on `ssr` routes you may additionally read `data` - it is fully resolved there; on
+streaming routes it may still be pending, so do not).
 
 ### Open Graph Tags
 
 ```typescript
-headContent: ({ data, meta }) => {
-  const title = data?.title || meta?.title || "Default title";
-  const description = data?.description || meta?.description || "";
-  const image = data?.ogImage || meta?.ogImage;
+headContent: ({ headData, meta }) => {
+  const title = headData?.title ?? meta?.title ?? "Default title";
+  const description = headData?.description ?? meta?.description ?? "";
+  const image = headData?.ogImage ?? meta?.ogImage;
 
   return `
     <title>${escapeHtml(title)}</title>
@@ -229,8 +233,8 @@ closed from inside the data:
 const jsonForScript = (value: unknown) =>
   JSON.stringify(value).replace(/</g, "\\u003c");
 
-headContent: ({ data, meta }) => {
-  const jsonLd = data?.jsonLd || meta?.jsonLd;
+headContent: ({ headData, meta }) => {
+  const jsonLd = headData?.jsonLd ?? meta?.jsonLd;
 
   return `
     <title>${escapeHtml(meta?.title || "Page")}</title>
@@ -248,8 +252,8 @@ If you use CSP with script-src restrictions, inline JSON-LD may require a nonce/
 ### Canonical URLs
 
 ```typescript
-headContent: ({ data, meta }) => {
-  const canonical = data.canonical || meta.canonical;
+headContent: ({ headData, meta }) => {
+  const canonical = headData?.canonical ?? meta?.canonical;
 
   return `
     <title>${escapeHtml(meta.title)}</title>
@@ -268,20 +272,23 @@ headContent: ({ data, meta }) => {
 
 ## Best Practices
 
-### 1. Prioritise Meta Over Data in Streaming
+### 1. Use `meta` for Static Values and `attr.head` for Dynamic Values
+
+`meta` is cheap, deterministic, and survives head-loader degradation - it is the fallback layer,
+not the answer to dynamic streamed heads. Declare `attr.head` for dynamic head-critical values:
 
 ```typescript
 import { escapeHtml } from "@taujs/react"; // or "@taujs/vue"
 
-// reliable in streaming
-headContent: ({ data, meta }) => `
-  <title>${escapeHtml(meta?.title || "Default Title")}</title>
+// correct on both strategies
+headContent: ({ headData, meta }) => `
+  <title>${escapeHtml(headData?.title ?? meta?.title ?? "Default Title")}</title>
   <meta name="description" content="${escapeHtml(
-    meta?.description || "Default description",
+    headData?.description ?? meta?.description ?? "Default description",
   )}">
   ${
-    data?.ogImage
-      ? `<meta property="og:image" content="${escapeHtml(data.ogImage)}">`
+    headData?.ogImage
+      ? `<meta property="og:image" content="${escapeHtml(headData.ogImage)}">`
       : ""
   }
 `;
@@ -290,7 +297,11 @@ headContent: ({ data, meta }) => `
 ### 2. Provide Fallbacks
 
 ```typescript
-const title = data.title || meta.title || "Default Title";
+// streaming (and safe everywhere): dynamic -> static -> default
+const title = headData?.title ?? meta?.title ?? "Default Title";
+
+// ssr only: route data is fully resolved, so it may join the chain
+const ssrTitle = data.title ?? meta?.title ?? "Default Title";
 ```
 
 ### 3. Escape User Content
@@ -305,8 +316,8 @@ it enters the string. Escape by output **context**, not by property name:
   ```typescript
   import { escapeHtml } from "@taujs/react"; // or "@taujs/vue"
 
-  headContent: ({ data }) => `
-    <meta property="og:image" content="${escapeHtml(data.ogImage)}">
+  headContent: ({ headData }) => `
+    <meta property="og:image" content="${escapeHtml(headData?.ogImage ?? "")}">
   `;
   ```
 


### PR DESCRIPTION
…ead guidance

The head-management guide taught two competing models: new attr.head sections beside older passages still teaching the pre-attr.head workaround (meta as THE answer to dynamic streamed heads). Rewritten to the single rule - meta for static defaults and degradation fallback, attr.head -> headData for dynamic head-critical values, attr.data for the body and never for streamed heads:

- Streaming Mode example reads headData (was reading potentially-pending data.ogImage) and states the rule.
- Common Patterns (OG, JSON-LD, canonical) read headData ?? meta with a both-strategies note; SSR may additionally read data.
- Best practice 1 'Prioritise Meta Over Data in Streaming' is now 'Use meta for Static Values and attr.head for Dynamic Values' with a degradation-survival rationale; practice 2's fallback chain is split by strategy (headData ?? meta ?? default vs the ssr data chain).
- data-loading.md streaming characteristics no longer say meta is required 'for reliable SEO' as the whole story - attr.head is named, with a pointer to the full model and taxonomy.
- Escaping-context snippet and the typed-routeContext example aligned.

Site-wide sweep for the old phrasing returns zero; meta-first or defaulted coalescing examples and the accepted renderer references are deliberately untouched. Astro clean.