### PR TITLE
fix(server): converge runtime logging with Fastify

### DIFF
--- a/.changeset/runtime-logger-convergence.md
+++ b/.changeset/runtime-logger-convergence.md
@@ -1,0 +1,12 @@
+---
+'@taujs/server': patch
+---
+
+Converge τjs runtime logging on the selected Fastify, explicit, or standalone
+logger, preserving request correlation, Pino policy, and CSP reporting across
+the server lifecycle.
+
+Custom structured sinks now receive the raw semantic message instead of a
+τjs-formatted timestamp and level prefix. This corrects the documented
+`BaseLogger` contract; consumers parsing the previous embedded prefix should
+use their sink's structured timestamp and level fields instead.

--- a/.changeset/runtime-logger-convergence.md
+++ b/.changeset/runtime-logger-convergence.md
@@ -10,3 +10,7 @@ Custom structured sinks now receive the raw semantic message instead of a
 τjs-formatted timestamp and level prefix. This corrects the documented
 `BaseLogger` contract; consumers parsing the previous embedded prefix should
 use their sink's structured timestamp and level fields instead.
+
+Pre-shell streaming failures now preserve the response's existing headers,
+including `x-trace-id` and Content Security Policy, on the resulting 500
+response.

--- a/packages/server/src/CreateServer.ts
+++ b/packages/server/src/CreateServer.ts
@@ -8,7 +8,7 @@ import { extractBuildConfigs, extractRoutes, extractSecurity } from './core/conf
 import { normaliseError } from './core/errors/AppError';
 
 import { CONTENT } from './constants';
-import { createLogger } from './logging/Logger';
+import { createRuntimeLogger, type RuntimeLoggerSelection } from './logging/RuntimeLogger';
 import { resolveNet } from './network/CLI';
 import { bannerPlugin } from './network/Network';
 import { verifyContracts, isAuthRequired, hasAuthenticate } from './security/VerifyMiddleware';
@@ -63,10 +63,13 @@ export const createServer = async (opts: CreateServerOptions): Promise<CreateSer
 
   const app = opts.fastify ?? Fastify({ logger: false });
   const fastifyLogger = app.log && app.log.level && app.log.level !== 'silent' ? app.log : undefined;
