### PR TITLE
feat: hydration observability parity - @taujs/solid + Vue/React corrections

### DIFF
--- a/.changeset/hydration-no-payload-logging.md
+++ b/.changeset/hydration-no-payload-logging.md
@@ -1,0 +1,12 @@
+---
+'@taujs/react': patch
+'@taujs/vue': patch
+---
+
+Debug hydration logging no longer includes the route-data payload or the store object
+
+`hydrateApp`'s `enableDebug` logging previously emitted `Initial data loaded: <payload>` and
+`Store created: <store>`. A supplied logger may forward to a server sink (for example Pino), so
+those lines could disclose request data. They are removed - only lifecycle messages
+(started/succeeded/failed) are logged now, aligning `@taujs/react` and `@taujs/vue` with
+`@taujs/solid`, which never logged the payload.

--- a/.changeset/solid-hydration-observability.md
+++ b/.changeset/solid-hydration-observability.md
@@ -1,0 +1,24 @@
+---
+'@taujs/solid': minor
+---
+
+Add client hydration observability options to `hydrateApp`
+
+`hydrateApp` now accepts `logger`, `enableDebug`, `onStart` and `onSuccess` alongside the existing
+`onHydrationError`, bringing `@taujs/solid` to the same client-hydration lifecycle contract as
+`@taujs/react` and `@taujs/vue`:
+
+- `onStart` observes the start of hydration (hydrate path only); `onSuccess` observes successful
+  root establishment on both the hydrate and CSR-fallback paths; `onHydrationError` observes a
+  failed root establishment. Exactly one of `onSuccess` | `onHydrationError` settles per call, each
+  at most once, and every observer is isolated - a callback throw is logged and never alters
+  settlement or tears down the root.
+- `logger` receives the lifecycle; `enableDebug` gates verbose start/success logs (warnings and
+  errors are never gated). With no logger supplied, warnings and errors fall back to the browser
+  console. The route-data snapshot is never logged.
+- The internal `hydration:*` beacons remain hydration-only and always precede the matching user
+  callback.
+
+`dataKey` is deliberately not added - `window.__INITIAL_DATA__` is the single snapshot authority.
+React-specific (`identifierPrefix`) and Vue-specific (`setupApp`) options are not inherited by
+analogy either; `renderId` remains Solid's framework-native identity option.

--- a/.changeset/vue-csr-onsuccess-parity.md
+++ b/.changeset/vue-csr-onsuccess-parity.md
@@ -1,0 +1,12 @@
+---
+'@taujs/vue': patch
+---
+
+`hydrateApp` now calls `onSuccess` after a successful CSR-fallback mount
+
+Previously `onSuccess` fired only on the hydrate path; a successful client-side render fallback (no
+SSR snapshot) established the application root but never reported it. It now calls `onSuccess(app)`
+exactly once after a successful `app.mount(...)` on the CSR path, matching `@taujs/react`, whose
+`onSuccess` already observes both hydrate and CSR root establishment. The CSR path still emits no
+hydration beacon and no `onStart` (a CSR mount is not a hydration), and the observer stays isolated:
+a throw is logged and the mounted app remains.

--- a/.changeset/vue-hydration-settlement.md
+++ b/.changeset/vue-hydration-settlement.md
@@ -1,0 +1,13 @@
+---
+'@taujs/vue': patch
+---
+
+`hydrateApp` no longer reverses a settled hydration success
+
+Vue emitted `hydration:success` / `onSuccess` immediately after `mount()` but kept its
+error-attribution phase open until the next tick, so an error surfaced through
+`app.config.errorHandler` in that window could still emit `hydration:error` and call
+`onHydrationError` for an already-successful hydration. A single-settlement guard now marks the
+attempt settled **before** emitting success, so any subsequent error in that window is log-only - it
+never emits a second beacon or reverses the success. Exactly one of `onSuccess` | `onHydrationError`
+settles per call.

--- a/fixtures/playground-solid/src/client/entry-client.tsx
+++ b/fixtures/playground-solid/src/client/entry-client.tsx
@@ -3,11 +3,30 @@ import { hydrateApp } from '@taujs/solid';
 import { App } from './App';
 import { RENDER_ID } from './renderId';
 
+// Fixture-owned state so the real-browser smoke (test/browser.test.ts) can observe the hydration
+// lifecycle - onStart, onSuccess and the debug logs - through window state. Harmless playground
+// instrumentation, not something an application must do. Logs go to this probe, NOT the console, so
+// the suite's "no console errors" assertions stay honest.
+type HydrationProbe = { events: string[]; logs: string[] };
+const probe: HydrationProbe = ((window as unknown as { __TAUJS_HYDRATION_PROBE__?: HydrationProbe }).__TAUJS_HYDRATION_PROBE__ ??= {
+  events: [],
+  logs: [],
+});
+
 hydrateApp({
   app: ({ location }) => <App location={location} />,
   renderId: RENDER_ID,
   rootElementId: 'root',
+  enableDebug: true,
+  logger: {
+    log: (message: string) => probe.logs.push(String(message)),
+    warn: (message: string) => probe.logs.push(String(message)),
+    error: (message: string) => probe.logs.push(String(message)),
+  },
+  onStart: () => probe.events.push('onStart'),
+  onSuccess: () => probe.events.push('onSuccess'),
   onHydrationError: (error) => {
+    probe.events.push('onHydrationError');
     console.error('[playground-solid] hydration failed:', error);
   },
 });

--- a/fixtures/playground-solid/src/client/entry-client.tsx
+++ b/fixtures/playground-solid/src/client/entry-client.tsx
@@ -19,9 +19,15 @@ hydrateApp({
   rootElementId: 'root',
   enableDebug: true,
   logger: {
-    log: (message: string) => probe.logs.push(String(message)),
-    warn: (message: string) => probe.logs.push(String(message)),
-    error: (message: string) => probe.logs.push(String(message)),
+    log: (...args: unknown[]) => {
+      probe.logs.push(args.map((a) => String(a)).join(' '));
+    },
+    warn: (...args: unknown[]) => {
+      probe.logs.push(args.map((a) => String(a)).join(' '));
+    },
+    error: (...args: unknown[]) => {
+      probe.logs.push(args.map((a) => String(a)).join(' '));
+    },
   },
   onStart: () => probe.events.push('onStart'),
   onSuccess: () => probe.events.push('onSuccess'),

--- a/fixtures/playground-solid/test/browser.test.ts
+++ b/fixtures/playground-solid/test/browser.test.ts
@@ -206,6 +206,31 @@ describe.skipIf(!HAS_PINNED_BROWSER)('slice 7 group C - real browser (production
     }
   });
 