-  const logger = createLogger({
+  const runtimeLogger: RuntimeLoggerSelection = {
+    source: opts.logger ? 'explicit' : fastifyLogger ? 'fastify' : 'fallback',
     debug: opts.debug,
     custom: opts.logger ?? fastifyLogger,
     minLevel: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
+  };
+  const logger = createRuntimeLogger(runtimeLogger, {
     includeContext: true,
   });
 
@@ -119,6 +122,7 @@ export const createServer = async (opts: CreateServerOptions): Promise<CreateSer
       serviceRegistry: opts.serviceRegistry,
       staticAssets: opts.staticAssets ?? false,
       debug: opts.debug,
+      runtimeLogger,
       alias: opts.alias,
       projectRoot: opts.projectRoot,
       security,

--- a/packages/server/src/CreateServer.ts
+++ b/packages/server/src/CreateServer.ts
@@ -76,6 +76,7 @@ export const createServer = async (opts: CreateServerOptions): Promise<CreateSer
   const net = resolveNet(opts.config.server);
   await app.register(bannerPlugin, {
     debug: opts.debug,
+    logger,
     hmr: { host: net.host, port: net.hmrPort },
   });
 

--- a/packages/server/src/SSRServer.ts
+++ b/packages/server/src/SSRServer.ts
@@ -17,7 +17,7 @@ import { isDevelopment } from './System';
 
 import { printVitePluginSummary } from './Setup';
 import { createLogger } from './logging/Logger';
-import { createRuntimeLogger } from './logging/RuntimeLogger';
+import { createRuntimeLogger, createRuntimeRequestLogger } from './logging/RuntimeLogger';
 import { toHttp } from './logging/utils';
 import { createAuthHook } from './security/Auth';
 import { cspPlugin } from './security/CSP';
@@ -25,7 +25,7 @@ import { cspReportPlugin } from './security/CSPReporting';
 import { createMaps, loadAssets, processConfigs } from './utils/AssetManager';
 import { setupDevServer } from './utils/DevServer';
 import { resolveDevViteConfig } from './utils/ViteMergeEngine';
-import { createRequestContext } from './utils/Telemetry';
+import { createRequestContext, getRequestContext } from './utils/Telemetry';
 import { handleRender } from './utils/HandleRender';
 import { handleNotFound } from './utils/HandleNotFound';
 import { registerStaticAssets } from './utils/StaticAssets';
@@ -188,7 +188,12 @@ export const SSRServer: FastifyPluginAsync<SSRServerOptions> = fp(
     // into the logs annex and the recorder rides the context (P0B-02).
     app.decorateRequest('taujsRequestContext', null);
     app.addHook('onRequest', async (req, reply) => {
-      const requestContext = createRequestContext(req, reply, logger);
+      const requestContext = createRequestContext(
+        req,
+        reply,
+        logger,
+        opts.runtimeLogger ? (bindings) => createRuntimeRequestLogger(opts.runtimeLogger!, req, { component: 'ssr-server', ...bindings }) : undefined,
+      );
       if (introspection) {
         requestContext.logger = introspection.wrapRequestLogger(requestContext.logger, requestContext.traceId);
         requestContext.recorder = introspection.recorder;
@@ -231,11 +236,12 @@ export const SSRServer: FastifyPluginAsync<SSRServerOptions> = fp(
 
     app.setErrorHandler((err, req, reply) => {
       const e = AppError.from(err);
+      const terminalLogger = getRequestContext(req)?.logger ?? logger;
 
       const alreadyLogged = !!(e as any)?.details && (e as any).details && (e as any).details.logged;
 
       if (!alreadyLogged) {
-        logger.error(
+        terminalLogger.error(
           {
             kind: e.kind,
             httpStatus: e.httpStatus,

--- a/packages/server/src/SSRServer.ts
+++ b/packages/server/src/SSRServer.ts
@@ -17,6 +17,7 @@ import { isDevelopment } from './System';
 
 import { printVitePluginSummary } from './Setup';
 import { createLogger } from './logging/Logger';
+import { createRuntimeLogger } from './logging/RuntimeLogger';
 import { toHttp } from './logging/utils';
 import { createAuthHook } from './security/Auth';
 import { cspPlugin } from './security/CSP';
@@ -42,13 +43,19 @@ export const SSRServer: FastifyPluginAsync<SSRServerOptions> = fp(
   async (app: FastifyInstance, opts: SSRServerOptions) => {
     const { alias, configs, routes, serviceRegistry = {}, clientRoot, security } = opts;
 
-    const logger = createLogger({
-      debug: opts.debug,
-      context: { component: 'ssr-server' },
-      minLevel: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
-      includeContext: true,
-      singleLine: true,
-    });
+    const logger = opts.runtimeLogger
+      ? createRuntimeLogger(opts.runtimeLogger, {
+          context: { component: 'ssr-server' },
+          includeContext: true,
+          singleLine: true,
+        })
+      : createLogger({
+          debug: opts.debug,
+          context: { component: 'ssr-server' },
+          minLevel: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
+          includeContext: true,
+          singleLine: true,
+        });
 
     const maps = createMaps();
 

--- a/packages/server/src/SSRServer.ts
+++ b/packages/server/src/SSRServer.ts
@@ -89,6 +89,7 @@ export const SSRServer: FastifyPluginAsync<SSRServerOptions> = fp(
         path: security.csp.reporting.endpoint,
         debug: opts.debug,
         logger,
+        runtimeLogger: opts.runtimeLogger,
         onViolation: security.csp.reporting.onViolation,
       });
     }
@@ -97,6 +98,8 @@ export const SSRServer: FastifyPluginAsync<SSRServerOptions> = fp(
       directives: opts.security?.csp?.directives,
       generateCSP: opts.security?.csp?.generateCSP,
       debug: opts.debug,
+      logger,
+      runtimeLogger: opts.runtimeLogger,
     });
 
     if (isDevelopment) {
@@ -160,6 +163,7 @@ export const SSRServer: FastifyPluginAsync<SSRServerOptions> = fp(
         declarativeAlias: opts.taujsConfig?.alias,
         projectRoot: opts.projectRoot,
         debug: opts.debug,
+        logger,
         devNet: opts.devNet,
         viteConfig: devViteConfig,
       });

--- a/packages/server/src/logging/Adapters.ts
+++ b/packages/server/src/logging/Adapters.ts
@@ -14,13 +14,21 @@ export interface MessageMetaLogger {
 }
 
 export function messageMetaAdapter<L extends MessageMetaLogger>(sink: L): BaseLogger {
-  return {
+  const adapted: BaseLogger = {
     debug: (meta, message) => sink.debug?.(message, cleanMeta(meta)),
     info: (meta, message) => sink.info?.(message, cleanMeta(meta)),
     warn: (meta, message) => sink.warn?.(message, cleanMeta(meta)),
     error: (meta, message) => sink.error?.(message, cleanMeta(meta)),
-    child: (ctx) => messageMetaAdapter(sink.child?.(ctx) ?? sink),
   };
+
+  if (sink.child) {
+    adapted.child = (ctx) => {
+      const child = sink.child?.(ctx);
+      return child ? messageMetaAdapter(child) : (undefined as never);
+    };
+  }
+
+  return adapted;
 }
 
 export function winstonAdapter(winston: MessageMetaLogger): BaseLogger {

--- a/packages/server/src/logging/Logger.ts
+++ b/packages/server/src/logging/Logger.ts
@@ -24,8 +24,13 @@ export class Logger implements Logs {
   }
 
   child(context: Record<string, unknown>): Logger {
-    const customChild = this.config.custom?.child?.(context) ?? this.config.custom;
-    const child = new Logger({ ...this.config, custom: customChild, context: { ...this.context, ...context } });
+    const mergedContext = { ...this.context, ...context };
+    const customChild = this.config.custom?.child?.(mergedContext);
+    const child = new Logger({
+      ...this.config,
+      custom: customChild ?? this.config.custom,
+      context: customChild ? {} : mergedContext,
+    });
     child.debugEnabled = new Set(this.debugEnabled);
     return child;
   }
@@ -129,8 +134,9 @@ export class Logger implements Logs {
     }
 
     const withCtx = wantCtx && Object.keys(this.context).length > 0 ? { context: this.context, ...baseMeta } : baseMeta;
+    const withCategory = category ? { ...withCtx, category } : withCtx;
 
-    const finalMeta = this.shouldIncludeStack(level) ? withCtx : this.stripStacks(withCtx);
+    const finalMeta = this.shouldIncludeStack(level) ? withCategory : this.stripStacks(withCategory);
     const hasMeta = finalMeta && typeof finalMeta === 'object' ? Object.keys(finalMeta as any).length > 0 : false;
 
     const levelText = level.toLowerCase() + (category ? `:${category.toLowerCase()}` : '');
@@ -150,8 +156,7 @@ export class Logger implements Logs {
       }
     })();
 
-    const tagForOutput = hasCustom ? plainTag : coloredTag;
-    const formatted = `${timestamp} ${tagForOutput} ${message}`;
+    const formatted = `${timestamp} ${coloredTag} ${message}`;
 
     if (this.config.singleLine && hasMeta && !hasCustom) {
       const metaStr = JSON.stringify(finalMeta).replace(/\n/g, '\\n');
@@ -162,7 +167,7 @@ export class Logger implements Logs {
     if (hasCustom) {
       const obj = hasMeta ? (finalMeta as Record<string, unknown>) : {};
       try {
-        boundSink!(obj, formatted);
+        boundSink!(obj, message);
       } catch {
         hasMeta ? consoleFallback(formatted, finalMeta) : consoleFallback(formatted);
       }

--- a/packages/server/src/logging/RuntimeLogger.ts
+++ b/packages/server/src/logging/RuntimeLogger.ts
@@ -1,5 +1,6 @@
 import { createLogger, type Logger } from './Logger';
 
+import type { FastifyRequest } from 'fastify';
 import type { BaseLogger, DebugConfig, LogLevel } from '../core/logging/types';
 
 export type RuntimeLoggerSource = 'explicit' | 'fastify' | 'fallback';
@@ -37,4 +38,20 @@ export const createRuntimeLogger = (selection: RuntimeLoggerSelection, options: 
     includeContext: options.includeContext,
     singleLine: options.singleLine,
   });
+};
+
+/** Derive a request logger from Fastify's req.log only when Fastify owns the selected sink. */
+export const createRuntimeRequestLogger = (selection: RuntimeLoggerSelection, req: FastifyRequest, context: Record<string, unknown>): Logger => {
+  const { reqId: _reqId, ...fastifyContext } = context;
+  const custom = selection.source === 'fastify' ? req.log : selection.custom;
+  const requestContext = selection.source === 'fastify' ? fastifyContext : { ...context, reqId: req.id };
+
+  return createRuntimeLogger(
+    { ...selection, custom },
+    {
+      context: requestContext,
+      includeContext: true,
+      singleLine: true,
+    },
+  );
 };

--- a/packages/server/src/logging/RuntimeLogger.ts
+++ b/packages/server/src/logging/RuntimeLogger.ts
@@ -1,0 +1,40 @@
+import { createLogger, type Logger } from './Logger';
+
+import type { BaseLogger, DebugConfig, LogLevel } from '../core/logging/types';
+
+export type RuntimeLoggerSource = 'explicit' | 'fastify' | 'fallback';
+
+export type RuntimeLoggerSelection = Readonly<{
+  source: RuntimeLoggerSource;
+  custom?: BaseLogger;
+  debug?: DebugConfig;
+  minLevel: LogLevel;
+}>;
+
+type RuntimeLoggerOptions = {
+  context?: Record<string, unknown>;
+  includeStack?: boolean | ((level: LogLevel) => boolean);
+  includeContext?: boolean | ((level: LogLevel) => boolean);
+  singleLine?: boolean;
+};
+
+/**
+ * Create one τjs logger node from the runtime-selected sink.
+ *
+ * A custom child owns its bindings. When no child seam exists, the τjs wrapper
+ * retains the context so plain BaseLogger implementations receive equivalent
+ * structured metadata.
+ */
+export const createRuntimeLogger = (selection: RuntimeLoggerSelection, options: RuntimeLoggerOptions = {}): Logger => {
+  const customChild = options.context ? selection.custom?.child?.(options.context) : undefined;
+
+  return createLogger({
+    debug: selection.debug,
+    custom: customChild ?? selection.custom,
+    context: customChild ? undefined : options.context,
+    minLevel: selection.minLevel,
+    includeStack: options.includeStack,
+    includeContext: options.includeContext,
+    singleLine: options.singleLine,
+  });
+};

--- a/packages/server/src/logging/test/Adapters.test.ts
+++ b/packages/server/src/logging/test/Adapters.test.ts
@@ -82,12 +82,12 @@ describe('messageMetaAdapter', () => {
     expect(calls).toHaveLength(0);
   });
 
-  it('when sink has no child(), child() returns an adapter wrapping the same sink', () => {
+  it('does not claim child-binding ownership when the sink has no child seam', () => {
     const { sink, calls } = makeSink();
     const log = messageMetaAdapter(sink);
 
-    const child = log.child?.({ foo: 'bar' }) as BaseLogger;
-    child.error?.({ oops: true }, 'boom');
+    expect(log.child).toBeUndefined();
+    log.error?.({ oops: true }, 'boom');
 
     expect(calls).toEqual([{ method: 'error', message: 'boom', meta: { oops: true } }]);
   });

--- a/packages/server/src/logging/test/Logger.test.ts
+++ b/packages/server/src/logging/test/Logger.test.ts
@@ -225,6 +225,48 @@ describe('Logger', () => {
     expect(console.error).toHaveBeenCalledTimes(1);
   });
 
+  it('passes semantic messages and structured debug categories to custom sinks', () => {
+    const custom = { info: vi.fn(), debug: vi.fn() };
+    const logger = createLogger({ custom, minLevel: 'debug' });
+    logger.configure(['ssr']);
+
+    logger.info({ route: '/products' }, 'Rendered response');
+    logger.debug('ssr', { strategy: 'streaming' }, 'Shell ready');
+
+    expect(custom.info).toHaveBeenCalledWith({ route: '/products' }, 'Rendered response');
+    expect(custom.debug).toHaveBeenCalledWith({ strategy: 'streaming', category: 'ssr' }, 'Shell ready');
+    expect(custom.info.mock.calls[0]?.[1]).not.toMatch(/\[info\]/);
+    expect(custom.debug.mock.calls[0]?.[1]).not.toMatch(/\[debug:ssr\]/);
+  });
+
+  it('lets a custom child own bindings once instead of echoing them in context', () => {
+    const childInfo = vi.fn();
+    const customChild = vi.fn(() => ({ info: childInfo }));
+    const logger = createLogger({
+      custom: { child: customChild },
+      context: { component: 'ssr-server' },
+      includeContext: true,
+    });
+
+    logger.child({ traceId: 'trace-1' }).info({ route: '/products' }, 'Rendered response');
+
+    expect(customChild).toHaveBeenCalledWith({ component: 'ssr-server', traceId: 'trace-1' });
+    expect(childInfo).toHaveBeenCalledWith({ route: '/products' }, 'Rendered response');
+  });
+
+  it('retains wrapper context when a custom sink has no child seam', () => {
+    const info = vi.fn();
+    const logger = createLogger({
+      custom: { info },
+      context: { component: 'ssr-server' },
+      includeContext: true,
+    });
+
+    logger.child({ traceId: 'trace-2' }).info({ route: '/account' }, 'Rendered response');
+
+    expect(info).toHaveBeenCalledWith({ context: { component: 'ssr-server', traceId: 'trace-2' }, route: '/account' }, 'Rendered response');
+  });
+
   it('hasMeta toggles: meta omitted vs provided', () => {
     const logger = createLogger();
 
@@ -406,12 +448,12 @@ describe('Logger', () => {
     const custom = { error: vi.fn() };
     const logger = createLogger({ custom: custom as any, includeContext: false });
 
-    logger.error(); // -> custom.error({}, "<ts> [error] ")
+    logger.error();
 
     expect(custom.error).toHaveBeenCalledTimes(1);
     const args = (custom.error as any).mock.calls[0];
     expect(args[0]).toEqual({});
-    expect(args[1]).toMatch(/\[error\] $/);
+    expect(args[1]).toBe('');
   });
 
   it('defaults message to empty string for debug(category) when omitted (with meta)', () => {
@@ -423,7 +465,7 @@ describe('Logger', () => {
     expect(console.log).toHaveBeenCalledTimes(1);
     const call = (console.log as any).mock.calls[0];
     expect(call[0]).toMatch(/\[debug:routes\] $/);
-    expect(call[1]).toEqual({ d: 1 });
+    expect(call[1]).toEqual({ d: 1, category: 'routes' });
   });
 
   it('defaults message to empty string for debug(category) when both meta and message omitted', () => {
@@ -434,7 +476,8 @@ describe('Logger', () => {
 
     expect(console.log).toHaveBeenCalledTimes(1);
     const call = (console.log as any).mock.calls[0];
-    expect(call.length).toBe(1);
+    expect(call.length).toBe(2);
     expect(call[0]).toMatch(/\[debug:routes\] $/);
+    expect(call[1]).toEqual({ category: 'routes' });
   });
 });

--- a/packages/server/src/logging/test/RuntimeLogger.test.ts
+++ b/packages/server/src/logging/test/RuntimeLogger.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest';
+
+import { createRuntimeLogger, type RuntimeLoggerSelection } from '../RuntimeLogger';
+
+const selection = (custom?: RuntimeLoggerSelection['custom']): RuntimeLoggerSelection => ({
+  source: custom ? 'fastify' : 'fallback',
+  custom,
+  debug: ['ssr'],
+  minLevel: 'debug',
+});
+
+describe('createRuntimeLogger', () => {
+  it('binds component context through a child-capable sink exactly once', () => {
+    const info = vi.fn();
+    const child = vi.fn(() => ({ info }));
+
+    const logger = createRuntimeLogger(selection({ child }), {
+      context: { component: 'ssr-server' },
+      includeContext: true,
+      singleLine: true,
+    });
+
+    logger.info({ route: '/' }, 'ready');
+
+    expect(child).toHaveBeenCalledWith({ component: 'ssr-server' });
+    expect(info).toHaveBeenCalledWith({ route: '/' }, 'ready');
+  });
+
+  it('keeps structured context for a plain sink without child()', () => {
+    const info = vi.fn();
+    const logger = createRuntimeLogger(selection({ info }), {
+      context: { component: 'ssr-server' },
+      includeContext: true,
+    });
+
+    logger.info({ route: '/' }, 'ready');
+
+    expect(info).toHaveBeenCalledWith({ context: { component: 'ssr-server' }, route: '/' }, 'ready');
+  });
+
+  it('preserves debug category metadata through the selected sink', () => {
+    const debug = vi.fn();
+    const logger = createRuntimeLogger(selection({ debug }));
+
+    logger.debug('ssr', { route: '/' }, 'shell');
+
+    expect(debug).toHaveBeenCalledWith({ route: '/', category: 'ssr' }, 'shell');
+  });
+});

--- a/packages/server/src/logging/test/RuntimeLogger.test.ts
+++ b/packages/server/src/logging/test/RuntimeLogger.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from 'vitest';
 
-import { createRuntimeLogger, type RuntimeLoggerSelection } from '../RuntimeLogger';
+import { createRuntimeLogger, createRuntimeRequestLogger, type RuntimeLoggerSelection } from '../RuntimeLogger';
 
 const selection = (custom?: RuntimeLoggerSelection['custom']): RuntimeLoggerSelection => ({
   source: custom ? 'fastify' : 'fallback',
@@ -37,6 +37,62 @@ describe('createRuntimeLogger', () => {
     logger.info({ route: '/' }, 'ready');
 
     expect(info).toHaveBeenCalledWith({ context: { component: 'ssr-server' }, route: '/' }, 'ready');
+  });
+
+  it('derives Fastify-owned requests from req.log without rebinding reqId', () => {
+    const info = vi.fn();
+    const requestChild = vi.fn(() => ({ info }));
+    const appChild = vi.fn();
+    const selected: RuntimeLoggerSelection = {
+      source: 'fastify',
+      custom: { child: appChild },
+      minLevel: 'debug',
+    };
+    const req = { id: 'req-1', log: { child: requestChild } } as any;
+
+    const logger = createRuntimeRequestLogger(selected, req, {
+      component: 'ssr-server',
+      traceId: 'trace-1',
+      reqId: 'req-1',
+      url: '/products',
+      method: 'GET',
+    });
+    logger.info({ route: '/products' }, 'rendered');
+
+    expect(appChild).not.toHaveBeenCalled();
+    expect(requestChild).toHaveBeenCalledWith({ component: 'ssr-server', traceId: 'trace-1', url: '/products', method: 'GET' });
+    expect(info).toHaveBeenCalledWith({ route: '/products' }, 'rendered');
+  });
+
+  it('keeps explicit request lineage on the explicit sink and binds reqId', () => {
+    const info = vi.fn();
+    const explicitChild = vi.fn(() => ({ info }));
+    const selected: RuntimeLoggerSelection = {
+      source: 'explicit',
+      custom: { child: explicitChild },
+      minLevel: 'debug',
+    };
+    const requestChild = vi.fn();
+    const req = { id: 'req-2', log: { child: requestChild } } as any;
+
+    const logger = createRuntimeRequestLogger(selected, req, {
+      component: 'ssr-server',
+      traceId: 'trace-2',
+      reqId: 'wrong-value-is-replaced',
+      url: '/account',
+      method: 'POST',
+    });
+    logger.info({}, 'rendered');
+
+    expect(requestChild).not.toHaveBeenCalled();
+    expect(explicitChild).toHaveBeenCalledWith({
+      component: 'ssr-server',
+      traceId: 'trace-2',
+      reqId: 'req-2',
+      url: '/account',
+      method: 'POST',
+    });
+    expect(info).toHaveBeenCalledWith({}, 'rendered');
   });
 
   it('preserves debug category metadata through the selected sink', () => {

--- a/packages/server/src/network/Network.ts
+++ b/packages/server/src/network/Network.ts
@@ -5,11 +5,13 @@ import { CONTENT } from '../constants';
 import { createLogger } from '../logging/Logger';
 
 import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
-import type { DebugConfig } from '../core/logging/types';
+import type { DebugConfig, Logs } from '../core/logging/types';
 
 type BannerPluginOpts = {
   debug?: DebugConfig;
   hmr?: { host: string; port: number };
+  /** Internal runtime logger; presentation output remains on console. */
+  logger?: Logs;
 };
 
 // RFC1918 ranges
@@ -25,7 +27,7 @@ const isPrivateIPv4 = (addr: string): boolean => {
 };
 
 export const bannerPlugin: FastifyPluginAsync<BannerPluginOpts> = async (fastify, options) => {
-  const logger = createLogger({ debug: options.debug });
+  const logger = options.logger ?? createLogger({ debug: options.debug });
   const dbgNetwork = logger.isDebugEnabled('network');
 
   fastify.decorate('showBanner', function showBanner(this: FastifyInstance) {

--- a/packages/server/src/network/test/Network.test.ts
+++ b/packages/server/src/network/test/Network.test.ts
@@ -117,6 +117,24 @@ describe('bannerPlugin', () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
+  it('uses a supplied runtime logger for operational records while keeping presentation on console', async () => {
+    const supplied = {
+      isDebugEnabled: vi.fn(() => true),
+      info: vi.fn(),
+      warn: vi.fn(),
+    };
+    netsMock.mockReturnValue({ en0: [{ address: '192.168.1.44', family: 'IPv4', internal: false }] });
+    const f = makeFastify({ address: () => ({ address: '0.0.0.0', port: 3000 }), listening: true });
+
+    await bannerPlugin(f as any, { debug: true, logger: supplied as any });
+    f.showBanner();
+
+    expect(createLoggerMock).not.toHaveBeenCalled();
+    expect(supplied.warn).toHaveBeenCalledTimes(1);
+    expect(supplied.info).toHaveBeenCalledTimes(1);
+    expect(console.log).toHaveBeenCalledWith('┃ Local    http://localhost:3000/');
+  });
+
   it('non-local host (0.0.0.0) with PRIVATE IPv4 found -> prints Network URL, warn if dbg on, info bound host', async () => {
     const { info, warn } = makeLogger({ dbgNetwork: true });
 

--- a/packages/server/src/security/Auth.ts
+++ b/packages/server/src/security/Auth.ts
@@ -1,10 +1,12 @@
 import { selectedRouteFrom } from '../core/routes/FastifyRoutes';
+import { getRequestContext } from '../utils/Telemetry';
 
 import type { FastifyRequest, FastifyReply, onRequestHookHandler } from 'fastify';
-import type { Logger } from '../logging/Logger';
+import type { Logs } from '../core/logging/types';
 
-export const createAuthHook = (logger: Logger): onRequestHookHandler => {
+export const createAuthHook = (logger: Logs): onRequestHookHandler => {
   return async function authHook(req: FastifyRequest, reply: FastifyReply) {
+    const requestLogger = getRequestContext(req)?.logger ?? logger;
     const selected = selectedRouteFrom(req);
     if (!selected) return;
 
@@ -30,12 +32,12 @@ export const createAuthHook = (logger: Logger): onRequestHookHandler => {
     };
 
     if (!authConfig) {
-      logger.debug('auth', { method: req.method, url: req.url }, '(none)');
+      requestLogger.debug('auth', { method: req.method, url: req.url }, '(none)');
       return;
     }
 
     if (typeof req.server.authenticate !== 'function') {
-      logger.warn(
+      requestLogger.warn(
         {
           path: url,
           appId: route.appId,
@@ -46,20 +48,20 @@ export const createAuthHook = (logger: Logger): onRequestHookHandler => {
     }
 
     try {
-      logger.debug('auth', { method: req.method, url: req.url }, 'Invoking authenticate(...)');
+      requestLogger.debug('auth', { method: req.method, url: req.url }, 'Invoking authenticate(...)');
 
       await req.server.authenticate(req, reply);
 
       // The documented handshake allows the decorator to reject without
       // throwing (reply.code(401).send(); return;) - that is not a success.
       if (reply.sent) {
-        logger.debug('auth', { method: req.method, url: req.url }, 'Authentication handled by decorator (reply already sent)');
+        requestLogger.debug('auth', { method: req.method, url: req.url }, 'Authentication handled by decorator (reply already sent)');
         return;
       }
 
-      logger.debug('auth', { method: req.method, url: req.url }, 'Authentication successful');
+      requestLogger.debug('auth', { method: req.method, url: req.url }, 'Authentication successful');
     } catch (err) {
-      logger.debug('auth', { method: req.method, url: req.url }, 'Authentication failed');
+      requestLogger.debug('auth', { method: req.method, url: req.url }, 'Authentication failed');
 
       return reply.send(err);
     }

--- a/packages/server/src/security/CSP.ts
+++ b/packages/server/src/security/CSP.ts
@@ -5,15 +5,21 @@ import { selectedRouteFrom } from '../core/routes/FastifyRoutes';
 import { isDevelopment } from '../System';
 import { DEV_CSP_DIRECTIVES } from '../constants';
 import { createLogger } from '../logging/Logger';
+import { createRuntimeLogger, createRuntimeRequestLogger } from '../logging/RuntimeLogger';
 
 import type { FastifyPluginAsync, FastifyRequest } from 'fastify';
 import type { RouteCSPConfig } from '../core/config/types';
-import type { DebugConfig } from '../core/logging/types';
+import type { DebugConfig, Logs } from '../core/logging/types';
+import type { RuntimeLoggerSelection } from '../logging/RuntimeLogger';
 
 export type CSPPluginOptions = {
   directives?: CSPDirectives;
   generateCSP?: (directives: CSPDirectives, nonce: string, req?: FastifyRequest) => string;
   debug?: DebugConfig;
+  /** Internal runtime logger state threaded by SSRServer. */
+  runtimeLogger?: RuntimeLoggerSelection;
+  /** Direct-registration fallback; normal createServer calls also provide runtimeLogger. */
+  logger?: Logs;
   reporting?: {
     reportOnly?: boolean;
   };
@@ -72,12 +78,19 @@ export const cspPlugin: FastifyPluginAsync<CSPPluginOptions> = fp(
     // ws:/http:/unsafe-inline would only look like protection).
     const globalDirectives = opts.directives || (isDevelopment ? DEV_CSP_DIRECTIVES : undefined);
 
-    const logger = createLogger({
-      debug,
-      context: { component: 'csp-plugin' },
-    });
+    const logger = opts.runtimeLogger
+      ? createRuntimeLogger(opts.runtimeLogger, { context: { component: 'csp-plugin' }, includeContext: true })
+      : (opts.logger ?? createLogger({ debug, context: { component: 'csp-plugin' } }));
 
     fastify.addHook('onRequest', (req, reply, done) => {
+      const requestLogger = opts.runtimeLogger
+        ? createRuntimeRequestLogger(opts.runtimeLogger, req, {
+            component: 'csp-plugin',
+            reqId: req.id,
+            url: req.url,
+            method: req.method,
+          })
+        : logger;
       const nonce = generateNonce();
       req.cspNonce = nonce;
 
@@ -126,7 +139,7 @@ export const cspPlugin: FastifyPluginAsync<CSPPluginOptions> = fp(
 
         reply.header(headerNameFor(routeCSP), cspHeader);
       } catch (error) {
-        logger.error(
+        requestLogger.error(
           {
             url: req.url,
             error: error instanceof Error ? { name: error.name, message: error.message, stack: error.stack } : String(error),

--- a/packages/server/src/security/CSPReporting.ts
+++ b/packages/server/src/security/CSPReporting.ts
@@ -2,9 +2,12 @@ import type { FastifyPluginAsync, FastifyRequest, FastifyReply, FastifyInstance 
 import fp from 'fastify-plugin';
 
 import { AppError } from '../core/errors/AppError';
-import { createLogger, Logger } from '../logging/Logger';
+import { createLogger } from '../logging/Logger';
+import { createRuntimeRequestLogger } from '../logging/RuntimeLogger';
+import { getRequestContext } from '../utils/Telemetry';
 
 import type { DebugConfig, Logs } from '../core/logging/types';
+import type { RuntimeLoggerSelection } from '../logging/RuntimeLogger';
 
 export type CSPViolationReport = {
   'document-uri': string;
@@ -42,6 +45,8 @@ export type CSPReportOptions = {
    * Optional logger instance to use. Defaults to a new Logger instance.
    */
   logger?: Logs;
+  /** Internal runtime logger state used to derive a request parent when no hoisted context exists. */
+  runtimeLogger?: RuntimeLoggerSelection;
   /**
    * Optional callback invoked when a valid report is received. Gives you the parsed
    * report plus the Fastify request object for additional context/actions.
@@ -144,7 +149,7 @@ export const processCSPReport = (body: unknown, context: CSPViolationContext, lo
   }
 };
 
-export const createCSPReportProcessor = (logger: Logger): CSPReportProcessor => {
+export const createCSPReportProcessor = (logger: Logs): CSPReportProcessor => {
   return {
     processReport: (body: unknown, context: CSPViolationContext) => {
       processCSPReport(body, context, logger);
@@ -162,13 +167,25 @@ export const cspReportPlugin: FastifyPluginAsync<CSPReportOptions> = fp(
 
     if (!opts.path || typeof opts.path !== 'string') throw AppError.badRequest('CSP report path is required and must be a string');
 
-    const logger = createLogger({
-      debug: opts.debug,
-      context: { service: 'csp-reporting' },
-      minLevel: 'info',
-    });
+    const logger =
+      opts.logger ??
+      createLogger({
+        debug: opts.debug,
+        context: { service: 'csp-reporting' },
+        minLevel: 'info',
+      });
 
     fastify.post(opts.path, async (req: FastifyRequest, reply: FastifyReply) => {
+      const requestLogger =
+        getRequestContext(req)?.logger ??
+        (opts.runtimeLogger
+          ? createRuntimeRequestLogger(opts.runtimeLogger, req, {
+              component: 'csp-reporting',
+              reqId: req.id,
+              url: req.url,
+              method: req.method,
+            })
+          : logger);
       const context: CSPViolationContext & { __fastifyRequest?: FastifyRequest } = {
         userAgent: req.headers['user-agent'] as string,
         ip: req.ip,
@@ -179,7 +196,7 @@ export const cspReportPlugin: FastifyPluginAsync<CSPReportOptions> = fp(
       };
 
       try {
-        processCSPReport(req.body, context, logger);
+        processCSPReport(req.body, context, requestLogger);
 
         const reportData = (req.body as any)?.['csp-report'] || req.body;
         if (onViolation && reportData && typeof reportData === 'object') {
@@ -203,7 +220,7 @@ export const cspReportPlugin: FastifyPluginAsync<CSPReportOptions> = fp(
           }
         }
       } catch (err) {
-        logger.warn(
+        requestLogger.warn(
           {
             error: err instanceof Error ? err.message : String(err),
           },

--- a/packages/server/src/security/test/Auth.test.ts
+++ b/packages/server/src/security/test/Auth.test.ts
@@ -78,6 +78,19 @@ describe('createAuthHook', () => {
     expect(reply.send).not.toHaveBeenCalled();
   });
 
+  it('uses the hoisted request logger rather than the plugin-scope logger', async () => {
+    const route = { appId: 'app-request', attr: { render: 'ssr', middleware: {} } } as Route;
+    const requestLogger = { debug: vi.fn(), warn: vi.fn(), info: vi.fn(), error: vi.fn(), child: vi.fn(), isDebugEnabled: vi.fn() };
+    const hook = createAuthHook(logger as any);
+    const { req, reply, done } = makeReqReply({ route, url: '/request-logger' });
+    req.taujsRequestContext = { traceId: 'trace-request', logger: requestLogger };
+
+    await (hook as any).call({} as any, req, reply, done);
+
+    expect(requestLogger.debug).toHaveBeenCalledWith('auth', { method: 'GET', url: '/request-logger' }, '(none)');
+    expect(logger.debug).not.toHaveBeenCalled();
+  });
+
   it('warns and replies 500 when auth required but server.authenticate is missing', async () => {
     const route = { path: '/secure', appId: 'appB', attr: { render: 'ssr', middleware: { auth: { required: true } } } } as Route;
 

--- a/packages/server/src/security/test/CSP.test.ts
+++ b/packages/server/src/security/test/CSP.test.ts
@@ -473,6 +473,22 @@ describe('cspPlugin', () => {
     expect(reply.header).toHaveBeenCalledWith('Content-Security-Policy', 'ROUTE-OVERRIDE-CSP');
   });
 
+  it('honours a supplied logger instead of constructing a competing plugin logger', async () => {
+    const { cspPlugin } = await importer(true);
+    const fastify = makeFastify();
+    const suppliedError = vi.fn();
+    selectedRouteMock.mockImplementation(() => {
+      throw new Error('supplied logger path');
+    });
+
+    await cspPlugin(fastify as any, { logger: { error: suppliedError } as any });
+    const { req, reply, done } = makeReqReply('/supplied-logger');
+    await fastify._hooks.onRequest(req, reply, done);
+
+    expect(createLoggerMock).not.toHaveBeenCalled();
+    expect(suppliedError).toHaveBeenCalledWith(expect.objectContaining({ url: '/supplied-logger' }), 'CSP plugin error');
+  });
+
   it('logs and applies fallback header when an error occurs in processing', async () => {
     const { cspPlugin } = await importer(true);
     const fastify = makeFastify();

--- a/packages/server/src/security/test/CSPReporting.test.ts
+++ b/packages/server/src/security/test/CSPReporting.test.ts
@@ -364,6 +364,31 @@ describe('cspReportPlugin', () => {
     expect(reply.send).toHaveBeenCalled();
   });
 
+  it('honours the supplied logger and prefers a hoisted request logger', async () => {
+    const { cspReportPlugin } = await importer();
+    const fastify = makeFastify();
+    const suppliedWarn = vi.fn();
+    const requestWarn = vi.fn();
+
+    await cspReportPlugin(fastify as any, { path: '/csp-report', logger: { warn: suppliedWarn } as any });
+    const handler = fastify._routes['/csp-report'];
+    const { req, reply } = makeReqReply(
+      { 'csp-report': { 'document-uri': 'https://example.test', 'violated-directive': 'script-src' } },
+      {
+        url: '/csp-report',
+        method: 'POST',
+        id: 'req-csp-1',
+        taujsRequestContext: { traceId: 'trace-csp-1', logger: { warn: requestWarn } },
+      },
+    );
+
+    await handler(req, reply);
+
+    expect(createLoggerMock).not.toHaveBeenCalled();
+    expect(requestWarn).toHaveBeenCalledWith(expect.objectContaining({ violation: expect.any(Object) }), 'CSP Violation');
+    expect(suppliedWarn).not.toHaveBeenCalled();
+  });
+
   it('does not call onViolation when body missing required fields', async () => {
     const { cspReportPlugin } = await importer();
     const fastify = makeFastify();

--- a/packages/server/src/test/CreateServer.test.ts
+++ b/packages/server/src/test/CreateServer.test.ts
@@ -315,6 +315,41 @@ describe('createServer', () => {
     );
   });
 
+  it('resolves runtime logger precedence as explicit > active Fastify logger > fallback', async () => {
+    const { createServer } = await importer();
+    const activeFastifyLogger = { level: 'info', info: vi.fn(), child: vi.fn() };
+    const explicitLogger = { info: vi.fn() };
+    const activeApp = { register: vi.fn(async () => undefined), log: activeFastifyLogger } as any;
+
+    await createServer({
+      config: minimalConfig,
+      serviceRegistry: dummyRegistry,
+      fastify: activeApp,
+      logger: explicitLogger,
+    });
+    let runtimeLogger = activeApp.register.mock.calls[1]?.[1]?.runtimeLogger;
+    expect(runtimeLogger).toEqual(expect.objectContaining({ source: 'explicit', custom: explicitLogger }));
+
+    activeApp.register.mockClear();
+    await createServer({ config: minimalConfig, serviceRegistry: dummyRegistry, fastify: activeApp });
+    runtimeLogger = activeApp.register.mock.calls[1]?.[1]?.runtimeLogger;
+    expect(runtimeLogger).toEqual(expect.objectContaining({ source: 'fastify', custom: activeFastifyLogger }));
+
+    const silentApp = { register: vi.fn(async () => undefined), log: { ...activeFastifyLogger, level: 'silent' } } as any;
+    await createServer({ config: minimalConfig, serviceRegistry: dummyRegistry, fastify: silentApp });
+    runtimeLogger = silentApp.register.mock.calls[1]?.[1]?.runtimeLogger;
+    expect(runtimeLogger).toEqual(expect.objectContaining({ source: 'fallback', custom: undefined }));
+  });
+
+  it('treats an empty Fastify logger level as inactive', async () => {
+    const { createServer } = await importer();
+    const app = { register: vi.fn(async () => undefined), log: { level: '', info: vi.fn() } } as any;
+
+    await createServer({ config: minimalConfig, serviceRegistry: dummyRegistry, fastify: app });
+
+    expect(app.register.mock.calls[1]?.[1]?.runtimeLogger).toEqual(expect.objectContaining({ source: 'fallback', custom: undefined }));
+  });
+
   it('when a Fastify instance is provided, returns only { net } (no app) and still registers plugins', async () => {
     const { createServer } = await importer();
 

--- a/packages/server/src/test/CreateServer.test.ts
+++ b/packages/server/src/test/CreateServer.test.ts
@@ -417,7 +417,7 @@ describe('createServer', () => {
       }),
     );
 
-    expect(registerMock).toHaveBeenNthCalledWith(1, bannerPluginMock, expect.objectContaining({ debug: debugConfig }));
+    expect(registerMock).toHaveBeenNthCalledWith(1, bannerPluginMock, expect.objectContaining({ debug: debugConfig, logger: fakeLogger }));
   });
 
   it('exercises contract required/verify lambdas (auth & csp)', async () => {

--- a/packages/server/src/test/RuntimeLoggerFallthrough.test.ts
+++ b/packages/server/src/test/RuntimeLoggerFallthrough.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment node
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const RESULT_PREFIX = 'TAUJS_FALLTHROUGH_LOGGER_RESULT=';
+
+describe('runtime logger fallthrough (real development server)', () => {
+  it('sends a successful unmatched-page record through the selected request logger', () => {
+    const fixtureRoot = fileURLToPath(new URL('../../../../fixtures/playground-react/', import.meta.url));
+    const childScript = fileURLToPath(new URL('./support/RuntimeLoggerFallthrough.child.ts', import.meta.url));
+    const result = spawnSync(process.execPath, ['--import', 'tsx', childScript], {
+      cwd: fixtureRoot,
+      env: { ...process.env, NODE_ENV: 'development' },
+      encoding: 'utf8',
+      timeout: 30_000,
+    });
+
+    expect(
+      {
+        status: result.status,
+        signal: result.signal,
+        error: result.error?.message,
+        stdout: result.stdout,
+        stderr: result.stderr,
+      },
+      'the real createServer() development child must complete cleanly',
+    ).toMatchObject({ status: 0, signal: null, error: undefined });
+
+    const line = result.stdout.split('\n').find((candidate) => candidate.startsWith(RESULT_PREFIX));
+    expect(line, 'the child must emit its structured result').toBeTruthy();
+
+    const evidence = JSON.parse(line!.slice(RESULT_PREFIX.length));
+    expect(evidence).toMatchObject({
+      status: 200,
+      responseTraceId: 'fallthrough-selected-logger-trace',
+      recordCount: 1,
+      record: {
+        level: 'debug',
+        bindings: {
+          traceId: 'fallthrough-selected-logger-trace',
+          reqId: 'fallthrough-fastify-request',
+          url: '/unmatched-page',
+          method: 'GET',
+        },
+        meta: { status: 200, category: 'ssr' },
+        message: 'Sending not-found fallback HTML',
+      },
+    });
+  });
+});

--- a/packages/server/src/test/SSRServer.test.ts
+++ b/packages/server/src/test/SSRServer.test.ts
@@ -502,6 +502,37 @@ describe('SSRServer', () => {
     expect(res.json()).toEqual({ message: 'safe' });
   });
 
+  it('error handler: logs through the hoisted request logger', async () => {
+    const setErrorHandlerSpy = vi.spyOn(app, 'setErrorHandler');
+    await app.register(SSRServer, {
+      alias: {},
+      configs: [],
+      routes: [],
+      serviceRegistry: {},
+      clientRoot: '/client',
+    });
+
+    const errorHandlerFn = setErrorHandlerSpy.mock.calls[0]?.[0] as any;
+    const requestLogger = { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn(), child: vi.fn(), isDebugEnabled: vi.fn() };
+    const mockReq = {
+      method: 'GET',
+      url: '/terminal',
+      routeOptions: { url: '/terminal' },
+      taujsRequestContext: { traceId: 'trace-terminal', logger: requestLogger },
+    };
+    const mockReply = {
+      raw: { headersSent: false, end: vi.fn() },
+      status: vi.fn().mockReturnThis(),
+      send: vi.fn().mockReturnThis(),
+    };
+    mockLogger.error.mockClear();
+
+    errorHandlerFn(new Error('terminal failure'), mockReq, mockReply);
+
+    expect(requestLogger.error).toHaveBeenCalledWith(expect.objectContaining({ method: 'GET', url: '/terminal' }), 'terminal failure');
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
   it('error handler: ends raw stream if headers already sent', async () => {
     let errorHandlerFn: any;
 

--- a/packages/server/src/test/SSRServer.test.ts
+++ b/packages/server/src/test/SSRServer.test.ts
@@ -207,6 +207,7 @@ describe('SSRServer', () => {
         directives: undefined,
         generateCSP: undefined,
         debug: false,
+        logger: mockLogger,
       }),
     );
 
@@ -389,6 +390,7 @@ describe('SSRServer', () => {
         clientRoot: '/client',
         alias: { '@': '/src' },
         debug: { all: true },
+        logger: mockLogger,
         devNet: { host: 'localhost', hmrPort: 5173 },
         declarativeAlias: undefined,
         viteConfig: expect.objectContaining({ plugins: ['composed:one', 'composed:two'] }),

--- a/packages/server/src/test/support/RuntimeLoggerFallthrough.child.ts
+++ b/packages/server/src/test/support/RuntimeLoggerFallthrough.child.ts
@@ -1,0 +1,88 @@
+import { fileURLToPath } from 'node:url';
+
+import Fastify from 'fastify';
+
+import config from '../../../../../fixtures/playground-react/taujs.config.ts';
+import { serviceRegistry } from '../../../../../fixtures/playground-react/src/server/services/registry.ts';
+import { createServer } from '../../CreateServer.ts';
+
+import type { TaujsConfig } from '../../Config.ts';
+import type { BaseLogger } from '../../core/logging/types.ts';
+
+const RESULT_PREFIX = 'TAUJS_FALLTHROUGH_LOGGER_RESULT=';
+const fixtureRoot = fileURLToPath(new URL('../../../../../fixtures/playground-react/', import.meta.url));
+process.chdir(fixtureRoot);
+
+const records: Array<{
+  level: string;
+  bindings: Record<string, unknown>;
+  meta: Record<string, unknown>;
+  message: string;
+}> = [];
+
+const captureLogger = (bindings: Record<string, unknown> = {}): BaseLogger => ({
+  debug(meta, message) {
+    records.push({ level: 'debug', bindings, meta: meta as Record<string, unknown>, message: message ?? '' });
+  },
+  info(meta, message) {
+    records.push({ level: 'info', bindings, meta: meta as Record<string, unknown>, message: message ?? '' });
+  },
+  warn(meta, message) {
+    records.push({ level: 'warn', bindings, meta: meta as Record<string, unknown>, message: message ?? '' });
+  },
+  error(meta, message) {
+    records.push({ level: 'error', bindings, meta: meta as Record<string, unknown>, message: message ?? '' });
+  },
+  child(childBindings) {
+    return captureLogger({ ...bindings, ...childBindings });
+  },
+});
+
+const traceId = 'fallthrough-selected-logger-trace';
+const app = Fastify({ logger: false, genReqId: () => 'fallthrough-fastify-request' });
+app.decorate('authenticate', async () => undefined);
+
+try {
+  await createServer({
+    // The external fixture carries the packed @taujs/server renderer brand; this source-package
+    // test intentionally crosses that built/source boundary while exercising the same runtime value.
+    config: config as unknown as TaujsConfig,
+    serviceRegistry,
+    fastify: app,
+    logger: captureLogger(),
+    debug: ['ssr'],
+    projectRoot: fixtureRoot,
+  });
+
+  const response = await app.inject({
+    method: 'GET',
+    url: '/unmatched-page',
+    headers: { 'x-trace-id': traceId },
+  });
+  const record = records.find((candidate) => candidate.message === 'Sending not-found fallback HTML');
+  const result = {
+    status: response.statusCode,
+    responseTraceId: response.headers['x-trace-id'],
+    record,
+    recordCount: records.filter((candidate) => candidate.message === 'Sending not-found fallback HTML').length,
+  };
+
+  process.stdout.write(`${RESULT_PREFIX}${JSON.stringify(result)}\n`);
+  await app.close();
+
+  const passed =
+    result.status === 200 &&
+    result.responseTraceId === traceId &&
+    result.recordCount === 1 &&
+    record?.level === 'debug' &&
+    record.bindings.traceId === traceId &&
+    record.bindings.reqId === 'fallthrough-fastify-request' &&
+    record.bindings.url === '/unmatched-page' &&
+    record.bindings.method === 'GET';
+
+  process.exit(passed ? 0 : 1);
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.stack : String(error)}\n`);
+  await app.close().catch(() => undefined);
+  process.exit(1);
+}

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -6,6 +6,7 @@ import type { CoreTaujsConfig, Route, RouteParams } from './core/config/types';
 import type { DebugConfig, Logs } from './core/logging/types';
 import type { ServiceRegistry } from './core/services/DataServices';
 
+import type { RuntimeLoggerSelection } from './logging/RuntimeLogger';
 import type { AppConfig, SecurityConfig } from './Config';
 import type { StaticAssetsRegistration } from './utils/StaticAssets';
 import type { TaujsViteOverride } from './ViteConfig';
@@ -25,6 +26,8 @@ export type SSRServerOptions = {
   security?: SecurityConfig;
   staticAssets?: StaticAssetsRegistration;
   debug?: DebugConfig;
+  /** Internal runtime logger selection threaded from createServer; not a public createServer option. */
+  runtimeLogger?: RuntimeLoggerSelection;
   devNet?: { host: string; hmrPort: number };
   /**
    * Full resolved config — consumed by dev introspection surfaces (graph endpoint) AND, per RFC 0005

--- a/packages/server/src/utils/DevServer.ts
+++ b/packages/server/src/utils/DevServer.ts
@@ -10,7 +10,7 @@ import { findFormerlyDiscoveredViteConfig, formerlyDiscoveredViteConfigWarning }
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { FastifyInstance } from 'fastify';
 import type { InlineConfig, ViteDevServer } from 'vite';
-import type { DebugConfig } from '../core/logging/types';
+import type { DebugConfig, Logs } from '../core/logging/types';
 
 /**
  * RFC 0005 VS4 - `setupDevServer` options.
@@ -35,6 +35,8 @@ export type SetupDevServerOptions = {
    */
   projectRoot?: string;
   debug?: DebugConfig;
+  /** Internal runtime logger selected by createServer. */
+  logger?: Logs;
   devNet?: { host: string; hmrPort: number };
   /**
    * The resolved, engine-merged dev Vite fragment (VS4), assembled ONCE in `SSRServer` via
@@ -49,11 +51,13 @@ export type SetupDevServerOptions = {
 export const setupDevServer = async (options: SetupDevServerOptions): Promise<ViteDevServer> => {
   const { app, clientRoot: baseClientRoot, alias, declarativeAlias, projectRoot, debug, devNet, viteConfig } = options;
 
-  const logger = createLogger({
-    context: { service: 'setupDevServer' },
-    debug,
-    minLevel: 'debug',
-  });
+  const logger =
+    options.logger ??
+    createLogger({
+      context: { service: 'setupDevServer' },
+      debug,
+      minLevel: 'debug',
+    });
 
   const host = devNet?.host ?? process.env.HOST?.trim() ?? process.env.FASTIFY_ADDRESS?.trim() ?? 'localhost';
   const hmrPort = devNet?.hmrPort ?? (Number(process.env.HMR_PORT) || 5174);

--- a/packages/server/src/utils/HandleRender.ts
+++ b/packages/server/src/utils/HandleRender.ts
@@ -119,14 +119,17 @@ export const handleRender = async (
 ) => {
   const { viteDevServer } = opts;
 
-  const logger =
-    (opts.logger as any) ??
+  const baseLogger =
+    (opts.logger as Logs | undefined) ??
     createLogger({
       debug: opts.debug,
       minLevel: isDevelopment ? 'debug' : 'info',
       includeContext: true,
       includeStack: (lvl) => lvl === 'error' || isDevelopment,
     });
+  const requestContext = getRequestContext(req) ?? createRequestContext(req, reply, baseLogger);
+  const { traceId, logger, headers, recorder } = requestContext;
+  const reqLogger = logger;
 
   try {
     const url = req.url ? new URL(req.url, `http://${req.headers.host}`).pathname : '/';
@@ -138,10 +141,7 @@ export const handleRender = async (
     const { attr, appId } = route;
 
     // Dev-only recorder riding the hoisted context (P0B-02); absent → all calls no-op.
-    const hoistedContext = getRequestContext(req);
-    const recorder = hoistedContext?.recorder;
-    if (recorder && hoistedContext)
-      recorder.routeMatched({ traceId: hoistedContext.traceId, path: route.path, appId: appId ?? '', render: attr?.render ?? RENDERTYPE.ssr });
+    if (recorder) recorder.routeMatched({ traceId, path: route.path, appId: appId ?? '', render: attr?.render ?? RENDERTYPE.ssr });
     const routeContext = {
       appId,
       path: route.path,
@@ -226,10 +226,8 @@ export const handleRender = async (
     const renderType = attr?.render ?? RENDERTYPE.ssr;
     const templateParts = processTemplate(template);
 
-    const baseLogger = (opts.logger ?? logger) as Logs;
-    // Hoisted by SSRServer's onRequest hook (P0B-01); created in place only when handleRender
-    // is invoked without the hook, preserving standalone behaviour byte-for-byte.
-    const { traceId, logger: reqLogger, headers } = hoistedContext ?? createRequestContext(req, reply, baseLogger);
+    // The request context is hoisted by SSRServer's onRequest hook (P0B-01); direct
+    // handler invocation creates it once at entry so every branch uses one logger lineage.
     // Dev stamp (spec 03 §7): present only when the structural gate holds — the decoration
     // exists solely on dev boots, so production HTML never carries it.
     const devtools = (req as { server?: { taujsIntrospection?: { token: string } } }).server?.taujsIntrospection;
@@ -461,6 +459,9 @@ export const handleRender = async (
       const commitHead = () => {
         if (!reply.raw.headersSent) reply.raw.writeHead(200, headers as any);
       };
+      const commitErrorHead = () => {
+        if (!reply.raw.headersSent) reply.raw.writeHead(500, { ...headers, 'Content-Type': 'text/html; charset=utf-8' } as any);
+      };
 
       const abortedState = { aborted: false };
       const ac = new AbortController();
@@ -524,7 +525,7 @@ export const handleRender = async (
         } catch {}
         try {
           if (!reply.raw.headersSent) {
-            reply.raw.writeHead(500, { 'Content-Type': 'text/html; charset=utf-8' });
+            commitErrorHead();
             reply.raw.end('Internal Server Error');
           } else if (!reply.raw.writableEnded && !reply.raw.destroyed) {
             reply.raw.destroy();
@@ -627,7 +628,7 @@ export const handleRender = async (
               // Nothing committed yet - send a real error response instead of
               // tearing down the socket.
               try {
-                reply.raw.writeHead(500, { 'Content-Type': 'text/html; charset=utf-8' });
+                commitErrorHead();
                 reply.raw.end('Internal Server Error');
               } catch (e) {
                 logger.debug?.('ssr', { error: safeNormaliseError(e) }, 'stream teardown: error response failed');
@@ -687,7 +688,7 @@ export const handleRender = async (
             // Deterministic termination — mirror the onError teardown idioms above.
             if (!reply.raw.headersSent) {
               try {
-                reply.raw.writeHead(500, { 'Content-Type': 'text/html; charset=utf-8' });
+                commitErrorHead();
                 reply.raw.end('Internal Server Error');
               } catch (e) {
                 logger.debug?.('ssr', { error: safeNormaliseError(e) }, 'stream teardown: error response failed');
@@ -722,9 +723,8 @@ export const handleRender = async (
       });
     }
   } catch (err) {
-    const hoisted = getRequestContext(req);
-    hoisted?.recorder?.failed({
-      traceId: hoisted.traceId,
+    recorder?.failed({
+      traceId,
       error: { kind: AppError.isAppError(err) ? (err as any).kind : 'internal', message: String((err as any)?.message ?? err ?? '') },
     });
 

--- a/packages/server/src/utils/Telemetry.ts
+++ b/packages/server/src/utils/Telemetry.ts
@@ -13,15 +13,21 @@ export function getRequestContext<L extends Logs>(req: FastifyRequest): RequestC
   return (req.taujsRequestContext as RequestContext<L> | null | undefined) ?? undefined;
 }
 
-export function createRequestContext<L extends Logs>(req: FastifyRequest, reply: FastifyReply, baseLogger: L): RequestContext<L> {
+export function createRequestContext<L extends Logs>(
+  req: FastifyRequest,
+  reply: FastifyReply,
+  baseLogger: L,
+  deriveLogger?: (bindings: Record<string, unknown>) => L,
+): RequestContext<L> {
   const raw = typeof req.headers['x-trace-id'] === 'string' ? req.headers['x-trace-id'] : '';
   const traceId = raw && REGEX.SAFE_TRACE.test(raw) ? raw : typeof (req as any).id === 'string' ? (req as any).id : crypto.randomUUID();
 
   reply.header('x-trace-id', traceId);
 
+  const bindings = { traceId, reqId: req.id, url: req.url, method: req.method };
   const anyLogger = baseLogger as Logs;
   const child = anyLogger.child;
-  const logger = (typeof child === 'function' ? child.call(baseLogger, { traceId, url: req.url, method: req.method }) : baseLogger) as typeof baseLogger;
+  const logger = (deriveLogger ? deriveLogger(bindings) : typeof child === 'function' ? child.call(baseLogger, bindings) : baseLogger) as typeof baseLogger;
   const headers: Record<string, string> = Object.fromEntries(
     Object.entries(req.headers as Record<string, string | string[] | undefined>).map(([headerName, headerValue]) => {
       const normalisedValue = Array.isArray(headerValue) ? headerValue.join(',') : (headerValue ?? '');

--- a/packages/server/src/utils/test/DevServer.test.ts
+++ b/packages/server/src/utils/test/DevServer.test.ts
@@ -164,6 +164,16 @@ describe('setupDevServer', () => {
     expect(server).toBeDefined();
   });
 
+  it('uses a supplied runtime logger instead of constructing a standalone logger', async () => {
+    const { setupDevServer } = await importer();
+    const app = makeApp();
+
+    await setupDevServer({ app: app as any, clientRoot: '/root/client', debug: { all: true }, logger: logger as any });
+
+    expect(createLoggerMock).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith('vite', expect.stringContaining('Development server debug started'));
+  });
+
   it('debug=true injects plugin which logs rx/tx via middleware', async () => {
     const { setupDevServer } = await importer();
 

--- a/packages/server/src/utils/test/HandleRender.test.ts
+++ b/packages/server/src/utils/test/HandleRender.test.ts
@@ -2015,11 +2015,22 @@ describe('handleRender', () => {
 
       mockMaps.renderModules.set('/test/client', { renderStream: mockRenderStream });
 
+      mockReq.taujsRequestContext = {
+        traceId: 'fatal-trace-1',
+        logger: mockLogger,
+        headers: { 'x-trace-id': 'fatal-trace-1' },
+      };
+      // Fastify's reply header store is the source copied into the raw streaming response.
+      mockReply.getHeaders.mockReturnValue({ 'x-trace-id': 'fatal-trace-1' });
+
       await handleRender(mockReq, mockReply, mockSelectedRoute, mockProcessedConfigs, mockServiceRegistry, mockMaps);
 
       expect(mockReply.hijack).toHaveBeenCalled();
       expect(mockReply.raw.writeHead).toHaveBeenCalledTimes(1);
-      expect(mockReply.raw.writeHead).toHaveBeenCalledWith(500, expect.objectContaining({ 'Content-Type': 'text/html; charset=utf-8' }));
+      expect(mockReply.raw.writeHead).toHaveBeenCalledWith(
+        500,
+        expect.objectContaining({ 'Content-Type': 'text/html; charset=utf-8', 'x-trace-id': 'fatal-trace-1' }),
+      );
       expect(mockReply.raw.end).toHaveBeenCalledWith('Internal Server Error');
       expect(mockReply.raw.destroy).not.toHaveBeenCalled();
     });

--- a/packages/server/src/utils/test/Telemetry.test.ts
+++ b/packages/server/src/utils/test/Telemetry.test.ts
@@ -94,6 +94,7 @@ describe('createRequestContext', () => {
         expect(bindings).toEqual(
           expect.objectContaining({
             traceId: expect.any(String),
+            reqId: 'req-child-1',
             url: '/child',
             method: 'GET',
           }),
@@ -113,6 +114,27 @@ describe('createRequestContext', () => {
 
     expect(loggerWithChild.child).toHaveBeenCalledTimes(1);
     expect(childThis).toBe(loggerWithChild);
+    expect(ctx.logger).toBe(derivedLogger);
+  });
+
+  it('uses an injected request-logger derivation seam when supplied', () => {
+    const derivedLogger = { ...baseLogger, marker: 'derived' };
+    const deriveLogger = vi.fn(() => derivedLogger);
+    const req: Req = {
+      headers: { host: 'factory.test' },
+      method: 'PATCH',
+      url: '/factory',
+      id: 'req-factory-1',
+    };
+
+    const ctx = createRequestContext(req as any, reply as any, baseLogger, deriveLogger as any);
+
+    expect(deriveLogger).toHaveBeenCalledWith({
+      traceId: 'req-factory-1',
+      reqId: 'req-factory-1',
+      url: '/factory',
+      method: 'PATCH',
+    });
     expect(ctx.logger).toBe(derivedLogger);
   });
 

--- a/website/src/content/docs/guides/logging-telemetry.md
+++ b/website/src/content/docs/guides/logging-telemetry.md
@@ -43,9 +43,42 @@ await createServer({
 });
 ```
 
-τjs automatically uses `fastify.log` for internal logging.
+When you supply a logging-enabled Fastify instance, τjs uses Fastify's logger
+for its runtime records. Request records inherit from `request.log`, so they
+retain Fastify's request ID, serializers, redaction rules, transport and
+destination.
+
+The complete precedence is:
+
+```text
+createServer({ logger })
+          ↓ otherwise
+active fastify.log / request.log
+          ↓ otherwise
+τjs console logger
+```
+
+An explicit `createServer({ logger })` is authoritative for τjs records. An
+active Fastify logger means that `fastify.log` has a non-empty level other than
+`silent`. When neither source is available, τjs uses its standalone formatted
+console logger.
+
+τjs does not alter the selected logger's level, serializers, redaction,
+transport or destination.
 
 ## Request Tracing
+
+### Fastify request IDs and τjs trace IDs
+
+These IDs describe related but different things:
+
+- `reqId` is Fastify's identity for the HTTP request.
+- `traceId` is τjs's identity for correlating route resolution, services,
+  rendering and the response.
+
+Request-scoped τjs records carry both. They also carry the request URL and
+method as structured bindings. The fields are bound once rather than repeated
+inside a nested logging context.
 
 ### Automatic Trace ID Generation
 
@@ -176,6 +209,15 @@ await createServer({
 });
 ```
 
+Debug output is admitted by the strictest combination of three controls:
+
+1. the τjs debug category must be enabled;
+2. τjs's runtime minimum must allow debug output;
+3. the selected logger's level must allow it.
+
+The current production runtime minimum is `info`. Setting Pino to `debug` in
+production therefore does not independently enable τjs debug records.
+
 ## Child Loggers
 
 ### In Data Handlers
@@ -225,6 +267,12 @@ export const OrderService = defineService({
 ```
 
 ## Structured Logging
+
+Structured sinks receive the semantic message and metadata. τjs does not add
+its console timestamp or `[level]` prefix before handing a record to Pino,
+Winston or a custom logger; the selected sink owns framing and presentation.
+Debug categories remain available as structured metadata, for example
+`{ category: "ssr" }`.
 
 ### Log Levels
 
@@ -363,6 +411,10 @@ await createServer({
   logger: customLoggerAdapter(myLogger),
 });
 ```
+
+Custom logger adapters receive metadata first and the raw semantic message
+second. If the logger supports `child()`, τjs uses it for request bindings. If
+it does not, τjs retains those bindings as structured metadata.
 
 ## Production Configuration
 
@@ -572,6 +624,11 @@ ctx.logger.error({ error, userId }, "Operation failed");
 
 ### 3. Don't Log Secrets
 
+τjs does not log route-data payloads, renderer stores, service return values,
+request bodies or complete request headers as part of its runtime lifecycle.
+Application logs can still disclose anything explicitly passed to them, so
+configure sink redaction and keep sensitive values out of metadata.
+
 ```typescript
 // redact sensitive data
 ctx.logger.info(
@@ -648,6 +705,17 @@ export const ExternalApiService = defineService({
   },
 });
 ```
+
+## Logs and request traces
+
+Logs and τjs request traces are complementary:
+
+- logs are the operational stream delivered through Fastify, Pino, Winston or
+  the standalone console logger;
+- request traces are τjs's structured evidence of how a response was resolved
+  and rendered.
+
+They share request correlation, but one is not a substitute for the other.
 
 <!--
 ## What's Next?


### PR DESCRIPTION
## Summary

  - Resolve the τjs runtime logger once using explicit logger → active Fastify logger → standalone fallback precedence.
  - Propagate the selected logger through boot, SSR, development Vite, network warnings, CSP, CSP reporting, auth, services, rendering, fallthrough and terminal errors.
  - Derive Fastify-owned request records from `req.log`, retaining Fastify request identity alongside the τjs trace ID.
  - Prevent child bindings from being repeated inside nested logger context.
  - Pass raw semantic messages and structured debug categories to custom sinks, leaving Pino/Winston responsible for framing.
  - Preserve existing response headers, including `x-trace-id` and CSP, on pre-shell streaming 500 responses.
  - Update the logging guide and add an `@taujs/server` patch changeset.

  No public API was added.

  ## Logger precedence

  ```text
  createServer({ logger })
            ↓ otherwise
  active fastify.log / request.log
            ↓ otherwise
  τjs standalone logger
```
  The selected sink retains control of its levels, serializers, redaction, transport and destination.

  ## Evidence

  - Real Fastify/Pino/React production proof: 22/22 assertions.
  - Eight reversible tamper checks covering precedence, request lineage, duplicate bindings, message framing, debug categories, CSP identity, CSP reporting and metadata redaction.
  - Real development createServer() fallthrough regression using Fastify, Vite and the React fixture.
  - Fallthrough regression tamper-verified by removing the hoisted request logger.

  ## Verification

  - @taujs/server: 858/858
  - Workspace typecheck: green
  - Full workspace suite: 1,590 passed, zero failed
  - One existing documented Solid pre-hydration replay test remains skipped
  - Generated React and Solid lifecycle tests: green
  - Renderer-composition and browser matrices: green
  - Packed export checks and website build: green
  - Changeset status: valid