+  // The one native-browser callback/logging smoke for the hydration-observability surface. The unit
+  // matrix (real hydrateApp, mocked terminals) lives in @taujs/solid's happy-dom suite; this proves
+  // the real callbacks and debug logs fire during a real production hydrate. The entry-client wires
+  // onStart/onSuccess/logger into window.__TAUJS_HYDRATION_PROBE__ (fixture-owned state).
+  it('fires onStart before onSuccess and emits debug lifecycle logs during real hydration', async () => {
+    const { page, faults } = await openPage();
+    try {
+      await page.goto(`${BASE}/`, { waitUntil: 'networkidle' });
+
+      const probe = await page.evaluate(
+        () => (window as unknown as { __TAUJS_HYDRATION_PROBE__?: { events: string[]; logs: string[] } }).__TAUJS_HYDRATION_PROBE__ ?? { events: [], logs: [] },
+      );
+
+      // onStart then onSuccess, exactly once each; no failure was reported.
+      expect(probe.events).toEqual(['onStart', 'onSuccess']);
+      // enableDebug:true surfaced the start and success lifecycle logs through the supplied logger.
+      expect(probe.logs.some((m) => /started/i.test(m))).toBe(true);
+      expect(probe.logs.some((m) => /succeeded/i.test(m))).toBe(true);
+
+      expectClean(await collectFaults(page, faults));
+    } finally {
+      await page.context().close();
+    }
+  });
+
   it("CAPTURES a pre-hydration click into Solid's event queue", async () => {
     const { page, faults } = await openPage();
     try {

--- a/packages/react/src/SSRHydration.tsx
+++ b/packages/react/src/SSRHydration.tsx
@@ -230,10 +230,9 @@ export function hydrateApp<T>({
     emitDevHook('hydration:start');
     runObserver('onStart', () => onStart?.());
 
-    if (enableDebug) log('Initial data loaded:', initialData);
-
+    // Lifecycle messages only - the route-data payload and the store object are NOT logged, so debug
+    // logging cannot disclose request data through a supplied (e.g. Pino) logger.
     const store = createSSRStore(initialData);
-    if (enableDebug) log('Store created:', store);
 
     try {
       hydrateRoot(rootEl, buildTree(store), rootErrorOptions);

--- a/packages/react/src/test/SSRHydration.test.tsx
+++ b/packages/react/src/test/SSRHydration.test.tsx
@@ -108,6 +108,23 @@ describe('hydrateApp (lean bootstrap: hydrate if data, else CSR)', () => {
     expect(error).not.toHaveBeenCalled();
   });
 
+  it('never logs the route-data payload or store object, even with enableDebug (no disclosure through the logger)', () => {
+    addRoot('root');
+    const SECRET = 'super-secret-token-9f3a';
+    (window as any).__INITIAL_DATA__ = { token: SECRET, nested: { x: SECRET } };
+    const log = vi.fn(),
+      warn = vi.fn(),
+      error = vi.fn();
+
+    hydrateApp({ appComponent: <div>App</div>, enableDebug: true, logger: { log, warn, error } });
+
+    const logged = [...log.mock.calls, ...warn.mock.calls, ...error.mock.calls]
+      .flat()
+      .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
+      .join(' ');
+    expect(logged).not.toContain(SECRET);
+  });
+
   it('a throwing onStart is isolated — hydration still proceeds to hydrateRoot (single-settlement intact)', () => {
     addRoot('root');
     (window as any).__INITIAL_DATA__ = { a: 1 };

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@taujs/solid",
   "version": "0.2.0",
-  "description": "Framework-agnostic Solid SSR primitives - ESC-1 build-time compiler plugin surface (renderer lands post-GO)",
+  "description": "Framework-agnostic Solid SSR primitives - transport layer for server-side rendering and hydration",
   "author": "Aoede <taujs@aoede.uk.net> (https://www.aoede.uk.net)",
   "license": "MIT",
   "homepage": "https://taujs.dev/",
@@ -51,6 +51,7 @@
     "@taujs/server": "workspace:*",
     "@types/node": "^24.0.7",
     "@types/picomatch": "^2.3.3",
+    "happy-dom": "^20.11.0",
     "solid-js": "~1.9.14",
     "tsup": "^8.2.4",
     "typescript": "^5.5.4",

--- a/packages/solid/src/SSRHydration.ts
+++ b/packages/solid/src/SSRHydration.ts
@@ -1,16 +1,26 @@
 import { hydrate, render } from 'solid-js/web';
 
 import { createSSRStore, provideSSRStore } from './SSRDataStore.js';
+import { createUILogger } from './utils/Logger.js';
 
 import type { JSX } from 'solid-js';
+import type { SolidLogger } from './utils/Logger.js';
 
 /**
- * Client-side bootstrap for a τjs Solid app.
+ * Client-side bootstrap for a τjs Solid app, and its hydration-observability surface.
  *
- * The option surface is EXACTLY the four members the design freezes (1.5) and nothing more.
- * @taujs/react's `hydrateApp` carries `logger`, `enableDebug`, `dataKey`, `onStart` and `onSuccess`;
- * every one of those is a compatibility obligation, and Solid v1 deliberately does not inherit them
- * by analogy. Adding any of them is a public-API change, not an implementation detail.
+ * The lifecycle callbacks are ADVISORY observers of one `hydrateApp` invocation:
+ * - `onStart` fires once when application hydration begins (hydrate path only), after the
+ *   `hydration:start` beacon and before the native `hydrate`.
+ * - `onSuccess` fires once when the framework establishes the application root - a successful return
+ *   from Solid's `hydrate(...)` on the hydrate path, or `render(...)` on the CSR-fallback path. It
+ *   does NOT mean every resource or `<Suspense>` boundary settled.
+ * - `onHydrationError` fires once for a failed root establishment (a synchronous hydrate/render
+ *   throw, or a missing root element).
+ *
+ * Exactly one of `onSuccess` | `onHydrationError` settles per invocation; each fires at most once.
+ * The internal τjs hydration beacons are hydration-only and always precede the corresponding user
+ * observer.
  */
 export type HydrateAppOptions = {
   app: (props: { location: string }) => JSX.Element;
@@ -21,6 +31,15 @@ export type HydrateAppOptions = {
    */
   renderId?: string;
   rootElementId?: string;
+  /** Receives hydration lifecycle logs. A Pino/server-shaped or UI-shaped logger; see `SolidLogger`. */
+  logger?: SolidLogger;
+  /** Gate verbose start/success/CSR lifecycle logs. Warnings and errors are never gated. Default `false`. */
+  enableDebug?: boolean;
+  /** Observes the start of application hydration (hydrate path only). */
+  onStart?: () => void;
+  /** Observes successful root establishment (hydrate or CSR). */
+  onSuccess?: () => void;
+  /** Observes a failed root establishment. */
   onHydrationError?: (error: unknown) => void;
 };
 
@@ -35,23 +54,75 @@ const emitBeacon = (event: 'hydration:start' | 'hydration:success' | 'hydration:
   }
 };
 
-export function hydrateApp({ app, renderId, rootElementId = 'root', onHydrationError }: HydrateAppOptions): void {
-  // Isolated: an observability callback must never destroy the root it observes.
-  const reportError = (error: unknown) => {
+export function hydrateApp({
+  app,
+  renderId,
+  rootElementId = 'root',
+  logger,
+  enableDebug = false,
+  onStart,
+  onSuccess,
+  onHydrationError,
+}: HydrateAppOptions): void {
+  // `logger ?? console`: with no supplied logger, warnings/errors fall back to `console.warn`/
+  // `console.error` (parity with @taujs/react and @taujs/vue), while verbose lifecycle logging stays
+  // gated by `enableDebug`. This only shapes the client hydration seam - `createUILogger`'s
+  // server-path defaults are unchanged.
+  const { log, error } = createUILogger(logger ?? console, { debugCategory: 'ssr', context: { scope: 'solid-hydration' }, enableDebug });
+
+  // Advisory observer isolation: a callback throw is logged and swallowed - it is never fed to
+  // `onHydrationError`, never manufactures a beacon, and never tears down the root it observes.
+  const runObserver = (label: string, run: () => void) => {
     try {
-      onHydrationError?.(error);
-    } catch {
-      // a throwing handler is swallowed - it cannot be allowed to escape the bootstrap
+      run();
+    } catch (cbErr) {
+      error(`Hydration ${label} callback threw (ignored):`, cbErr);
     }
+  };
+
+  // Beacon policy: the hydrate path emits `hydration:*` beacons; the CSR-fallback path emits none (a
+  // CSR mount is not a hydration). Set once when the path is chosen, read by the report helpers.
+  let emitBeacons = false;
+
+  // Single settlement: exactly one of `onSuccess` | `onHydrationError`, each at most once. Solid's
+  // `hydrate`/`render` return synchronously, so success is reported inline after the native call -
+  // but the guard is explicit so a later edit cannot produce success followed by failure. `onStart`
+  // is hydration-only and, running once per invocation, fires at most once.
+  let settled = false;
+
+  // Verbose lifecycle logs (`log`) are gated by `enableDebug` inside `createUILogger`; warnings and
+  // errors are never gated. There is one gate, in the logger adapter - the calls here are
+  // unconditional so gating cannot drift between the two.
+  const reportStart = () => {
+    log('Hydration started');
+    if (emitBeacons) emitBeacon('hydration:start');
+    runObserver('onStart', () => onStart?.());
+  };
+
+  const reportSuccess = (message: string) => {
+    if (settled) return;
+    settled = true;
+    log(message);
+    if (emitBeacons) emitBeacon('hydration:success');
+    runObserver('onSuccess', () => onSuccess?.());
+  };
+
+  const reportFailure = (message: string, err: unknown) => {
+    if (settled) return;
+    settled = true;
+    error(message, err);
+    if (emitBeacons) emitBeacon('hydration:error', err);
+    runObserver('onHydrationError', () => onHydrationError?.(err));
   };
 
   const bootstrap = () => {
     const rootElement = document.getElementById(rootElementId);
 
     if (!rootElement) {
-      const error = new Error(`taujs: root element with id "${rootElementId}" not found`);
-      emitBeacon('hydration:error', error);
-      reportError(error);
+      // A missing root is a bootstrap failure: emit an error beacon with no preceding `start`, and
+      // report through the single failure path (design 4 / react + vue precedent).
+      emitBeacons = true;
+      reportFailure(`taujs: root element with id "${rootElementId}" not found`, new Error(`taujs: root element with id "${rootElementId}" not found`));
 
       return;
     }
@@ -59,35 +130,39 @@ export function hydrateApp({ app, renderId, rootElementId = 'root', onHydrationE
     const initialData = (window as { __INITIAL_DATA__?: Record<string, unknown> }).__INITIAL_DATA__;
     const location = window.location.pathname + window.location.search;
 
-    // Missing initial data falls back to CSR (design 4). A CSR mount is NOT a hydration, so it
-    // emits NO beacon - the beacon fires only when application hydration actually ran, which is
-    // also what keeps it absent under `shouldHydrate: false` (no client entry is emitted at all in
-    // that cell, so this module never runs).
+    // Missing initial data falls back to CSR (design 4): a CSR mount is NOT a hydration, so it emits
+    // no beacon and no `onStart`. A successful CSR root establishment still reports `onSuccess`; a
+    // failed one reports `onHydrationError`.
     if (initialData === undefined) {
+      log('No initial SSR data; mounting CSR');
+
       try {
         rootElement.innerHTML = '';
         const store = createSSRStore<Record<string, unknown>>({});
         render(() => provideSSRStore(store, () => app({ location })), rootElement);
-      } catch (error) {
-        reportError(error);
+        reportSuccess('CSR mount succeeded');
+      } catch (err) {
+        reportFailure('CSR mount failed', err);
       }
 
       return;
     }
 
-    emitBeacon('hydration:start');
+    // Hydration path. On the pinned Solid runtime `hydrate(...)` establishes the root synchronously
+    // and returns, so a successful return is an honest "root established" signal (design 2). Internal
+    // first: the `start` beacon precedes `onStart`, and the `success` beacon precedes `onSuccess`.
+    emitBeacons = true;
+    reportStart();
 
     try {
       const store = createSSRStore(initialData);
       hydrate(() => provideSSRStore(store, () => app({ location })), rootElement, renderId ? { renderId } : undefined);
-
-      emitBeacon('hydration:success');
-    } catch (error) {
+      reportSuccess('Hydration succeeded');
+    } catch (err) {
       // A hydration failure reports and STOPS. It deliberately does NOT silently remount as CSR
-      // (design 4): a silent remount hides a real server/client divergence behind a page that
-      // looks fine, and destroys the server-rendered markup that would have shown the mismatch.
-      emitBeacon('hydration:error', error);
-      reportError(error);
+      // (design 4): a silent remount hides a real server/client divergence behind a page that looks
+      // fine, and destroys the server-rendered markup that would have shown the mismatch.
+      reportFailure('Hydration failed', err);
     }
   };
 

--- a/packages/solid/src/test/HydrateAppOptions.test-d.ts
+++ b/packages/solid/src/test/HydrateAppOptions.test-d.ts
@@ -1,0 +1,49 @@
+// Compile-time contract for @taujs/solid's client hydration surface (hydration-observability
+// parity). Typechecked by `pnpm --filter @taujs/solid typecheck` (tsc); the `.test-d.ts` suffix is
+// outside vitest's glob, so it never runs as a spec.
+import type { JSX } from 'solid-js';
+
+import type { HydrateAppOptions } from '../SSRHydration.js';
+
+// 1. Exact key equality, both directions: the eight ruled members and nothing else. Adding or
+//    removing an option flips this to `false` and breaks the assignment.
+type ExpectedKeys = 'app' | 'renderId' | 'rootElementId' | 'logger' | 'enableDebug' | 'onStart' | 'onSuccess' | 'onHydrationError';
+type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+const _keysAreExact: Exact<keyof HydrateAppOptions, ExpectedKeys> = true;
+void _keysAreExact;
+
+const app = (_props: { location: string }): JSX.Element => null as unknown as JSX.Element;
+
+// A fully-populated options object typechecks.
+const _valid: HydrateAppOptions = {
+  app,
+  renderId: 'r',
+  rootElementId: 'root',
+  logger: { warn: () => {}, error: () => {} },
+  enableDebug: true,
+  onStart: () => {},
+  onSuccess: () => {},
+  onHydrationError: () => {},
+};
+void _valid;
+
+// `onStart`/`onSuccess` take NO arguments in Solid (unlike Vue's App-instance form).
+const _onStart: NonNullable<HydrateAppOptions['onStart']> = () => {};
+const _onSuccess: NonNullable<HydrateAppOptions['onSuccess']> = () => {};
+void _onStart;
+void _onSuccess;
+
+// 2. `dataKey` is NOT part of the Solid surface - τjs has one snapshot authority
+//    (`window.__INITIAL_DATA__`).
+// @ts-expect-error - dataKey is rejected
+const _rejectDataKey: HydrateAppOptions = { app, dataKey: '__INITIAL_DATA__' };
+void _rejectDataKey;
+
+// 3. React-only / Vue-only options are rejected by analogy.
+// @ts-expect-error - identifierPrefix is React-only
+const _rejectIdentifierPrefix: HydrateAppOptions = { app, identifierPrefix: 'x' };
+void _rejectIdentifierPrefix;
+
+// @ts-expect-error - setupApp is Vue-only
+const _rejectSetupApp: HydrateAppOptions = { app, setupApp: () => {} };
+void _rejectSetupApp;

--- a/packages/solid/src/test/PublicSurface.test.ts
+++ b/packages/solid/src/test/PublicSurface.test.ts
@@ -12,8 +12,10 @@ import { describe, expect, it } from 'vitest';
 const packageJson = JSON.parse(readFileSync(fileURLToPath(new URL('../../package.json', import.meta.url)), 'utf8')) as {
   exports: Record<string, unknown>;
   dependencies: Record<string, string>;
+  devDependencies?: Record<string, string>;
   peerDependencies: Record<string, string>;
   peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+  files?: string[];
 };
 
 const distPath = (file: string) => fileURLToPath(new URL(`../../dist/${file}`, import.meta.url));
@@ -111,6 +113,16 @@ describe('slice 6 - the raw plugin subpath (`@taujs/solid/plugin`) stays portabl
 });
 
 describe('slice 6 - dependency classification', () => {
+  it('happy-dom is a devDependency only - never a runtime dependency, peer, or packed output', () => {
+    // The client hydration tests run in a happy-dom worker; it is the one sanctioned dependency of
+    // the hydration-observability work and must never reach a consumer. `files` ships only `dist`,
+    // and a test-only DOM environment appears in no runtime surface.
+    expect(packageJson.devDependencies?.['happy-dom']).toBeTruthy();
+    expect(packageJson.dependencies['happy-dom']).toBeUndefined();
+    expect(packageJson.peerDependencies['happy-dom']).toBeUndefined();
+    expect(packageJson.files).toEqual(['dist']);
+  });
+
   it('seroval is a real dependency pinned exactly, not an optional peer', () => {
     expect(packageJson.dependencies.seroval).toBe('1.5.5');
     expect(packageJson.peerDependencies.seroval).toBeUndefined();

--- a/packages/solid/src/test/SSRHydration.test.ts
+++ b/packages/solid/src/test/SSRHydration.test.ts
@@ -1,0 +1,347 @@
+// @vitest-environment happy-dom
+//
+// Hydration-observability parity for @taujs/solid. This is the ONLY happy-dom file in the package;
+// the package-wide environment stays `node` (vitest.config.ts). It drives the REAL exported
+// `hydrateApp` and mocks ONLY Solid's terminal `hydrate`/`render` primitives, so a deterministic
+// throw can be injected and the exact native-call ordering recorded. `hydrateApp` itself is never
+// mocked or reproduced.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { hydrateMock, renderMock } = vi.hoisted(() => ({ hydrateMock: vi.fn(), renderMock: vi.fn() }));
+
+vi.mock('solid-js/web', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('solid-js/web')>();
+
+  return { ...actual, hydrate: hydrateMock, render: renderMock };
+});
+
+import { hydrateApp } from '../SSRHydration.js';
+
+import type { JSX } from 'solid-js';
+
+/** Never invoked - `hydrate`/`render` are mocked, so the app factory is only a shape. */
+const stubApp = (_props: { location: string }): JSX.Element => null as unknown as JSX.Element;
+
+const setRoot = () => {
+  document.body.innerHTML = '<div id="root"></div>';
+};
+const setData = (d: unknown) => {
+  (window as unknown as { __INITIAL_DATA__?: unknown }).__INITIAL_DATA__ = d;
+};
+const clearData = () => {
+  delete (window as unknown as { __INITIAL_DATA__?: unknown }).__INITIAL_DATA__;
+};
+/** Install a devtools-hook consumer that appends `beacon:<event>` to `events`. */
+const setHook = (events: string[]) => {
+  (window as unknown as { __TAUJS_DEVTOOLS_HOOK__?: unknown }).__TAUJS_DEVTOOLS_HOOK__ = {
+    emit: (e: string) => events.push(`beacon:${e}`),
+  };
+};
+const clearHook = () => {
+  delete (window as unknown as { __TAUJS_DEVTOOLS_HOOK__?: unknown }).__TAUJS_DEVTOOLS_HOOK__;
+};
+
+let consoleSpies: {
+  log: ReturnType<typeof vi.spyOn>;
+  debug: ReturnType<typeof vi.spyOn>;
+  warn: ReturnType<typeof vi.spyOn>;
+  error: ReturnType<typeof vi.spyOn>;
+};
+
+beforeEach(() => {
+  hydrateMock.mockReset();
+  renderMock.mockReset();
+  document.body.innerHTML = '';
+  clearData();
+  clearHook();
+  consoleSpies = {
+    log: vi.spyOn(console, 'log').mockImplementation(() => {}),
+    debug: vi.spyOn(console, 'debug').mockImplementation(() => {}),
+    warn: vi.spyOn(console, 'warn').mockImplementation(() => {}),
+    error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('hydrateApp - lifecycle ordering and settlement (happy-dom, real hydrateApp)', () => {
+  it('successful hydration: start beacon -> onStart -> native hydrate -> success beacon -> onSuccess', () => {
+    const events: string[] = [];
+    setHook(events);
+    setRoot();
+    setData({ ok: 1 });
+    hydrateMock.mockImplementation(() => events.push('native:hydrate'));
+    const onHydrationError = vi.fn();
+
+    hydrateApp({
+      app: stubApp,
+      onStart: () => events.push('cb:onStart'),
+      onSuccess: () => events.push('cb:onSuccess'),
+      onHydrationError,
+    });
+
+    expect(events).toEqual(['beacon:hydration:start', 'cb:onStart', 'native:hydrate', 'beacon:hydration:success', 'cb:onSuccess']);
+    expect(hydrateMock).toHaveBeenCalledTimes(1);
+    expect(renderMock).not.toHaveBeenCalled();
+    expect(onHydrationError).not.toHaveBeenCalled();
+  });
+
+  it('the same callbacks run with the devtools hook absent', () => {
+    clearHook();
+    setRoot();
+    setData({ ok: 1 });
+    const onStart = vi.fn();
+    const onSuccess = vi.fn();
+    const onHydrationError = vi.fn();
+
+    hydrateApp({ app: stubApp, onStart, onSuccess, onHydrationError });
+
+    expect(onStart).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onHydrationError).not.toHaveBeenCalled();
+  });
+
+  it('a synchronous hydrate throw: start then error, onHydrationError once, never onSuccess', () => {
+    const events: string[] = [];
+    setHook(events);
+    setRoot();
+    setData({ ok: 1 });
+    const boom = new Error('hydrate boom');
+    hydrateMock.mockImplementation(() => {
+      throw boom;
+    });
+    const onSuccess = vi.fn();
+    const onHydrationError = vi.fn(() => events.push('cb:onHydrationError'));
+
+    hydrateApp({ app: stubApp, onStart: () => events.push('cb:onStart'), onSuccess, onHydrationError });
+
+    expect(events).toEqual(['beacon:hydration:start', 'cb:onStart', 'beacon:hydration:error', 'cb:onHydrationError']);
+    expect(onHydrationError).toHaveBeenCalledTimes(1);
+    expect(onHydrationError).toHaveBeenCalledWith(boom);
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('a missing root: error beacon only, onHydrationError once, no start/success', () => {
+    const events: string[] = [];
+    setHook(events);
+    document.body.innerHTML = ''; // no #root
+    setData({ ok: 1 });
+    const onStart = vi.fn();
+    const onSuccess = vi.fn();
+    const onHydrationError = vi.fn(() => events.push('cb:onHydrationError'));
+
+    hydrateApp({ app: stubApp, rootElementId: 'root', onStart, onSuccess, onHydrationError });
+
+    expect(events).toEqual(['beacon:hydration:error', 'cb:onHydrationError']);
+    expect(onHydrationError).toHaveBeenCalledTimes(1);
+    expect(onStart).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(hydrateMock).not.toHaveBeenCalled();
+    expect(renderMock).not.toHaveBeenCalled();
+  });
+
+  it('successful CSR fallback (no snapshot): no beacon, no onStart, onSuccess once', () => {
+    const events: string[] = [];
+    setHook(events);
+    setRoot();
+    clearData();
+    renderMock.mockImplementation(() => events.push('native:render'));
+    const onStart = vi.fn();
+    const onHydrationError = vi.fn();
+
+    hydrateApp({ app: stubApp, onStart, onSuccess: () => events.push('cb:onSuccess'), onHydrationError });
+
+    expect(events).toEqual(['native:render', 'cb:onSuccess']);
+    expect(renderMock).toHaveBeenCalledTimes(1);
+    expect(hydrateMock).not.toHaveBeenCalled();
+    expect(onStart).not.toHaveBeenCalled();
+    expect(onHydrationError).not.toHaveBeenCalled();
+  });
+
+  it('a failed CSR fallback: no beacon, onHydrationError once, never onSuccess', () => {
+    const events: string[] = [];
+    setHook(events);
+    setRoot();
+    clearData();
+    const boom = new Error('csr boom');
+    renderMock.mockImplementation(() => {
+      throw boom;
+    });
+    const onSuccess = vi.fn();
+    const onHydrationError = vi.fn(() => events.push('cb:onHydrationError'));
+
+    hydrateApp({ app: stubApp, onSuccess, onHydrationError });
+
+    expect(events).toEqual(['cb:onHydrationError']);
+    expect(onHydrationError).toHaveBeenCalledTimes(1);
+    expect(onHydrationError).toHaveBeenCalledWith(boom);
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});
+
+describe('hydrateApp - observer isolation', () => {
+  it('a throwing onStart is logged and hydration still succeeds', () => {
+    setRoot();
+    setData({ ok: 1 });
+    const onSuccess = vi.fn();
+    const onHydrationError = vi.fn();
+
+    hydrateApp({
+      app: stubApp,
+      onStart: () => {
+        throw new Error('onStart boom');
+      },
+      onSuccess,
+      onHydrationError,
+    });
+
+    expect(hydrateMock).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onHydrationError).not.toHaveBeenCalled(); // a callback throw must not manufacture failure
+    expect(consoleSpies.error).toHaveBeenCalled(); // the throw was logged
+  });
+
+  it('a throwing onSuccess is logged and does not manufacture failure or remove the root', () => {
+    setRoot();
+    setData({ ok: 1 });
+    const onHydrationError = vi.fn();
+
+    hydrateApp({
+      app: stubApp,
+      onSuccess: () => {
+        throw new Error('onSuccess boom');
+      },
+      onHydrationError,
+    });
+
+    expect(hydrateMock).toHaveBeenCalledTimes(1);
+    expect(onHydrationError).not.toHaveBeenCalled();
+    expect(consoleSpies.error).toHaveBeenCalled();
+  });
+
+  it('a throwing onHydrationError is swallowed and does not escape', () => {
+    setRoot();
+    setData({ ok: 1 });
+    hydrateMock.mockImplementation(() => {
+      throw new Error('hydrate boom');
+    });
+
+    expect(() =>
+      hydrateApp({
+        app: stubApp,
+        onHydrationError: () => {
+          throw new Error('handler boom');
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it('a throwing logger cannot escape or alter settlement', () => {
+    setRoot();
+    setData({ ok: 1 });
+    const throwingLogger = {
+      log: () => {
+        throw new Error('log boom');
+      },
+      warn: () => {
+        throw new Error('warn boom');
+      },
+      error: () => {
+        throw new Error('error boom');
+      },
+    };
+    const onSuccess = vi.fn();
+
+    expect(() => hydrateApp({ app: stubApp, logger: throwingLogger, enableDebug: true, onSuccess })).not.toThrow();
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('hydrateApp - logging contract', () => {
+  it('enableDebug:false suppresses verbose start/success messages (UI logger)', () => {
+    setRoot();
+    setData({ ok: 1 });
+    const uiLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    hydrateApp({ app: stubApp, logger: uiLogger, enableDebug: false, onSuccess: vi.fn() });
+
+    expect(uiLogger.log).not.toHaveBeenCalled();
+  });
+
+  it('enableDebug:true emits start and success via a UI logger', () => {
+    setRoot();
+    setData({ ok: 1 });
+    const uiLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    hydrateApp({ app: stubApp, logger: uiLogger, enableDebug: true, onSuccess: vi.fn() });
+
+    const messages = uiLogger.log.mock.calls.map((c) => String(c[0]));
+    expect(messages.some((m) => /started/i.test(m))).toBe(true);
+    expect(messages.some((m) => /succeeded/i.test(m))).toBe(true);
+  });
+
+  it('a server-shaped (Pino) logger receives the same lifecycle through its debug shape', () => {
+    setRoot();
+    setData({ ok: 1 });
+    const server = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+    hydrateApp({ app: stubApp, logger: server, enableDebug: true, onSuccess: vi.fn() });
+
+    expect(server.debug.mock.calls.length).toBeGreaterThan(0);
+    const messages = server.debug.mock.calls.map((c) => String(c[2] ?? ''));
+    expect(messages.some((m) => /started/i.test(m))).toBe(true);
+    expect(messages.some((m) => /succeeded/i.test(m))).toBe(true);
+  });
+
+  it('hydration/CSR failures reach error regardless of enableDebug', () => {
+    for (const enableDebug of [false, true]) {
+      setRoot();
+      setData({ ok: 1 });
+      hydrateMock.mockImplementationOnce(() => {
+        throw new Error('boom');
+      });
+      const uiLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+      hydrateApp({ app: stubApp, logger: uiLogger, enableDebug, onHydrationError: vi.fn() });
+
+      expect(uiLogger.error, `error should fire with enableDebug=${enableDebug}`).toHaveBeenCalled();
+    }
+  });
+
+  it('with no logger, errors use console while verbose lifecycle stays off by default', () => {
+    // Failure with no logger -> console.error.
+    setRoot();
+    setData({ ok: 1 });
+    hydrateMock.mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+    hydrateApp({ app: stubApp, onHydrationError: vi.fn() });
+    expect(consoleSpies.error).toHaveBeenCalled();
+
+    // Success with enableDebug default false -> no verbose console output.
+    consoleSpies.debug.mockClear();
+    consoleSpies.log.mockClear();
+    setRoot();
+    setData({ ok: 1 });
+    hydrateApp({ app: stubApp, onSuccess: vi.fn() });
+    expect(consoleSpies.debug).not.toHaveBeenCalled();
+    expect(consoleSpies.log).not.toHaveBeenCalled();
+  });
+
+  it('the initial-data payload is never logged', () => {
+    const SECRET = 'super-secret-token-9f3a';
+    setRoot();
+    setData({ token: SECRET, nested: { x: SECRET } });
+    const uiLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    hydrateApp({ app: stubApp, logger: uiLogger, enableDebug: true, onSuccess: vi.fn() });
+
+    const logged = [...uiLogger.log.mock.calls, ...uiLogger.warn.mock.calls, ...uiLogger.error.mock.calls]
+      .flat()
+      .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
+      .join(' ');
+    expect(logged).not.toContain(SECRET);
+  });
+});

--- a/packages/vue/src/SSRHydration.ts
+++ b/packages/vue/src/SSRHydration.ts
@@ -132,26 +132,26 @@ export function hydrateApp<T>({
   };
 
   const startHydration = (rootEl: HTMLElement, initialData: T) => {
+    // Lifecycle messages only - the route-data payload and the store object are NOT logged, so debug
+    // logging cannot disclose request data through a supplied (e.g. Pino) logger.
     if (enableDebug) log('Hydration started');
-    if (enableDebug) log('Initial data loaded:', initialData);
 
     const store = createSSRStore(initialData);
-    if (enableDebug) log('Store created:', store);
 
-    // "Hydration phase": the window during which an error is attributable to hydration.
-    // It ends on the first post-mount tick, so ordinary runtime errors afterwards are
-    // logged only, not reported as hydration failures. `errored` guards against the
-    // double-emit that would otherwise happen when app.config.errorHandler fires DURING a
-    // mount() that still returns normally (Vue swallows a handled error) — once we've
-    // emitted hydration:error we must suppress hydration:success. Known limitation: an
-    // async/<Suspense> error completing after the first tick is misclassified as post-phase.
+    // Single settlement: exactly one of success | failure fires, at most once. `settled` is set the
+    // moment either happens - crucially BEFORE emitting success - so an error arriving in the
+    // post-mount window (Vue surfaces hydration problems through `app.config.errorHandler`, which
+    // stays installed for the app's life) is log-only and cannot reverse a settled success.
+    // `inHydrationPhase` additionally makes post-tick runtime errors log-only even before settlement.
     let inHydrationPhase = true;
-    let errored = false;
+    let settled = false;
     const vueErrLog = createVueErrorHandler(logger, enableDebug);
 
     const reportHydrationFailure = (err: unknown) => {
-      if (!inHydrationPhase || errored) return;
-      errored = true;
+      // After settlement (a success or a prior error) the error is log-only - `vueErrLog` already
+      // logged it; this must not emit a second beacon or reverse a settled success.
+      if (!inHydrationPhase || settled) return;
+      settled = true;
       emitDevHook('hydration:error', err);
       // Isolated: this runs from Vue's app.config.errorHandler and from the outer catch, where an
       // un-isolated observer throw would escape hydrateApp.
@@ -199,7 +199,10 @@ export function hydrateApp<T>({
       // createSSRApp(...).mount() hydrates by default; no non-public second argument (F11).
       app.mount(rootEl);
 
-      if (!errored) {
+      if (!settled) {
+        // Settle BEFORE emitting success so an error in the post-mount, pre-nextTick window is
+        // log-only and cannot reverse this success.
+        settled = true;
         if (enableDebug) log('Hydration completed');
         emitDevHook('hydration:success');
         // Isolated: an un-isolated throw would hit the outer catch and emit hydration:error +

--- a/packages/vue/src/SSRHydration.ts
+++ b/packages/vue/src/SSRHydration.ts
@@ -45,8 +45,9 @@ export type HydrateAppOptions<T> = {
 /**
  * Vue client bootstrap. Contract-parity with taujs/react, with documented Vue-native
  * divergences:
- * - If window[dataKey] is missing, mount CSR (and clear existing DOM) — no hydration
- *   events are emitted (a CSR mount is not a hydration).
+ * - If window[dataKey] is missing, mount CSR (and clear existing DOM) — no beacon events
+ *   or `onStart` are emitted (a CSR mount is not a hydration), but a successful CSR root
+ *   reports `onSuccess(app)` and a failed one `onHydrationError` (react parity).
  * - Otherwise, hydrate SSR markup, emitting `hydration:start|success|error` to the
  *   dev-only `window.__TAUJS_DEVTOOLS_HOOK__` around the user callbacks.
  *
@@ -114,6 +115,12 @@ export function hydrateApp<T>({
       // back to CSR.
       setupApp?.(app);
       app.mount(rootEl);
+
+      // A successful CSR root establishment reports onSuccess exactly once (react parity). The CSR
+      // path still emits NO beacon and NO onStart - a CSR mount is not a hydration. Isolated: an
+      // observer throw is swallowed and the mounted app remains.
+      if (enableDebug) log('CSR mount succeeded');
+      runObserver('onSuccess', () => onSuccess?.(app));
     } catch (err) {
       // R2: a throwing setupApp/mount is an application error — route to onHydrationError
       // (the only client error channel). The CSR path emits NO beacon events: a CSR mount is

--- a/packages/vue/src/test/SSRHydration.test.ts
+++ b/packages/vue/src/test/SSRHydration.test.ts
@@ -40,9 +40,11 @@ describe('hydrateApp — mount paths', () => {
     expect(onSuccess).toHaveBeenCalledTimes(1);
   });
 
-  it('mounts CSR (fresh) when SSR data is absent — clears stale markup, no hydration callbacks', () => {
+  it('mounts CSR (fresh) when SSR data is absent - clears stale markup, calls onSuccess once, no onStart or beacon (Slice B)', () => {
     setRoot('<div>stale</div>');
     setData(undefined);
+    const events: string[] = [];
+    (window as any).__TAUJS_DEVTOOLS_HOOK__ = { emit: (ev: string) => events.push(ev) };
     const onStart = vi.fn();
     const onSuccess = vi.fn();
 
@@ -50,8 +52,32 @@ describe('hydrateApp — mount paths', () => {
 
     const root = document.getElementById('root')!;
     expect(root.textContent).toBe('app');
+    // Slice B: a successful CSR root establishment reports onSuccess (react parity), receiving the App.
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess.mock.calls[0]![0]).toBeDefined();
+    // ...but the CSR path still emits no onStart and no hydration beacon (a CSR mount is not a hydration).
     expect(onStart).not.toHaveBeenCalled();
-    expect(onSuccess).not.toHaveBeenCalled();
+    expect(events).toEqual([]);
+  });
+
+  it('a throwing CSR onSuccess is isolated and the mounted app remains (Slice B)', () => {
+    setRoot('<div>stale</div>');
+    setData(undefined);
+    const onHydrationError = vi.fn();
+
+    expect(() =>
+      hydrateApp({
+        appComponent: CleanApp,
+        onSuccess: () => {
+          throw new Error('csr onSuccess boom');
+        },
+        onHydrationError,
+      }),
+    ).not.toThrow();
+
+    const root = document.getElementById('root')!;
+    expect(root.textContent).toBe('app'); // the app stayed mounted
+    expect(onHydrationError).not.toHaveBeenCalled(); // a callback throw is not a bootstrap failure
   });
 
   it('logs and does not mount when the root element is missing', () => {

--- a/packages/vue/src/test/SSRHydration.test.ts
+++ b/packages/vue/src/test/SSRHydration.test.ts
@@ -164,6 +164,53 @@ describe('hydrateApp — error handler wiring (F11)', () => {
     expect(onHydrationError).not.toHaveBeenCalled();
   });
 
+  it('an error after success but before nextTick does not reverse settlement (settlement guard)', () => {
+    setRoot('<div>app</div>');
+    setData({ a: 1 });
+    const events: string[] = [];
+    (window as any).__TAUJS_DEVTOOLS_HOOK__ = { emit: (ev: string) => events.push(ev) };
+    const onSuccess = vi.fn();
+    const onHydrationError = vi.fn();
+    let captured: App | undefined;
+
+    hydrateApp({
+      appComponent: CleanApp,
+      onSuccess: (app) => {
+        captured = app;
+        onSuccess(app);
+      },
+      onHydrationError,
+    });
+
+    // Success has settled synchronously; the phase-closing nextTick has NOT run yet.
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(events).toEqual(['hydration:start', 'hydration:success']);
+
+    // Provoke Vue's error handler in the post-success, pre-nextTick window - the exact window the
+    // old phase-only guard left open.
+    captured!.config.errorHandler!(new Error('post-success boom'), null, 'x');
+
+    // Settlement holds: still one success, no hydration:error beacon, no onHydrationError.
+    expect(events).toEqual(['hydration:start', 'hydration:success']);
+    expect(onHydrationError).not.toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it('never logs the route-data payload, even with enableDebug (no disclosure through the logger)', () => {
+    const SECRET = 'super-secret-token-9f3a';
+    setRoot('<div>app</div>');
+    setData({ token: SECRET, nested: { x: SECRET } });
+    const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    hydrateApp({ appComponent: CleanApp, enableDebug: true, logger });
+
+    const logged = [...logger.log.mock.calls, ...logger.warn.mock.calls, ...logger.error.mock.calls]
+      .flat()
+      .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
+      .join(' ');
+    expect(logged).not.toContain(SECRET);
+  });
+
   it('forwards Vue warnings to the logger in enableDebug mode (hydration mismatch)', () => {
     // Markup deliberately mismatches the component render → Vue emits a hydration warning.
     setRoot('<span>mismatch</span>');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,7 +70,7 @@ importers:
         version: 2.11.12(solid-js@1.9.14)(vite@7.3.6(@types/node@24.13.3)(tsx@4.23.0))
       vitest:
         specifier: ^3.2.4
-        version: 3.2.7(@types/node@24.13.3)(@vitest/ui@3.2.7)(jsdom@25.0.1)(tsx@4.23.0)
+        version: 3.2.7(@types/node@24.13.3)(@vitest/ui@3.2.7)(happy-dom@20.11.0)(jsdom@25.0.1)(tsx@4.23.0)
       vue:
         specifier: ^3.5.0
         version: 3.5.39(typescript@5.9.3)
@@ -153,7 +153,7 @@ importers:
         version: 2.11.12(solid-js@1.9.14)(vite@7.3.6(@types/node@20.19.43)(tsx@4.23.0))
       vitest:
         specifier: ^3.2.4
-        version: 3.2.7(@types/node@20.19.43)(@vitest/ui@3.2.7)(jsdom@25.0.1)(tsx@4.23.0)
+        version: 3.2.7(@types/node@20.19.43)(@vitest/ui@3.2.7)(happy-dom@20.11.0)(jsdom@25.0.1)(tsx@4.23.0)
 
   fixtures/playground-vue:
     dependencies:
@@ -221,7 +221,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.7(@types/node@20.19.43)(@vitest/ui@3.2.7)(jsdom@25.0.1)(tsx@4.23.0)
+        version: 3.2.7(@types/node@20.19.43)(@vitest/ui@3.2.7)(happy-dom@20.11.0)(jsdom@25.0.1)(tsx@4.23.0)
 
   packages/mcp:
     dependencies:
@@ -249,7 +249,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@types/node@20.19.43)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@25.0.1)(vite@7.3.6(@types/node@20.19.43)(tsx@4.23.0))
+        version: 4.1.10(@types/node@20.19.43)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@25.0.1)(vite@7.3.6(@types/node@20.19.43)(tsx@4.23.0))
 
   packages/react:
     dependencies:
@@ -283,7 +283,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.7(vitest@3.2.7(@types/node@24.13.3)(@vitest/ui@3.2.7)(jsdom@25.0.1)(tsx@4.23.0))
+        version: 3.2.7(vitest@3.2.7(@types/node@24.13.3)(@vitest/ui@3.2.7)(happy-dom@20.11.0)(jsdom@25.0.1)(tsx@4.23.0))
       '@vitest/ui':
         specifier: ^3.2.4
         version: 3.2.7(vitest@3.2.7)
@@ -310,7 +310,7 @@ importers:
         version: 7.3.6(@types/node@24.13.3)(tsx@4.23.0)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.7(@types/node@24.13.3)(@vitest/ui@3.2.7)(jsdom@25.0.1)(tsx@4.23.0)
+        version: 3.2.7(@types/node@24.13.3)(@vitest/ui@3.2.7)(happy-dom@20.11.0)(jsdom@25.0.1)(tsx@4.23.0)
 
   packages/server:
     dependencies:
@@ -365,7 +365,7 @@ importers:
         version: 7.3.6(@types/node@20.19.43)(tsx@4.23.0)
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@types/node@20.19.43)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@25.0.1)(vite@7.3.6(@types/node@20.19.43)(tsx@4.23.0))
+        version: 4.1.10(@types/node@20.19.43)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@25.0.1)(vite@7.3.6(@types/node@20.19.43)(tsx@4.23.0))
 
   packages/solid:
     dependencies:
@@ -391,6 +391,9 @@ importers:
       '@types/picomatch':
         specifier: ^2.3.3
         version: 2.3.4
+      happy-dom:
+        specifier: ^20.11.0
+        version: 20.11.0
       solid-js:
         specifier: ~1.9.14
         version: 1.9.14
@@ -408,7 +411,7 @@ importers:
         version: 2.11.12(solid-js@1.9.14)(vite@7.3.6(@types/node@24.13.3)(tsx@4.23.0))
       vitest:
         specifier: ^3.2.4
-        version: 3.2.7(@types/node@24.13.3)(@vitest/ui@3.2.7)(jsdom@25.0.1)(tsx@4.23.0)
+        version: 3.2.7(@types/node@24.13.3)(@vitest/ui@3.2.7)(happy-dom@20.11.0)(jsdom@25.0.1)(tsx@4.23.0)
 
   packages/vue:
     devDependencies:
@@ -435,7 +438,7 @@ importers:
         version: 6.0.7(vite@7.3.6(@types/node@22.20.1)(tsx@4.23.0))(vue@3.5.39(typescript@5.9.3))
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.7(vitest@3.2.7(@types/node@22.20.1)(@vitest/ui@3.2.7)(jsdom@25.0.1)(tsx@4.23.0))
+        version: 3.2.7(vitest@3.2.7(@types/node@22.20.1)(@vitest/ui@3.2.7)(happy-dom@20.11.0)(jsdom@25.0.1)(tsx@4.23.0))
       '@vitest/ui':
         specifier: ^3.2.4
         version: 3.2.7(vitest@3.2.7)
@@ -462,7 +465,7 @@ importers:
         version: 7.3.6(@types/node@22.20.1)(tsx@4.23.0)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.7(@types/node@22.20.1)(@vitest/ui@3.2.7)(jsdom@25.0.1)(tsx@4.23.0)
+        version: 3.2.7(@types/node@22.20.1)(@vitest/ui@3.2.7)(happy-dom@20.11.0)(jsdom@25.0.1)(tsx@4.23.0)
       vue:
         specifier: ^3.5.25
         version: 3.5.39(typescript@5.9.3)
@@ -1390,6 +1393,12 @@ packages:
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@vitejs/plugin-react@5.2.0':
     resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1706,6 +1715,10 @@ packages:
     resolution: {integrity: sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -2191,6 +2204,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  happy-dom@20.11.0:
+    resolution: {integrity: sha512-XogN4asPd1a56di9prVG6bZxteNcXsZxxKmAvcEfc5Px5Ca2hMyMgk8wvqK2K1V8zXg40j9VANXsDaJYh9DeNA==}
+    engines: {node: '>=20.0.0'}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -3492,6 +3509,10 @@ packages:
     engines: {node: '>=18'}
     deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
@@ -4504,6 +4525,12 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.43
+
   '@vitejs/plugin-react@5.2.0(vite@7.3.6(@types/node@24.13.3)(tsx@4.23.0))':
     dependencies:
       '@babel/core': 7.29.7
@@ -4534,7 +4561,7 @@ snapshots:
       vite: 7.3.6(@types/node@24.13.3)(tsx@4.23.0)
       vue: 3.5.39(typescript@5.9.3)
 
-  '@vitest/coverage-v8@3.2.7(vitest@3.2.7(@types/node@22.20.1)(@vitest/ui@3.2.7)(jsdom@25.0.1)(tsx@4.23.0))':
+  '@vitest/coverage-v8@3.2.7(vitest@3.2.7(@types/node@22.20.1)(@vitest/ui@3.2.7)(happy-dom@20.11.0)(jsdom@25.0.1)(tsx@4.23.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -4549,11 +4576,11 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.7(@types/node@22.20.1)(@vitest/ui@3.2.7)(jsdom@25.0.1)(tsx@4.23.0)
+      vitest: 3.2.7(@types/node@22.20.1)(@vitest/ui@3.2.7)(happy-dom@20.11.0)(jsdom@25.0.1)(tsx@4.23.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.7(vitest@3.2.7(@types/node@24.13.3)(@vitest/ui@3.2.7)(jsdom@25.0.1)(tsx@4.23.0))':
+  '@vitest/coverage-v8@3.2.7(vitest@3.2.7(@types/node@24.13.3)(@vitest/ui@3.2.7)(happy-dom@20.11.0)(jsdom@25.0.1)(tsx@4.23.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -4568,7 +4595,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.7(@types/node@24.13.3)(@vitest/ui@3.2.7)(jsdom@25.0.1)(tsx@4.23.0)
+      vitest: 3.2.7(@types/node@24.13.3)(@vitest/ui@3.2.7)(happy-dom@20.11.0)(jsdom@25.0.1)(tsx@4.23.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -4584,7 +4611,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@20.19.43)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@25.0.1)(vite@7.3.6(@types/node@20.19.43)(tsx@4.23.0))
+      vitest: 4.1.10(@types/node@20.19.43)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@25.0.1)(vite@7.3.6(@types/node@20.19.43)(tsx@4.23.0))
 
   '@vitest/expect@3.2.7':
     dependencies:
@@ -4682,7 +4709,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 2.0.0
-      vitest: 3.2.7(@types/node@24.13.3)(@vitest/ui@3.2.7)(jsdom@25.0.1)(tsx@4.23.0)
+      vitest: 3.2.7(@types/node@24.13.3)(@vitest/ui@3.2.7)(happy-dom@20.11.0)(jsdom@25.0.1)(tsx@4.23.0)
 
   '@vitest/ui@4.1.10(vitest@4.1.10)':
     dependencies:
@@ -4693,7 +4720,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@20.19.43)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@25.0.1)(vite@7.3.6(@types/node@20.19.43)(tsx@4.23.0))
+      vitest: 4.1.10(@types/node@20.19.43)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@25.0.1)(vite@7.3.6(@types/node@20.19.43)(tsx@4.23.0))
 
   '@vitest/utils@3.2.7':
     dependencies:
@@ -4953,6 +4980,10 @@ snapshots:
       electron-to-chromium: 1.5.389
       node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.5)
+
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 20.19.43
 
   bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
@@ -5532,6 +5563,19 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  happy-dom@20.11.0:
+    dependencies:
+      '@types/node': 20.19.43
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-bigints@1.1.0: {}
 
@@ -6747,7 +6791,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.6(@types/node@24.13.3)(tsx@4.23.0)
 
-  vitest@3.2.7(@types/node@20.19.43)(@vitest/ui@3.2.7)(jsdom@25.0.1)(tsx@4.23.0):
+  vitest@3.2.7(@types/node@20.19.43)(@vitest/ui@3.2.7)(happy-dom@20.11.0)(jsdom@25.0.1)(tsx@4.23.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.7
@@ -6775,6 +6819,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.43
       '@vitest/ui': 3.2.7(vitest@3.2.7)
+      happy-dom: 20.11.0
       jsdom: 25.0.1
     transitivePeerDependencies:
       - jiti
@@ -6790,7 +6835,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.7(@types/node@22.20.1)(@vitest/ui@3.2.7)(jsdom@25.0.1)(tsx@4.23.0):
+  vitest@3.2.7(@types/node@22.20.1)(@vitest/ui@3.2.7)(happy-dom@20.11.0)(jsdom@25.0.1)(tsx@4.23.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.7
@@ -6818,6 +6863,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.20.1
       '@vitest/ui': 3.2.7(vitest@3.2.7)
+      happy-dom: 20.11.0
       jsdom: 25.0.1
     transitivePeerDependencies:
       - jiti
@@ -6833,7 +6879,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.7(@types/node@24.13.3)(@vitest/ui@3.2.7)(jsdom@25.0.1)(tsx@4.23.0):
+  vitest@3.2.7(@types/node@24.13.3)(@vitest/ui@3.2.7)(happy-dom@20.11.0)(jsdom@25.0.1)(tsx@4.23.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.7
@@ -6861,6 +6907,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.13.3
       '@vitest/ui': 3.2.7(vitest@3.2.7)
+      happy-dom: 20.11.0
       jsdom: 25.0.1
     transitivePeerDependencies:
       - jiti
@@ -6876,7 +6923,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.10(@types/node@20.19.43)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@25.0.1)(vite@7.3.6(@types/node@20.19.43)(tsx@4.23.0)):
+  vitest@4.1.10(@types/node@20.19.43)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@25.0.1)(vite@7.3.6(@types/node@20.19.43)(tsx@4.23.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@20.19.43)(tsx@4.23.0))
@@ -6902,6 +6949,7 @@ snapshots:
       '@types/node': 20.19.43
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
       '@vitest/ui': 4.1.10(vitest@4.1.10)
+      happy-dom: 20.11.0
       jsdom: 25.0.1
     transitivePeerDependencies:
       - msw
@@ -6937,6 +6985,8 @@ snapshots:
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
+
+  whatwg-mimetype@3.0.0: {}
 
   whatwg-mimetype@4.0.0: {}
 

--- a/website/src/content/docs/renderers/react.mdx
+++ b/website/src/content/docs/renderers/react.mdx
@@ -468,7 +468,7 @@ function hydrateApp<T>(options: {
 
 - `appComponent`: Your root React component (already instantiated)
 - `rootElementId`: DOM element ID to hydrate into (default: `'root'`)
-- `enableDebug`: Enable debug logging (default: `false`)
+- `enableDebug`: Enable debug logging (default: `false`). Debug logging is lifecycle messages only - the route-data payload and the store object are never logged, so a logger that forwards to a server sink cannot disclose request data.
 - `logger`: Custom logger implementation
 - `dataKey`: Key for initial data on window object (default: `'__INITIAL_DATA__'`)
 - `identifierPrefix`: React's `useId` prefix, passed to both `hydrateRoot` and the CSR-fallback `createRoot`. Must be identical to the value the server rendered with (`createRenderer`'s `identifierPrefix`), or hydration mismatches.

--- a/website/src/content/docs/renderers/solid.mdx
+++ b/website/src/content/docs/renderers/solid.mdx
@@ -406,6 +406,7 @@ Hydrates a server-rendered Solid application on the client, or mounts a fresh CS
 
 ```typescript
 import type { JSX } from "solid-js";
+import type { SolidLogger } from "@taujs/solid";
 
 function hydrateApp(options: {
   /** Your root, receiving { location }. */
@@ -413,9 +414,34 @@ function hydrateApp(options: {
   /** Must match the renderId the SERVER rendered with. */
   renderId?: string;
   rootElementId?: string; // default 'root'
+  /** Receives hydration lifecycle logs (see below). */
+  logger?: SolidLogger;
+  /** Gate verbose lifecycle logs. Warnings and errors are never gated. Default false. */
+  enableDebug?: boolean;
+  /** Observes the start of hydration (hydrate path only). */
+  onStart?: () => void;
+  /** Observes successful root establishment (hydrate or CSR). */
+  onSuccess?: () => void;
+  /** Observes a failed root establishment. */
   onHydrationError?: (error: unknown) => void;
 }): void;
 ```
+
+**Lifecycle callbacks.** The three observers are advisory - a throw from any of them is logged and swallowed; it never becomes an `onHydrationError`, manufactures a beacon, or tears down the root.
+
+| Path                 | `onStart`                    | `onSuccess`                      | `onHydrationError` |
+| -------------------- | ---------------------------- | -------------------------------- | ------------------ |
+| Hydration succeeds   | once, before native `hydrate` | once, after `hydrate` returns    | never              |
+| Hydration throws     | once                         | never                            | once               |
+| CSR fallback succeeds | never                        | once, after `render` establishes | never              |
+| CSR fallback throws  | never                        | never                            | once               |
+| Root element missing | never                        | never                            | once               |
+
+`onSuccess` means Solid returned from `hydrate(...)` (or `render(...)` on CSR) without a bootstrap failure - the root is established. It does **not** mean every resource or `<Suspense>` boundary settled. Exactly one of `onSuccess` | `onHydrationError` settles per call, each at most once.
+
+This is the same lifecycle contract `@taujs/react` and `@taujs/vue` expose; the option objects are not identical (Solid's `renderId`, React's `identifierPrefix`, Vue's `setupApp` and its `App`-instance callback argument remain framework-native), and Solid deliberately has no `dataKey` - `window.__INITIAL_DATA__` is the one snapshot authority.
+
+**Logging.** With `enableDebug: true` the start/success/CSR lifecycle is logged through `logger`; warnings and errors are logged regardless of `enableDebug`. With no `logger`, warnings and errors fall back to `console.warn` / `console.error` (verbose stays off unless `enableDebug`). The route-data snapshot is never logged.
 
 **Example:**
 
@@ -438,7 +464,7 @@ hydrateApp({
 **Behaviour:**
 
 - If `window.__INITIAL_DATA__` exists: hydrates the SSR markup with `hydrate(...)` under `renderId`, seeding the store from the payload.
-- If `window.__INITIAL_DATA__` is missing: clears any stale markup and mounts a fresh CSR app. **No hydration beacon events fire** - a CSR mount is not a hydration. A failed CSR mount is still reported to `onHydrationError`.
+- If `window.__INITIAL_DATA__` is missing: clears any stale markup and mounts a fresh CSR app. **No hydration beacon events and no `onStart` fire** - a CSR mount is not a hydration. A successful CSR mount still reports `onSuccess`; a failed one reports `onHydrationError`.
 - Automatically handles `DOMContentLoaded` timing.
 - Provides the store to your tree on both the hydrate and CSR paths.
 
@@ -446,7 +472,7 @@ hydrateApp({
 On a hydration error `hydrateApp` routes the error to `onHydrationError` and stops. It deliberately does **not** silently remount as CSR: a silent remount hides a real server/client divergence behind a page that looks fine, and destroys the server-rendered markup that would have shown the mismatch.
 </Aside>
 
-**Devtools beacon (dev-only).** On the hydrate path, `hydrateApp` emits `hydration:start`, `hydration:success` and `hydration:error` to `window.__TAUJS_DEVTOOLS_HOOK__` around the work. The hook is only ever set by the server-injected dev script, is absent in production, and emission can never throw into hydration. The CSR-fallback path emits nothing.
+**Devtools beacon (dev-only).** On the hydrate path, `hydrateApp` emits `hydration:start`, `hydration:success` and `hydration:error` to `window.__TAUJS_DEVTOOLS_HOOK__`, each **before** the matching user callback. The hook is only ever set by the server-injected dev script, is absent in production, and emission can never throw into hydration. The CSR-fallback path emits no beacons (a CSR mount is not a hydration), though it still reports `onSuccess` / `onHydrationError`.
 
 **HTML template requirements.** Your server-rendered HTML must include the root element, the initial-data script and the client bundle. With `@taujs/server` these are assembled for you; standalone you provide them yourself:
 

--- a/website/src/content/docs/renderers/vue.mdx
+++ b/website/src/content/docs/renderers/vue.mdx
@@ -519,7 +519,7 @@ hydrateApp({
 **Behaviour:**
 
 - If `window[dataKey]` exists: hydrates the SSR markup with `createSSRApp(...).mount(rootEl)`.
-- If `window[dataKey]` is missing: clears any stale markup and mounts a fresh CSR app. **No hydration callbacks or beacon events fire** - a CSR mount is not a hydration.
+- If `window[dataKey]` is missing: clears any stale markup and mounts a fresh CSR app. **No hydration beacon events and no `onStart` fire** - a CSR mount is not a hydration. A successful CSR mount still calls `onSuccess(app)` (the committed root); a failed one calls `onHydrationError`.
 - Automatically handles `DOMContentLoaded` timing.
 - Wraps your app in `SSRStoreProvider` on both the hydrate and CSR paths.
 
@@ -1027,7 +1027,7 @@ const setupApp = (app) => {
 3. **Head data: `meta` for static, `attr.head` for dynamic.** In streaming mode the data snapshot is usually pending when the head is built - guard optional `data` fields. Static values belong in `meta`; DYNAMIC head values belong in an `attr.head` loader, which the host resolves before the render and delivers as `headData` (handle `undefined` - it degrades on deadline or `optional` failure).
 4. **Share one `setupApp` across server and client.** Keep it synchronous, DOM-free and idempotent so the identical function runs on both sides; seed Pinia/state from SSR data rather than adding a serialisation channel.
 5. **Match `@vue/server-renderer` to `vue`.** Pin both to the same version.
-6. **Handle CSR fallback.** Provide `onHydrationError` so a hydration failure degrades gracefully; remember the CSR path emits no hydration callbacks by design.
+6. **Handle CSR fallback.** Provide `onHydrationError` so a hydration failure degrades gracefully; the CSR path emits no hydration beacons or `onStart`, but a successful CSR mount does call `onSuccess(app)`.
 7. **Reserve teleports for `ssr` routes.** `<Teleport>` targets outside the app root are only captured by `renderSSR`.
 8. **Client-side updates after SSR are userland.** For data that changes after the initial render, call your own `/api/*` endpoints with a client library such as TanStack Query or SWR - τjs keeps SSR request-first and does not add a client data channel.
 

--- a/website/src/content/docs/renderers/vue.mdx
+++ b/website/src/content/docs/renderers/vue.mdx
@@ -523,13 +523,15 @@ hydrateApp({
 - Automatically handles `DOMContentLoaded` timing.
 - Wraps your app in `SSRStoreProvider` on both the hydrate and CSR paths.
 
-**Error reporting (Vue-native).** Unlike React, which surfaces hydration failures as synchronous throws, Vue reports them through `app.config.errorHandler` and recoverable warnings. So `hydrateApp` installs an error handler **before** `mount()` and treats errors during the hydration phase as hydration failures, routing them to `onHydrationError`. In `enableDebug` mode it also forwards Vue hydration-mismatch warnings to the logger. A user handler installed via `setupApp` still fires alongside τjs's routing.
+**Error reporting (Vue-native).** Unlike React, which surfaces hydration failures as synchronous throws, Vue reports them through `app.config.errorHandler` and recoverable warnings. So `hydrateApp` installs an error handler **before** `mount()` and treats errors during the hydration phase as hydration failures, routing them to `onHydrationError`. In `enableDebug` mode it also forwards Vue hydration-mismatch warnings to the logger. A user handler installed via `setupApp` still fires alongside τjs's routing. Exactly one of `onSuccess` or `onHydrationError` settles per call: once a hydration has succeeded, a later Vue error is an ordinary logged error and cannot reverse that success into a failure.
+
+**Logging.** Hydration debug logging (under `enableDebug`) contains lifecycle messages only - the route-data payload and the store object are never logged, so a logger that forwards to a server sink cannot disclose request data.
 
 <Aside type="note" title="onStart / onSuccess receive the App instance">
 This is a deliberate divergence from `@taujs/react`, whose callbacks take no arguments. `setupApp`, `onStart` and `onSuccess` all receive the same `App` instance, so you can inspect or interact with the fully-configured app.
 </Aside>
 
-**Devtools beacon (dev-only).** On the hydrate path, `hydrateApp` emits `hydration:start`, `hydration:success` and `hydration:error` to `window.__TAUJS_DEVTOOLS_HOOK__` around your callbacks (internal emission first, user callback second). The hook is only ever set by the server-injected dev script, is absent in production, and emission can never throw into hydration. The CSR-fallback path emits nothing.
+**Devtools beacon (dev-only).** On the hydrate path, `hydrateApp` emits `hydration:start`, `hydration:success` and `hydration:error` to `window.__TAUJS_DEVTOOLS_HOOK__` around your callbacks (internal emission first, user callback second). The hook is only ever set by the server-injected dev script, is absent in production, and emission can never throw into hydration. The CSR-fallback path emits no hydration beacons (it still calls `onSuccess(app)` on a committed root).
 
 **HTML template requirements.** Your server-rendered HTML must include the root element, an initial data script, and the client bundle:
 


### PR DESCRIPTION
## Summary

Brings client-hydration observability to parity across the three renderers, plus the two
correctness/safety fixes the work surfaced.

- **@taujs/solid** gains the client-hydration lifecycle surface on `hydrateApp`: `logger`,
  `enableDebug`, `onStart`, `onSuccess` (alongside `onHydrationError`) - isolated observers, single
  settlement, internal-first beacons, `logger ?? console` fallback. `dataKey` deliberately not added.
- **@taujs/vue**: `hydrateApp` now reports `onSuccess(app)` after a successful CSR-fallback mount
  (React parity), and a settlement guard stops a post-`mount()` error from reversing an
  already-settled success.
- **@taujs/react + @taujs/vue**: hydration debug logging no longer includes the route-data payload
  or the store object (a Pino-shaped logger could otherwise forward request data to a server sink).

## Packages

| Package | Bump |
| --- | --- |
| @taujs/solid | minor (additive hydration API) |
| @taujs/react | patch (no payload logging) |
| @taujs/vue | patch (CSR onSuccess, settlement guard, no payload logging) |

## Testing

- Solid: happy-dom suite drives the real `hydrateApp` (only terminal `hydrate`/`render` mocked) plus
  a compile-time contract test; one unmocked Chromium callback/logging smoke.
- Vue: settlement regression (error after success, before nextTick) + tamper-verified guard;
  secret-bearing-data logging test.
- React: secret-bearing-data logging test; full hydration suite otherwise unchanged.
- happy-dom is dev-only in @taujs/solid (guarded: not in deps/peers/packed output).
- Solid 176, Vue 186, React 238; builds, typechecks, attw, website build and prettier all green.

Note: the Solid single-settlement guard is defensive future-proofing - Solid's synchronous
hydrate/render make double-settlement structurally impossible, so it is not counted as verified behaviour.
