### PR TITLE
feat(server): respect caller-owned Fastify hosts

### DIFF
--- a/.changeset/rfc-0010-host-ownership.md
+++ b/.changeset/rfc-0010-host-ownership.md
@@ -1,0 +1,41 @@
+---
+'@taujs/server': minor
+---
+
+Respect a caller-supplied Fastify instance (RFC 0010)
+
+τjs now derives one internal ownership fact from whether you passed `fastify` to `createServer`.
+
+**Bring your own Fastify and τjs respects it.** When you supply an instance, τjs registers its
+routes, CSP, trace, auth, static assets, introspection and error conversion into a single
+encapsulated Fastify scope. It no longer replaces your error handler or not-found handler, applies
+no CSP or trace to your routes, claims no root decorators, prints no banner or presentation output,
+and adds no `onReady` hook. It still registers under its own name, so it appears in your plugin
+tree. In development a single root `onRequest` hook delegates otherwise-unmatched requests to the
+τjs-owned Vite server and returns control unchanged; production installs no root hook at all.
+
+**Let τjs create Fastify and it provides the complete experience.** Omit `fastify` and behaviour is
+unchanged: whole-server CSP and trace, the implicit application shell, the banner and configured
+line.
+
+No new ownership option or mode is introduced. Standalone applications are unaffected; embedded
+applications should read the migration notes below, since some may need to declare a wildcard page
+or establish host-wide CSP on their own instance.
+
+### Behaviour changes for embedded hosts
+
+These previously applied to your whole server and now apply only to τjs-owned responses:
+
+- **The implicit application shell is gone.** Unmatched URLs fall to your own not-found policy. If
+  you want τjs to render them, declare a terminal wildcard page route (`path: '/*'`), which is an
+  ordinary τjs page and now also owns asset-like URLs it matches.
+- **Configured τjs CSP no longer applies to your routes.** Host-wide policy belongs to Fastify;
+  τjs CSP, nonces and route-level `merge`/`replace` continue to apply to τjs pages.
+- **`x-trace-id` no longer appears on your routes**, and no τjs trace episode opens for them. τjs
+  still adopts an inbound `x-trace-id` or your Fastify `req.id` for its own responses, so one
+  correlation identity spans both.
+
+Two boot failures are also fixed: supplying an instance that already owns a not-found handler, or
+that has already registered `@fastify/static`, previously prevented τjs from booting.
+
+The boot summary now states which ownership mode is in effect.

--- a/.changeset/rfc-0010-host-ownership.md
+++ b/.changeset/rfc-0010-host-ownership.md
@@ -31,9 +31,14 @@ These previously applied to your whole server and now apply only to τjs-owned r
   ordinary τjs page and now also owns asset-like URLs it matches.
 - **Configured τjs CSP no longer applies to your routes.** Host-wide policy belongs to Fastify;
   τjs CSP, nonces and route-level `merge`/`replace` continue to apply to τjs pages.
-- **`x-trace-id` no longer appears on your routes**, and no τjs trace episode opens for them. τjs
-  still adopts an inbound `x-trace-id` or your Fastify `req.id` for its own responses, so one
-  correlation identity spans both.
+- **`x-trace-id` no longer appears on your routes**, and no τjs trace episode opens for them. For
+  its own responses τjs still adopts an inbound `x-trace-id`, or otherwise your Fastify `req.id`,
+  so your records and τjs's join on one identity in the logs. The shared value is not on the wire:
+  your routes carry no trace header.
+
+`req.id` adoption now also accepts a numeric `genReqId`. Previously only a string identity was
+adopted and a counter-based `genReqId` silently fell through to an unrelated random UUID, breaking
+that correlation without warning.
 
 Two boot failures are also fixed: supplying an instance that already owns a not-found handler, or
 that has already registered `@fastify/static`, previously prevented τjs from booting.

--- a/packages/server/src/CreateServer.ts
+++ b/packages/server/src/CreateServer.ts
@@ -13,7 +13,7 @@ import { resolveNet } from './network/CLI';
 import { bannerPlugin } from './network/Network';
 import { verifyContracts, isAuthRequired, hasAuthenticate } from './security/VerifyMiddleware';
 import { printConfigSummary, printContractReport, printSecuritySummary } from './Setup';
-import { SSRServer } from './SSRServer';
+import { ssrServerPlugin } from './SSRServer';
 import { isDevelopment } from './System';
 
 import type { FastifyInstance } from 'fastify';
@@ -61,6 +61,13 @@ export const createServer = async (opts: CreateServerOptions): Promise<CreateSer
   const t0 = performance.now();
   const clientRoot = resolveClientRoot(opts.clientRoot);
 
+  // RFC 0010: the one internal ownership fact. Supplying a Fastify instance means the caller owns
+  // the server and τjs owns only an encapsulated scope within it; omitting one means τjs created
+  // the server and provides the complete experience. Derived here, never a public option, and never
+  // threaded through plugin options - it selects the registration form below, so the form and the
+  // behaviour cannot drift apart.
+  const callerOwnedHost = opts.fastify !== undefined;
+
   const app = opts.fastify ?? Fastify({ logger: false });
   const fastifyLogger = app.log && app.log.level && app.log.level !== 'silent' ? app.log : undefined;
   const runtimeLogger: RuntimeLoggerSelection = {
@@ -74,11 +81,16 @@ export const createServer = async (opts: CreateServerOptions): Promise<CreateSer
   });
 
   const net = resolveNet(opts.config.server);
-  await app.register(bannerPlugin, {
-    debug: opts.debug,
-    logger,
-    hmr: { host: net.host, port: net.hmrPort },
-  });
+
+  // RFC 0010: the banner is τjs-created-host presentation. A caller-owned host receives no banner
+  // decoration and no `onReady` hook; its boot summaries still reach the resolved logger below.
+  if (!callerOwnedHost) {
+    await app.register(bannerPlugin, {
+      debug: opts.debug,
+      logger,
+      hmr: { host: net.host, port: net.hmrPort },
+    });
+  }
 
   const configs = extractBuildConfigs(opts.config);
   const { routes, apps, totalRoutes, durationMs } = extractRoutes(opts.config);
@@ -86,6 +98,16 @@ export const createServer = async (opts: CreateServerOptions): Promise<CreateSer
 
   printConfigSummary(logger, apps, configs.length, totalRoutes, durationMs);
   printSecuritySummary(logger, routes, security, hasExplicitCSP, securityDuration);
+
+  // RFC 0010: ownership is derived, never configured, so the boot summary has to say which side of
+  // the thesis this process is on. Without it a caller cannot tell from the logs why their 404s,
+  // CSP or trace headers changed.
+  logger.info(
+    { component: 'ownership', callerOwnedHost },
+    callerOwnedHost
+      ? `${CONTENT.TAG} [ownership] Fastify supplied by caller - τjs owns its declared routes in an encapsulated scope; host errors, not-found, CSP and trace remain yours`
+      : `${CONTENT.TAG} [ownership] Fastify created by τjs - whole-server shell, CSP and trace`,
+  );
 
   // RFC security model §2: relaxing the loopback guard must shout in the boot summary —
   // exact text, not a debug line.
@@ -116,7 +138,7 @@ export const createServer = async (opts: CreateServerOptions): Promise<CreateSer
   printContractReport(logger, report);
 
   try {
-    await app.register(SSRServer, {
+    await app.register(ssrServerPlugin({ callerOwnedHost }), {
       clientRoot,
       configs,
       routes,
@@ -129,6 +151,11 @@ export const createServer = async (opts: CreateServerOptions): Promise<CreateSer
       security,
       devNet: { host: net.host, hmrPort: net.hmrPort },
       taujsConfig: opts.config,
+      // RFC 0010: the single caller-root exception, and the only value that reaches the plugin from
+      // the caller's instance. Vite must observe development URLs Fastify did not route, which only
+      // a root-level hook sees. Withheld unless the caller owns the host AND we are in development,
+      // so production never receives the handle at all.
+      viteRequestHookOwner: callerOwnedHost && isDevelopment ? app : undefined,
     });
   } catch (err) {
     logger.error(
@@ -144,19 +171,19 @@ export const createServer = async (opts: CreateServerOptions): Promise<CreateSer
     throw err;
   }
 
-  // Structural gate (RFC security model §1): in production this branch never runs, so the
-  // introspection emission code is never even loaded — absence, not a disabled flag.
-  if (isDevelopment) {
-    try {
-      const { registerBootGraphEmission } = await import('./core/introspection/EmitGraph');
-      registerBootGraphEmission(app, opts.config, opts.serviceRegistry, logger);
-    } catch (err) {
-      logger.warn({ component: 'introspection', error: normaliseError(err) }, 'Graph emission unavailable (non-fatal)');
-    }
-  }
+  // RFC 0010: boot-graph emission moved into the owned scope alongside the dev files and recorder,
+  // so it has one owner rather than a second registration site here. Its structural gate is
+  // unchanged: it lives inside the `isDevelopment` branch of the SSR plugin behind a lazy dynamic
+  // import, so in production the emission code is never loaded.
 
   const t1 = performance.now();
-  console.log(`\n${pc.bgGreen(pc.black(` ${CONTENT.TAG} `))} configured in ${(t1 - t0).toFixed(0)}ms\n`);
+
+  // RFC 0010: presentation, not a log record. A caller-owned host receives no direct PRESENTATION
+  // output. Its boot and error records still travel through the resolved logger, and when neither an
+  // explicit logger nor an active Fastify logger exists that resolved logger is the released console
+  // fallback - which writes to the console by design. The distinction is mediated records versus
+  // unmediated presentation, not silence.
+  if (!callerOwnedHost) console.log(`\n${pc.bgGreen(pc.black(` ${CONTENT.TAG} `))} configured in ${(t1 - t0).toFixed(0)}ms\n`);
 
   if (opts.fastify) return { net } as const;
   return { app, net } as const;

--- a/packages/server/src/SSRServer.ts
+++ b/packages/server/src/SSRServer.ts
@@ -39,188 +39,227 @@ import type { SSRServerOptions } from './types';
 
 export { TEMPLATE };
 
-export const SSRServer: FastifyPluginAsync<SSRServerOptions> = fp(
-  async (app: FastifyInstance, opts: SSRServerOptions) => {
-    const { alias, configs, routes, serviceRegistry = {}, clientRoot, security } = opts;
+/**
+ * RFC 0010: the one τjs body, installed into the one scope τjs owns.
+ *
+ * `callerOwnedHost` is never carried in plugin options - it is bound here by `ssrServerPlugin`,
+ * which selects Fastify's own encapsulation switch from the same fact. That keeps the registration
+ * form and the ownership behaviour from drifting apart.
+ */
+const installOwnedScope = async (scope: FastifyInstance, opts: SSRServerOptions, callerOwnedHost: boolean): Promise<void> => {
+  const { alias, configs, routes, serviceRegistry = {}, clientRoot, security } = opts;
 
-    const logger = opts.runtimeLogger
-      ? createRuntimeLogger(opts.runtimeLogger, {
-          context: { component: 'ssr-server' },
-          includeContext: true,
-          singleLine: true,
-        })
-      : createLogger({
-          debug: opts.debug,
-          context: { component: 'ssr-server' },
-          minLevel: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
-          includeContext: true,
-          singleLine: true,
-        });
-
-    const maps = createMaps();
-
-    const processedConfigs = processConfigs(configs, clientRoot, TEMPLATE);
-    let viteDevServer: ViteDevServer | undefined;
-    let introspection: DevIntrospection | undefined;
-
-    await loadAssets(
-      processedConfigs,
-      clientRoot,
-      maps.bootstrapModules,
-      maps.cssLinks,
-      maps.manifests,
-      maps.preloadLinks,
-      maps.renderModules,
-      maps.ssrManifests,
-      maps.templates,
-      { logger },
-    );
-
-    if (!isDevelopment && !opts.staticAssets) {
-      const fastifyStatic = await import('@fastify/static');
-
-      await registerStaticAssets(app, clientRoot, { plugin: fastifyStatic.default });
-    }
-
-    if (opts.staticAssets) await registerStaticAssets(app, clientRoot, opts.staticAssets);
-
-    if (security?.csp?.reporting) {
-      app.register(cspReportPlugin, {
-        path: security.csp.reporting.endpoint,
+  const logger = opts.runtimeLogger
+    ? createRuntimeLogger(opts.runtimeLogger, {
+        context: { component: 'ssr-server' },
+        includeContext: true,
+        singleLine: true,
+      })
+    : createLogger({
         debug: opts.debug,
-        logger,
-        runtimeLogger: opts.runtimeLogger,
-        onViolation: security.csp.reporting.onViolation,
+        context: { component: 'ssr-server' },
+        minLevel: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
+        includeContext: true,
+        singleLine: true,
       });
-    }
 
-    app.register(cspPlugin, {
-      directives: opts.security?.csp?.directives,
-      generateCSP: opts.security?.csp?.generateCSP,
+  const maps = createMaps();
+
+  const processedConfigs = processConfigs(configs, clientRoot, TEMPLATE);
+  let viteDevServer: ViteDevServer | undefined;
+  let introspection: DevIntrospection | undefined;
+
+  await loadAssets(
+    processedConfigs,
+    clientRoot,
+    maps.bootstrapModules,
+    maps.cssLinks,
+    maps.manifests,
+    maps.preloadLinks,
+    maps.renderModules,
+    maps.ssrManifests,
+    maps.templates,
+    { logger },
+  );
+
+  if (!isDevelopment && !opts.staticAssets) {
+    const fastifyStatic = await import('@fastify/static');
+
+    await registerStaticAssets(scope, clientRoot, { plugin: fastifyStatic.default });
+  }
+
+  if (opts.staticAssets) await registerStaticAssets(scope, clientRoot, opts.staticAssets);
+
+  if (security?.csp?.reporting) {
+    scope.register(cspReportPlugin, {
+      path: security.csp.reporting.endpoint,
       debug: opts.debug,
       logger,
       runtimeLogger: opts.runtimeLogger,
+      onViolation: security.csp.reporting.onViolation,
+    });
+  }
+
+  scope.register(cspPlugin, {
+    directives: opts.security?.csp?.directives,
+    generateCSP: opts.security?.csp?.generateCSP,
+    debug: opts.debug,
+    logger,
+    runtimeLogger: opts.runtimeLogger,
+  });
+
+  if (isDevelopment) {
+    // RFC 0005 §1 (VS4): resolve `config.vite` ONCE, with the discriminated `serve` context arm
+    // (no `appId` - per-app dev servers are rejected by maintainer ruling). Resolution happens
+    // HERE rather than inside the engine so the override's plugins can enter the same §5
+    // composition rule as app plugins below, instead of bypassing dedupe via the engine's plain
+    // append; the remaining admitted fields ride to the engine with plugins stripped.
+    const devOverride = opts.taujsConfig?.vite;
+    const resolvedDevOverride =
+      typeof devOverride === 'function' ? devOverride({ command: 'serve', mode: 'development', isSSRBuild: false, clientRoot }) : devOverride;
+    const { plugins: overridePlugins, ...devOverrideFields } = resolvedDevOverride ?? {};
+
+    // ESC-1 (RFC 0006) - GLOBAL ownership preparation over ALL apps + the §5 dev composition, in the
+    // ONE ordering `assembleDevPluginChain` owns (phase 1 prepareOwnership -> phase 2
+    // assembleManagedSources instantiating EVERY active key + a fresh fail-closed diagnostic + the
+    // tagged-raw-compiler hard error -> composePlugins). Host-owned managed sources are PREPENDED
+    // (diagnostic first within the `enforce:'pre'` tier), then each app is a labelled source of its
+    // RAW plugins (managed contributions removed), then the resolved `config.vite` source. Cross-app
+    // collisions and reserved-prefix drops are promoted from debug to WARN through the shared reporter
+    // so dev and build emit one format. `internal` is empty here: the sole dev internal plugin
+    // (`τjs-development-server-debug-logging`) is appended LAST inside setupDevServer, which holds the
+    // dev logger it closes over - the same §5 contract composePlugins enforces for `internal`. The
+    // integration fixture drives this SAME function (via a test-only source alias), so its evidence
+    // exercises the real ordering rather than a hand-rolled copy. A no-op when no managed contribution
+    // is declared.
+    const { plugins, ownership } = await assembleDevPluginChain({
+      apps: processedConfigs.map((c) => ({ appId: c.appId, appRoot: c.clientRoot, plugins: c.plugins, renderer: c.renderer })),
+      projectRoot: opts.projectRoot ?? process.cwd(),
+      overridePlugins,
+      onCollision: (c) => logger.warn({ plugin: c.name, sources: c.sources, winner: c.winner }, pluginCollisionMessage(c)),
+      onReservedPrefix: (d) => logger.warn({ plugin: d.name, source: d.source }, reservedPluginMessage(d)),
+    });
+    const rawOf = (appId: string) => ownership.rawByApp.get(appId) ?? [];
+
+    printVitePluginSummary(
+      logger,
+      processedConfigs.map((c) => ({
+        appId: c.appId,
+        plugins: rawOf(c.appId).map((p) => (Array.isArray(p) ? `array(${p.length})` : ((p as any)?.name ?? typeof p))),
+      })),
+      plugins,
+    );
+
+    // The engine (DEV_PROFILE) merges the remaining admitted dev fields (define, css, esbuild,
+    // logLevel, optimizeDeps, non-alias resolve) over the composed plugin list + scss default and
+    // warns any protected field; `setupDevServer` then receives one resolved fragment rather than
+    // a growing positional list. `taujsBuild({ vite })` is build-only and is NOT consulted here.
+    const devViteConfig = resolveDevViteConfig({
+      viteOverride: resolvedDevOverride ? devOverrideFields : undefined,
+      clientRoot,
+      appPlugins: plugins,
     });
 
-    if (isDevelopment) {
-      // RFC 0005 §1 (VS4): resolve `config.vite` ONCE, with the discriminated `serve` context arm
-      // (no `appId` - per-app dev servers are rejected by maintainer ruling). Resolution happens
-      // HERE rather than inside the engine so the override's plugins can enter the same §5
-      // composition rule as app plugins below, instead of bypassing dedupe via the engine's plain
-      // append; the remaining admitted fields ride to the engine with plugins stripped.
-      const devOverride = opts.taujsConfig?.vite;
-      const resolvedDevOverride =
-        typeof devOverride === 'function' ? devOverride({ command: 'serve', mode: 'development', isSSRBuild: false, clientRoot }) : devOverride;
-      const { plugins: overridePlugins, ...devOverrideFields } = resolvedDevOverride ?? {};
+    // RFC 0005 §3 (VS5): `alias` is the programmatic escape hatch (createServer option); the
+    // declarative `config.alias` is layered UNDER it inside setupDevServer.
+    viteDevServer = await setupDevServer({
+      app: scope,
+      // RFC 0010: the single caller-root exception. Supplied only for embedded development, so
+      // the delegating hook can observe URLs Fastify did not route to a τjs route. Undefined on
+      // every other path, where the hook lands on the owned scope exactly as before.
+      viteRequestHookOwner: opts.viteRequestHookOwner,
+      clientRoot,
+      alias,
+      declarativeAlias: opts.taujsConfig?.alias,
+      projectRoot: opts.projectRoot,
+      debug: opts.debug,
+      logger,
+      devNet: opts.devNet,
+      viteConfig: devViteConfig,
+    });
 
-      // ESC-1 (RFC 0006) - GLOBAL ownership preparation over ALL apps + the §5 dev composition, in the
-      // ONE ordering `assembleDevPluginChain` owns (phase 1 prepareOwnership -> phase 2
-      // assembleManagedSources instantiating EVERY active key + a fresh fail-closed diagnostic + the
-      // tagged-raw-compiler hard error -> composePlugins). Host-owned managed sources are PREPENDED
-      // (diagnostic first within the `enforce:'pre'` tier), then each app is a labelled source of its
-      // RAW plugins (managed contributions removed), then the resolved `config.vite` source. Cross-app
-      // collisions and reserved-prefix drops are promoted from debug to WARN through the shared reporter
-      // so dev and build emit one format. `internal` is empty here: the sole dev internal plugin
-      // (`τjs-development-server-debug-logging`) is appended LAST inside setupDevServer, which holds the
-      // dev logger it closes over - the same §5 contract composePlugins enforces for `internal`. The
-      // integration fixture drives this SAME function (via a test-only source alias), so its evidence
-      // exercises the real ordering rather than a hand-rolled copy. A no-op when no managed contribution
-      // is declared.
-      const { plugins, ownership } = await assembleDevPluginChain({
-        apps: processedConfigs.map((c) => ({ appId: c.appId, appRoot: c.clientRoot, plugins: c.plugins, renderer: c.renderer })),
-        projectRoot: opts.projectRoot ?? process.cwd(),
-        overridePlugins,
-        onCollision: (c) => logger.warn({ plugin: c.name, sources: c.sources, winner: c.winner }, pluginCollisionMessage(c)),
-        onReservedPrefix: (d) => logger.warn({ plugin: d.name, source: d.source }, reservedPluginMessage(d)),
-      });
-      const rawOf = (appId: string) => ownership.rawByApp.get(appId) ?? [];
+    // RFC 0010: τjs creates the Vite server, so τjs closes it. Guarded because `onClose` can be
+    // reached more than once when a caller closes an instance that is already closing.
+    const ownedViteDevServer = viteDevServer;
+    let viteClosed = false;
+    scope.addHook('onClose', async () => {
+      if (viteClosed) return;
+      viteClosed = true;
+      await ownedViteDevServer.close();
+    });
 
-      printVitePluginSummary(
-        logger,
-        processedConfigs.map((c) => ({
-          appId: c.appId,
-          plugins: rawOf(c.appId).map((p) => (Array.isArray(p) ? `array(${p.length})` : ((p as any)?.name ?? typeof p))),
-        })),
-        plugins,
-      );
+    // Structural gate (spec 03 invariant 1): recorder, dev files, and overlay endpoints
+    // exist only when the dev Vite middleware exists, loaded via lazy dynamic import.
+    // Failure is non-fatal.
+    try {
+      const { createDevIntrospection } = await import('./core/introspection/DevIntrospection');
+      const { registerDevFiles } = await import('./core/introspection/DevFiles');
+      const { registerIntrospectionEndpoints } = await import('./core/introspection/DevEndpoints');
 
-      // The engine (DEV_PROFILE) merges the remaining admitted dev fields (define, css, esbuild,
-      // logLevel, optimizeDeps, non-alias resolve) over the composed plugin list + scss default and
-      // warns any protected field; `setupDevServer` then receives one resolved fragment rather than
-      // a growing positional list. `taujsBuild({ vite })` is build-only and is NOT consulted here.
-      const devViteConfig = resolveDevViteConfig({
-        viteOverride: resolvedDevOverride ? devOverrideFields : undefined,
-        clientRoot,
-        appPlugins: plugins,
-      });
+      const redaction = opts.taujsConfig?.introspection?.redaction;
+      introspection = createDevIntrospection({ logger, denyKeys: redaction?.denyKeys, replaceDefaultDenyKeys: redaction?.replaceDefaultDenyKeys });
 
-      // RFC 0005 §3 (VS5): `alias` is the programmatic escape hatch (createServer option); the
-      // declarative `config.alias` is layered UNDER it inside setupDevServer.
-      viteDevServer = await setupDevServer({
-        app,
-        clientRoot,
-        alias,
-        declarativeAlias: opts.taujsConfig?.alias,
-        projectRoot: opts.projectRoot,
+      scope.decorate('taujsIntrospection', introspection);
+      registerDevFiles(scope, introspection, logger);
+      registerIntrospectionEndpoints(scope, { introspection, taujsConfig: opts.taujsConfig, serviceRegistry, logger });
+    } catch (err) {
+      logger.warn({ component: 'introspection', error: (err as Error)?.message ?? String(err) }, 'Trace recording unavailable (non-fatal)');
+    }
+
+    // RFC 0010: boot-graph emission belongs to whichever scope τjs owns, so it has the same owner
+    // as the dev files and recorder above rather than a second site in `createServer`. The hook is
+    // `onListen`, which fires for an encapsulated child when the host binds. Non-fatal.
+    if (opts.taujsConfig) {
+      try {
+        const { registerBootGraphEmission } = await import('./core/introspection/EmitGraph');
+
+        registerBootGraphEmission(scope, opts.taujsConfig, serviceRegistry, logger);
+      } catch (err) {
+        logger.warn({ component: 'introspection', error: (err as Error)?.message ?? String(err) }, 'Graph emission unavailable (non-fatal)');
+      }
+    }
+  }
+  // Trace context first, deliberately before auth: every request — rendered, fallthrough,
+  // asset-like — gets a traceId and the x-trace-id response header before auth,
+  // and auth logging can carry the traceId (P0B-01). In dev the request logger is teed
+  // into the logs annex and the recorder rides the context (P0B-02).
+  scope.decorateRequest('taujsRequestContext', null);
+  scope.addHook('onRequest', async (req, reply) => {
+    const requestContext = createRequestContext(
+      req,
+      reply,
+      logger,
+      opts.runtimeLogger ? (bindings) => createRuntimeRequestLogger(opts.runtimeLogger!, req, { component: 'ssr-server', ...bindings }) : undefined,
+    );
+    if (introspection) {
+      requestContext.logger = introspection.wrapRequestLogger(requestContext.logger, requestContext.traceId);
+      requestContext.recorder = introspection.recorder;
+    }
+    req.taujsRequestContext = requestContext;
+    requestContext.recorder?.requestStart({ traceId: requestContext.traceId, url: req.url, method: req.method });
+  });
+  scope.addHook('onRequest', createAuthHook(logger));
+
+  for (const route of routes) {
+    scope.get(route.path, { config: fastifyConfigForRoute(route) }, async (req, reply) => {
+      const selectedRoute = selectedRouteFrom(req);
+      if (!selectedRoute) throw AppError.internal(`Fastify selected route "${route.path}" without its τjs route identity`);
+
+      await handleRender(req, reply, selectedRoute, processedConfigs, serviceRegistry, maps, {
         debug: opts.debug,
         logger,
-        devNet: opts.devNet,
-        viteConfig: devViteConfig,
+        viteDevServer,
       });
-
-      // Structural gate (spec 03 invariant 1): recorder, dev files, and overlay endpoints
-      // exist only when the dev Vite middleware exists, loaded via lazy dynamic import.
-      // Failure is non-fatal.
-      try {
-        const { createDevIntrospection } = await import('./core/introspection/DevIntrospection');
-        const { registerDevFiles } = await import('./core/introspection/DevFiles');
-        const { registerIntrospectionEndpoints } = await import('./core/introspection/DevEndpoints');
-
-        const redaction = opts.taujsConfig?.introspection?.redaction;
-        introspection = createDevIntrospection({ logger, denyKeys: redaction?.denyKeys, replaceDefaultDenyKeys: redaction?.replaceDefaultDenyKeys });
-
-        app.decorate('taujsIntrospection', introspection);
-        registerDevFiles(app, introspection, logger);
-        registerIntrospectionEndpoints(app, { introspection, taujsConfig: opts.taujsConfig, serviceRegistry, logger });
-      } catch (err) {
-        logger.warn({ component: 'introspection', error: (err as Error)?.message ?? String(err) }, 'Trace recording unavailable (non-fatal)');
-      }
-    }
-    // Trace context first, deliberately before auth: every request — rendered, fallthrough,
-    // asset-like — gets a traceId and the x-trace-id response header before auth,
-    // and auth logging can carry the traceId (P0B-01). In dev the request logger is teed
-    // into the logs annex and the recorder rides the context (P0B-02).
-    app.decorateRequest('taujsRequestContext', null);
-    app.addHook('onRequest', async (req, reply) => {
-      const requestContext = createRequestContext(
-        req,
-        reply,
-        logger,
-        opts.runtimeLogger ? (bindings) => createRuntimeRequestLogger(opts.runtimeLogger!, req, { component: 'ssr-server', ...bindings }) : undefined,
-      );
-      if (introspection) {
-        requestContext.logger = introspection.wrapRequestLogger(requestContext.logger, requestContext.traceId);
-        requestContext.recorder = introspection.recorder;
-      }
-      req.taujsRequestContext = requestContext;
-      requestContext.recorder?.requestStart({ traceId: requestContext.traceId, url: req.url, method: req.method });
     });
-    app.addHook('onRequest', createAuthHook(logger));
+  }
 
-    for (const route of routes) {
-      app.get(route.path, { config: fastifyConfigForRoute(route) }, async (req, reply) => {
-        const selectedRoute = selectedRouteFrom(req);
-        if (!selectedRoute) throw AppError.internal(`Fastify selected route "${route.path}" without its τjs route identity`);
-
-        await handleRender(req, reply, selectedRoute, processedConfigs, serviceRegistry, maps, {
-          debug: opts.debug,
-          logger,
-          viteDevServer,
-        });
-      });
-    }
-
-    app.setNotFoundHandler(async (req, reply) => {
+  // RFC 0010 (Q5): the implicit application shell is a τjs-created-host convenience only. Fastify
+  // keys not-found handlers by PREFIX, not scope, so an unprefixed child registering one either
+  // collides with a caller handler at boot or silently becomes the 404 owner for the whole server
+  // when the caller has none. A caller-owned host keeps its own not-found policy; a shell there
+  // requires an explicitly declared terminal wildcard page route.
+  if (!callerOwnedHost) {
+    scope.setNotFoundHandler(async (req, reply) => {
       await handleNotFound(
         req,
         reply,
@@ -237,36 +276,53 @@ export const SSRServer: FastifyPluginAsync<SSRServerOptions> = fp(
         },
       );
     });
+  }
 
-    app.setErrorHandler((err, req, reply) => {
-      const e = AppError.from(err);
-      const terminalLogger = getRequestContext(req)?.logger ?? logger;
+  // Scoped, not route-local: on a caller-owned host this belongs to the encapsulated child, so τjs
+  // pages, static, CSP reporting and introspection all convert errors the τjs way while the
+  // caller's own handler stays authoritative for the caller's routes. On a τjs-created host the
+  // owned scope IS the root, preserving today's whole-server behaviour.
+  scope.setErrorHandler((err, req, reply) => {
+    const e = AppError.from(err);
+    const terminalLogger = getRequestContext(req)?.logger ?? logger;
 
-      const alreadyLogged = !!(e as any)?.details && (e as any).details && (e as any).details.logged;
+    const alreadyLogged = !!(e as any)?.details && (e as any).details && (e as any).details.logged;
 
-      if (!alreadyLogged) {
-        terminalLogger.error(
-          {
-            kind: e.kind,
-            httpStatus: e.httpStatus,
-            ...(e.code ? { code: e.code } : {}),
-            ...(e.details ? { details: e.details } : {}),
-            method: req.method,
-            url: req.url,
-            route: (req as any).routeOptions?.url,
-            stack: e.stack,
-          },
-          e.message,
-        );
-      }
+    if (!alreadyLogged) {
+      terminalLogger.error(
+        {
+          kind: e.kind,
+          httpStatus: e.httpStatus,
+          ...(e.code ? { code: e.code } : {}),
+          ...(e.details ? { details: e.details } : {}),
+          method: req.method,
+          url: req.url,
+          route: (req as any).routeOptions?.url,
+          stack: e.stack,
+        },
+        e.message,
+      );
+    }
 
-      if (!reply.raw.headersSent) {
-        const { status, body } = toHttp(e);
-        reply.status(status).send(body);
-      } else {
-        reply.raw.end();
-      }
-    });
-  },
-  { name: 'τjs-ssr-server' },
-);
+    if (!reply.raw.headersSent) {
+      const { status, body } = toHttp(e);
+      reply.status(status).send(body);
+    } else {
+      reply.raw.end();
+    }
+  });
+};
+
+/**
+ * RFC 0010: one plugin, two registration forms.
+ *
+ * The ownership fact drives `fastify-plugin`'s own `encapsulate` switch, so the code reads as the
+ * ruled thesis: a caller-supplied instance gets an encapsulated child, and an instance τjs created
+ * gets the complete experience installed at its root. Both forms are wrapped, so the plugin is named
+ * in the host's plugin tree either way - registration is visible, policy is not.
+ */
+export const ssrServerPlugin = ({ callerOwnedHost }: { callerOwnedHost: boolean }): FastifyPluginAsync<SSRServerOptions> =>
+  fp(async (scope: FastifyInstance, opts: SSRServerOptions) => installOwnedScope(scope, opts, callerOwnedHost), {
+    name: 'τjs-ssr-server',
+    encapsulate: callerOwnedHost,
+  });

--- a/packages/server/src/test/CreateServer.test.ts
+++ b/packages/server/src/test/CreateServer.test.ts
@@ -124,8 +124,16 @@ vi.mock('../security/VerifyMiddleware', () => ({
 
 let ssrShouldThrow = false;
 const SSRServerPlugin = Symbol('SSRServerPlugin');
+// RFC 0010: `createServer` now selects a registration form rather than importing one plugin. The
+// factory is recorded so tests can assert which ownership mode was chosen, and still returns a
+// stable sentinel so the identity matching below is unchanged.
+const ssrServerPluginCalls: Array<{ callerOwnedHost: boolean }> = [];
 vi.mock('../SSRServer', () => ({
-  SSRServer: SSRServerPlugin,
+  ssrServerPlugin: (args: { callerOwnedHost: boolean }) => {
+    ssrServerPluginCalls.push(args);
+
+    return SSRServerPlugin;
+  },
 }));
 
 beforeEach(() => {
@@ -327,17 +335,17 @@ describe('createServer', () => {
       fastify: activeApp,
       logger: explicitLogger,
     });
-    let runtimeLogger = activeApp.register.mock.calls[1]?.[1]?.runtimeLogger;
+    let runtimeLogger = activeApp.register.mock.calls[0]?.[1]?.runtimeLogger;
     expect(runtimeLogger).toEqual(expect.objectContaining({ source: 'explicit', custom: explicitLogger }));
 
     activeApp.register.mockClear();
     await createServer({ config: minimalConfig, serviceRegistry: dummyRegistry, fastify: activeApp });
-    runtimeLogger = activeApp.register.mock.calls[1]?.[1]?.runtimeLogger;
+    runtimeLogger = activeApp.register.mock.calls[0]?.[1]?.runtimeLogger;
     expect(runtimeLogger).toEqual(expect.objectContaining({ source: 'fastify', custom: activeFastifyLogger }));
 
     const silentApp = { register: vi.fn(async () => undefined), log: { ...activeFastifyLogger, level: 'silent' } } as any;
     await createServer({ config: minimalConfig, serviceRegistry: dummyRegistry, fastify: silentApp });
-    runtimeLogger = silentApp.register.mock.calls[1]?.[1]?.runtimeLogger;
+    runtimeLogger = silentApp.register.mock.calls[0]?.[1]?.runtimeLogger;
     expect(runtimeLogger).toEqual(expect.objectContaining({ source: 'fallback', custom: undefined }));
   });
 
@@ -347,10 +355,13 @@ describe('createServer', () => {
 
     await createServer({ config: minimalConfig, serviceRegistry: dummyRegistry, fastify: app });
 
-    expect(app.register.mock.calls[1]?.[1]?.runtimeLogger).toEqual(expect.objectContaining({ source: 'fallback', custom: undefined }));
+    expect(app.register.mock.calls[0]?.[1]?.runtimeLogger).toEqual(expect.objectContaining({ source: 'fallback', custom: undefined }));
   });
 
-  it('when a Fastify instance is provided, returns only { net } (no app) and still registers plugins', async () => {
+  // RFC 0010 delta: a caller-owned host previously received the banner plugin as well as the SSR
+  // plugin. The banner is now τjs-created-host presentation, so a supplied instance receives exactly
+  // one registration - the encapsulated SSR scope - and no `onReady` hook or `showBanner` decoration.
+  it('when a Fastify instance is provided, returns only { net } (no app) and registers only the encapsulated SSR plugin', async () => {
     const { createServer } = await importer();
 
     const externalFastify = { register: vi.fn(registerMock) } as any;
@@ -363,8 +374,10 @@ describe('createServer', () => {
 
     expect(result).toEqual({ net: netResolved });
 
-    expect(registerMock).toHaveBeenNthCalledWith(1, bannerPluginMock, expect.any(Object));
-    expect(registerMock).toHaveBeenNthCalledWith(2, SSRServerPlugin, expect.any(Object));
+    expect(registerMock).toHaveBeenCalledTimes(1);
+    expect(registerMock).toHaveBeenNthCalledWith(1, SSRServerPlugin, expect.any(Object));
+    expect(registerMock).not.toHaveBeenCalledWith(bannerPluginMock, expect.anything());
+    expect(ssrServerPluginCalls.at(-1)).toEqual({ callerOwnedHost: true });
   });
 
   it('sets logger minLevel to "info" in production NODE_ENV', async () => {

--- a/packages/server/src/test/CreateServerEmission.test.ts
+++ b/packages/server/src/test/CreateServerEmission.test.ts
@@ -18,7 +18,7 @@ vi.mock('../core/introspection/EmitGraph', () => {
 });
 
 vi.mock('../SSRServer', () => ({
-  SSRServer: { __id: 'ssr-server-plugin' },
+  ssrServerPlugin: () => ({ __id: 'ssr-server-plugin' }),
 }));
 
 vi.mock('../network/Network', () => ({
@@ -72,7 +72,17 @@ describe('createServer — graph emission wiring (structural gate)', () => {
     expect(app.addHook).not.toHaveBeenCalled();
   });
 
-  it('development boot lazy-loads the module and registers emission with config + registry + logger', async () => {
+  // RFC 0010 delta: boot-graph emission used to be wired here, on whatever instance `createServer`
+  // was handed - which on a caller-owned host meant an `onListen` hook on the caller's root. It now
+  // registers inside the scope τjs owns, next to the dev files and recorder that share its
+  // lifecycle, so `createServer` neither loads the emission module nor registers a hook.
+  //
+  // This file can only prove the negative half, because it mocks the SSR plugin out. The positive
+  // half - that the owned scope acquired the registration and emits exactly once after a real
+  // `listen()` - is proved by `HostOwnershipDevelopment.test.ts` against a real Vite boot and the
+  // real graph artefact. Without that pairing, deleting the registration outright would leave every
+  // assertion here green.
+  it('development boot no longer wires emission here: the owned scope owns it', async () => {
     process.env.NODE_ENV = 'development';
     vi.resetModules();
     const { createServer } = await import('../CreateServer');
@@ -81,13 +91,9 @@ describe('createServer — graph emission wiring (structural gate)', () => {
 
     await createServer({ config, fastify: app, serviceRegistry });
 
-    expect(hoisted.emitGraphEvaluations).toBe(1);
-    expect(hoisted.registerBootGraphEmission).toHaveBeenCalledTimes(1);
-    const [calledApp, calledConfig, calledRegistry, calledLogger] = hoisted.registerBootGraphEmission.mock.calls[0]!;
-    expect(calledApp).toBe(app);
-    expect(calledConfig).toBe(config);
-    expect(calledRegistry).toBe(serviceRegistry);
-    expect(calledLogger).toBeTruthy();
+    expect(hoisted.emitGraphEvaluations).toBe(0);
+    expect(hoisted.registerBootGraphEmission).not.toHaveBeenCalled();
+    expect(app.addHook).not.toHaveBeenCalled();
   });
 
   it('a failing emission module degrades to a warning, never a failed boot', async () => {

--- a/packages/server/src/test/FastifyOwnershipArrangement.test.ts
+++ b/packages/server/src/test/FastifyOwnershipArrangement.test.ts
@@ -1,0 +1,290 @@
+// @vitest-environment node
+//
+// RFC 0010: the Fastify mechanics the host-ownership arrangement depends on.
+//
+// Plain Fastify only - no τjs. Every assertion here is a property of Fastify or fastify-plugin
+// rather than something τjs implements, so if either changes this file fails before the product
+// suite does and names the reason.
+
+import { createRequire } from 'node:module';
+
+import fastify from 'fastify';
+import fp from 'fastify-plugin';
+import { describe, expect, it } from 'vitest';
+
+import type { FastifyInstance } from 'fastify';
+
+const require = createRequire(import.meta.url);
+const FASTIFY_BASELINE = '5.10.0';
+const FASTIFY_PLUGIN_BASELINE = '5.1.0';
+const SKIP_OVERRIDE = Symbol.for('skip-override');
+const REGISTERED_PLUGINS = Symbol.for('registered-plugin');
+const PLUGIN_NAME = 'rfc0010-owned-scope';
+
+type Branded = Record<symbol, unknown>;
+
+/** The shipped arrangement: one body, and the ownership fact drives Fastify's own encapsulation switch. */
+const ownedScopePlugin = ({ callerOwnedHost }: { callerOwnedHost: boolean }) =>
+  fp(
+    async (scope: FastifyInstance) => {
+      scope.decorate('ownedMark', callerOwnedHost ? 'embedded' : 'created');
+      scope.decorateRequest('ownedCtx', null);
+      scope.addHook('onRequest', async (request) => {
+        (request as never as { ownedCtx?: string }).ownedCtx = 'owned';
+      });
+      scope.setErrorHandler(async (error: Error, _request, reply) => reply.status(500).send({ owner: 'owned', message: error.message }));
+      scope.get('/owned-page', async (request) => ({ owner: 'owned', ctx: (request as never as { ownedCtx?: string }).ownedCtx }));
+      scope.get('/owned-boom', async () => {
+        throw new Error('owned-boom');
+      });
+    },
+    { name: PLUGIN_NAME, encapsulate: callerOwnedHost },
+  );
+
+const closing = async <T>(app: FastifyInstance, run: () => Promise<T>): Promise<T> => {
+  try {
+    return await run();
+  } finally {
+    await app.close();
+  }
+};
+
+describe('RFC 0010 - Fastify ownership arrangement', () => {
+  it('pins the Fastify and fastify-plugin versions this arrangement was measured against', () => {
+    expect((require('fastify/package.json') as { version: string }).version).toBe(FASTIFY_BASELINE);
+    // `encapsulate` is a fastify-plugin v5 option and the whole design rests on it.
+    expect((require('fastify-plugin/package.json') as { version: string }).version).toBe(FASTIFY_PLUGIN_BASELINE);
+  });
+
+  it('fp() brands the function it is given, which is why no bare-function variant exists', async () => {
+    const installer = async (scope: FastifyInstance) => {
+      scope.decorate('sharedMark', true);
+    };
+
+    expect((installer as never as Branded)[SKIP_OVERRIDE]).toBeUndefined();
+
+    const wrapped = fp(installer, { name: 'rfc0010-shared-installer' });
+
+    // fastify-plugin mutates its input and returns that same reference, so registering the "raw"
+    // object afterwards silently stops encapsulating. The shipped arrangement avoids the shape
+    // entirely by wrapping in both modes and varying `encapsulate`.
+    expect((installer as never as Branded)[SKIP_OVERRIDE]).toBe(true);
+    expect(wrapped).toBe(installer);
+
+    const leaked = fastify({ logger: false });
+    await closing(leaked, async () => {
+      await leaked.register(installer);
+      await leaked.ready();
+      expect(Object.prototype.hasOwnProperty.call(leaked, 'sharedMark')).toBe(true);
+    });
+  });
+
+  it('encapsulate: true isolates hooks, decorators and the error handler from the caller root', async () => {
+    const app = fastify({ logger: false });
+
+    app.decorate('authenticate', async () => undefined);
+    app.setErrorHandler(async (error: Error, _request, reply) => reply.status(599).send({ owner: 'caller', message: error.message }));
+    app.setNotFoundHandler(async (_request, reply) => reply.status(404).send({ owner: 'caller-not-found' }));
+    app.get('/host-before', async (request) => ({ owner: 'caller', ctx: (request as never as { ownedCtx?: string }).ownedCtx ?? 'none' }));
+    app.get('/host-before-error', async () => {
+      throw new Error('caller-before-boom');
+    });
+
+    await app.register(ownedScopePlugin({ callerOwnedHost: true }));
+
+    app.get('/host-after', async (request) => ({ owner: 'caller', ctx: (request as never as { ownedCtx?: string }).ownedCtx ?? 'none' }));
+    app.get('/host-after-error', async () => {
+      throw new Error('caller-after-boom');
+    });
+
+    await closing(app, async () => {
+      await app.ready();
+
+      // Caller routes keep their own everything, declared before or after registration.
+      for (const url of ['/host-before', '/host-after']) {
+        expect(JSON.parse((await app.inject(url)).body)).toEqual({ owner: 'caller', ctx: 'none' });
+      }
+      for (const url of ['/host-before-error', '/host-after-error']) {
+        const response = await app.inject(url);
+        expect(response.statusCode).toBe(599);
+        expect(JSON.parse(response.body).owner).toBe('caller');
+      }
+      expect(JSON.parse((await app.inject('/nope')).body)).toEqual({ owner: 'caller-not-found' });
+
+      // The owned scope keeps its own lifecycle.
+      expect(JSON.parse((await app.inject('/owned-page')).body)).toEqual({ owner: 'owned', ctx: 'owned' });
+      const ownedError = await app.inject('/owned-boom');
+      expect(ownedError.statusCode).toBe(500);
+      expect(JSON.parse(ownedError.body).owner).toBe('owned');
+
+      // Decorations stay in the child, but the plugin is still named in the host's tree: registration
+      // is visible, policy is not.
+      expect('ownedMark' in app).toBe(false);
+      expect((app as never as Record<symbol, string[]>)[REGISTERED_PLUGINS]).toContain(PLUGIN_NAME);
+      expect(app.printPlugins()).toContain(PLUGIN_NAME);
+    });
+  });
+
+  it('the encapsulated child inherits caller decorators, so auth delegation still works', async () => {
+    const app = fastify({ logger: false });
+    app.decorate('authenticate', async () => undefined);
+    app.decorate('callerThing', 'from-caller');
+
+    await app.register(
+      fp(
+        async (scope: FastifyInstance) => {
+          scope.get('/probe', async () => ({
+            authenticate: typeof (scope as never as { authenticate?: unknown }).authenticate,
+            callerThing: (scope as never as { callerThing?: string }).callerThing,
+          }));
+        },
+        { name: 'rfc0010-inheritance-probe', encapsulate: true },
+      ),
+    );
+
+    await closing(app, async () => {
+      await app.ready();
+      expect(JSON.parse((await app.inject('/probe')).body)).toEqual({ authenticate: 'function', callerThing: 'from-caller' });
+    });
+  });
+
+  it('encapsulate: false installs at the owned root, giving the created-host experience', async () => {
+    const app = fastify({ logger: false });
+
+    // A route captures the error handler present when it is registered, so anything declared before
+    // the installer keeps Fastify's default. Unreachable for a τjs-created host, which constructs
+    // the instance and registers immediately, but pinned so the ordering property is documented.
+    app.get('/root-before', async () => {
+      throw new Error('root-before-boom');
+    });
+
+    await app.register(ownedScopePlugin({ callerOwnedHost: false }));
+
+    // A created host hands `app` back after createServer resolves, so real caller routes land here
+    // and inherit the owned handler. That is the complete experience.
+    app.get('/root-after', async () => {
+      throw new Error('root-after-boom');
+    });
+
+    await closing(app, async () => {
+      await app.ready();
+
+      expect(JSON.parse((await app.inject('/owned-page')).body)).toEqual({ owner: 'owned', ctx: 'owned' });
+
+      const afterError = await app.inject('/root-after');
+      expect(afterError.statusCode).toBe(500);
+      expect(JSON.parse(afterError.body).owner).toBe('owned');
+
+      const beforeError = await app.inject('/root-before');
+      expect(beforeError.statusCode).toBe(500);
+      expect(JSON.parse(beforeError.body).owner).toBeUndefined();
+
+      expect('ownedMark' in app).toBe(true);
+      expect(app.printPlugins()).toContain(PLUGIN_NAME);
+    });
+  });
+
+  it('a scoped error handler boots under allowErrorHandlerOverride: false and covers every route in its scope', async () => {
+    const app = fastify({ allowErrorHandlerOverride: false, logger: false });
+
+    app.setErrorHandler(async (error: Error, _request, reply) => reply.status(599).send({ owner: 'caller', message: error.message }));
+
+    await expect(
+      app.register(
+        fp(
+          async (scope: FastifyInstance) => {
+            scope.setErrorHandler(async (error: Error, _request, reply) => reply.status(500).send({ owner: 'owned', message: error.message }));
+            // Stands in for the τjs facilities sharing the owned scope: pages, static, CSP report,
+            // introspection. All must inherit the scoped handler, not the caller's.
+            scope.get('/owned-page', async () => {
+              throw new Error('page-boom');
+            });
+            await scope.register(async (nested) => {
+              nested.get('/owned-facility', async () => {
+                throw new Error('facility-boom');
+              });
+            });
+          },
+          { name: 'rfc0010-strict-scope', encapsulate: true },
+        ),
+      ),
+    ).resolves.not.toThrow();
+
+    await closing(app, async () => {
+      await app.ready();
+
+      for (const url of ['/owned-page', '/owned-facility']) {
+        const response = await app.inject(url);
+        expect(response.statusCode).toBe(500);
+        expect(JSON.parse(response.body).owner).toBe('owned');
+      }
+    });
+  });
+
+  it('not-found handlers are keyed by prefix, so an unprefixed child cannot own one safely', async () => {
+    // With a caller handler present, registering one in the child is a hard boot failure.
+    const collides = fastify({ logger: false });
+    collides.setNotFoundHandler(async (_request, reply) => reply.status(404).send({ owner: 'caller-not-found' }));
+
+    await expect(
+      collides.register(
+        fp(
+          async (scope: FastifyInstance) => {
+            scope.setNotFoundHandler(async (_request, reply) => reply.status(404).send({ owner: 'owned-not-found' }));
+          },
+          { name: 'rfc0010-notfound-collision', encapsulate: true },
+        ),
+      ),
+    ).rejects.toThrow("Not found handler already set for Fastify instance with prefix: '/'");
+    await collides.close();
+
+    // With no caller handler, the child silently becomes the not-found owner for the whole server.
+    // This is why the installer registers one only in created mode.
+    const captures = fastify({ logger: false });
+    await captures.register(
+      fp(
+        async (scope: FastifyInstance) => {
+          scope.setNotFoundHandler(async (_request, reply) => reply.status(404).send({ owner: 'owned-not-found' }));
+        },
+        { name: 'rfc0010-notfound-capture', encapsulate: true },
+      ),
+    );
+
+    await closing(captures, async () => {
+      await captures.ready();
+      expect(JSON.parse((await captures.inject('/anything')).body)).toEqual({ owner: 'owned-not-found' });
+    });
+  });
+
+  it('only a root-level onRequest hook observes URLs Fastify did not route', async () => {
+    const app = fastify({ logger: false });
+    const rootSaw: string[] = [];
+    const childSaw: string[] = [];
+
+    app.addHook('onRequest', async (request) => {
+      rootSaw.push(request.url);
+    });
+    await app.register(
+      fp(
+        async (scope: FastifyInstance) => {
+          scope.addHook('onRequest', async (request) => {
+            childSaw.push(request.url);
+          });
+          scope.get('/owned-page', async () => ({ owner: 'owned' }));
+        },
+        { name: 'rfc0010-unrouted-probe', encapsulate: true },
+      ),
+    );
+
+    await closing(app, async () => {
+      await app.ready();
+      await app.inject('/owned-page');
+      await app.inject('/@vite/client');
+
+      // The whole reason `viteRequestHookOwner` exists: Vite must see unrouted development URLs,
+      // and an encapsulated hook never will.
+      expect(rootSaw).toEqual(['/owned-page', '/@vite/client']);
+      expect(childSaw).toEqual(['/owned-page']);
+    });
+  });
+});

--- a/packages/server/src/test/HostOwnership.test.ts
+++ b/packages/server/src/test/HostOwnership.test.ts
@@ -1,0 +1,260 @@
+// @vitest-environment node
+//
+// RFC 0010 permanent ownership regressions.
+//
+// > Bring your own Fastify and τjs respects it. Let τjs create Fastify and it provides the complete
+// > experience.
+//
+// Every case drives the real public `createServer` path. These replace the disposable P0 and
+// candidate proof matrices; the Fastify mechanics they rest on are pinned separately in
+// `FastifyOwnershipArrangement.test.ts`.
+//
+// Deliberately not protected here: development Vite delegation and introspection, which need a real
+// Vite server and are covered by the development suites; and cancellation, which RFC 0010 does not
+// touch and whose existing matrices run unchanged.
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createServer } from '../CreateServer';
+import {
+  CALLER_ASSET,
+  CALLER_ASSET_PATH,
+  CALLER_CSP,
+  CALLER_REQUEST_ID,
+  OWNER,
+  PATHS,
+  TAUJS_ASSET_PATH,
+  captureConsole,
+  closeAll,
+  createCreatedHost,
+  createDefaultNotFoundHost,
+  createEmbeddedHost,
+  createExplicitLoggerHost,
+  createStaticCoexistenceHost,
+  createStrictHost,
+  observe,
+  taujsConfig,
+} from './support/hostOwnership';
+
+afterEach(async () => {
+  await closeAll();
+});
+
+describe('RFC 0010 - caller-owned host', () => {
+  it('leaves caller responses, errors and not-found exactly as the caller declared them', async () => {
+    const host = await createEmbeddedHost();
+    await host.activate(createServer);
+
+    // Registered before and after τjs: ownership must not depend on registration order.
+    const before = observe(await host.app.inject(PATHS.callerBefore));
+    const after = observe(await host.app.inject(PATHS.callerAfter));
+    const beforeError = observe(await host.app.inject(PATHS.callerBeforeError));
+    const afterError = observe(await host.app.inject(PATHS.callerAfterError));
+    const missing = observe(await host.app.inject('/rfc0010-missing'));
+
+    expect(JSON.parse(before.body)).toEqual({ owner: OWNER.callerBefore });
+    expect(JSON.parse(after.body)).toEqual({ owner: OWNER.callerAfter });
+    expect({ status: before.status, type: before.type }).toEqual({ status: after.status, type: after.type });
+
+    for (const errored of [beforeError, afterError]) {
+      expect(errored.status).toBe(599);
+      expect(JSON.parse(errored.body).owner).toBe(OWNER.callerError);
+    }
+
+    expect(missing.status).toBe(404);
+    expect(JSON.parse(missing.body).owner).toBe(OWNER.callerNotFound);
+  });
+
+  it('gives caller responses no τjs CSP and no τjs trace header', async () => {
+    const host = await createEmbeddedHost();
+    await host.activate(createServer);
+
+    for (const url of [PATHS.callerBefore, PATHS.callerAfter, '/rfc0010-missing']) {
+      const response = observe(await host.app.inject(url));
+
+      expect(response.csp).toBe(CALLER_CSP);
+      expect(response.traceId).toBeUndefined();
+    }
+  });
+
+  it('owns its own page responses: render, CSP, trace and error conversion', async () => {
+    const host = await createEmbeddedHost();
+    await host.activate(createServer);
+
+    const page = observe(await host.app.inject(PATHS.taujsPage));
+    const failure = observe(await host.app.inject(PATHS.taujsFailure));
+
+    expect(page.status).toBe(200);
+    expect(page.body).toContain(`${OWNER.taujsPage}:${PATHS.taujsPage}`);
+    expect(page.csp).toContain("default-src 'rfc0010-taujs'");
+    expect(page.traceId).toBe(CALLER_REQUEST_ID);
+
+    // τjs converts its own failures; the caller's 599 handler is not reached.
+    expect(failure.status).toBe(500);
+    expect(JSON.parse(failure.body).owner).toBeUndefined();
+  });
+
+  it('does not install an implicit shell: unmatched, API-like and unsupported-method requests stay the caller´s', async () => {
+    const host = await createEmbeddedHost();
+    await host.activate(createServer);
+
+    const cases = [
+      await host.app.inject({ method: 'GET', url: '/rfc0010-missing', headers: { accept: 'text/html' } }),
+      await host.app.inject({ method: 'GET', url: '/api/rfc0010-missing', headers: { accept: 'application/json' } }),
+      await host.app.inject({ method: 'POST', url: PATHS.taujsPage }),
+    ];
+
+    for (const response of cases.map(observe)) {
+      expect(response.status).toBe(404);
+      expect(JSON.parse(response.body).owner).toBe(OWNER.callerNotFound);
+    }
+  });
+
+  it('never becomes the not-found owner when the caller declared none', async () => {
+    // The silent failure mode: Fastify keys not-found handlers by prefix, so a τjs scope registering
+    // one would answer every unmatched URL on the caller's server.
+    const host = await createDefaultNotFoundHost();
+    await host.activate(createServer);
+
+    const missing = observe(await host.app.inject('/rfc0010-missing'));
+
+    expect(missing.status).toBe(404);
+    expect(missing.type).toContain('application/json');
+    expect(JSON.parse(missing.body)).toMatchObject({ error: 'Not Found', statusCode: 404 });
+    expect(missing.body).not.toContain(OWNER.taujsPage);
+    expect(missing.csp).toBeUndefined();
+    expect(missing.traceId).toBeUndefined();
+  });
+
+  it('renders an explicitly declared terminal wildcard as an ordinary τjs page', async () => {
+    const host = await createEmbeddedHost();
+    await host.activate(createServer, taujsConfig({ wildcard: true }));
+
+    for (const url of ['/rfc0010-document', '/api/rfc0010', '/rfc0010-logo.png']) {
+      const response = observe(await host.app.inject(url));
+
+      expect(response.status).toBe(200);
+      expect(response.body).toContain(`${OWNER.taujsPage}:${url}`);
+    }
+  });
+
+  it('boots under allowErrorHandlerOverride: false without replacing the caller handler', async () => {
+    const host = await createStrictHost();
+
+    await expect(host.activate(createServer)).resolves.toBeTruthy();
+
+    expect(JSON.parse(observe(await host.app.inject(PATHS.callerBeforeError)).body).owner).toBe(OWNER.callerError);
+    expect(observe(await host.app.inject(PATHS.taujsFailure)).status).toBe(500);
+  });
+
+  it('writes no presentation to stdout and prefers an explicit logger', async () => {
+    const host = await createExplicitLoggerHost();
+    const output = captureConsole();
+
+    try {
+      await host.activate(createServer);
+    } finally {
+      output.restore();
+    }
+
+    expect(output.records).toEqual([]);
+    expect(host.logs.length).toBeGreaterThan(0);
+  });
+
+  it('appears in the caller´s plugin tree: registration is visible, policy is not', async () => {
+    const host = await createEmbeddedHost();
+    await host.activate(createServer);
+    await host.app.ready();
+
+    expect(host.app.printPlugins()).toContain('τjs-ssr-server');
+    // ...while owning nothing of the caller's lifecycle.
+    expect(Object.prototype.hasOwnProperty.call(host.app, 'taujsIntrospection')).toBe(false);
+  });
+
+  it('fails at boot on an exact page collision rather than silently taking the route', async () => {
+    const host = await createEmbeddedHost();
+    host.app.get(PATHS.taujsPage, async () => ({ owner: OWNER.callerBefore }));
+
+    await expect(host.activate(createServer)).rejects.toMatchObject({ code: 'FST_ERR_DUPLICATED_ROUTE' });
+  });
+
+  it('boots alongside a caller that already registered @fastify/static, and both facilities keep working', async () => {
+    // P0's headline failure: τjs decorated `sendFile` on the caller root and this combination could
+    // not boot at all. Encapsulation fixes it, but that is proved here rather than inferred.
+    const host = await createStaticCoexistenceHost();
+
+    await expect(host.activate(createServer)).resolves.toBeTruthy();
+
+    const callerAsset = observe(await host.app.inject(CALLER_ASSET_PATH));
+    const taujsAsset = observe(await host.app.inject(TAUJS_ASSET_PATH));
+    const page = observe(await host.app.inject(PATHS.taujsPage));
+
+    expect(callerAsset.status).toBe(200);
+    expect(callerAsset.body).toContain(CALLER_ASSET);
+
+    expect(taujsAsset.status).toBe(200);
+    expect(taujsAsset.body).toContain(OWNER.taujsPage);
+
+    expect(page.status).toBe(200);
+    expect(page.body).toContain(`${OWNER.taujsPage}:${PATHS.taujsPage}`);
+  });
+
+  it('still fails at boot when caller static and a declared τjs wildcard claim the same route', async () => {
+    // Kept separate and expected: `@fastify/static` defaults `wildcard` to true, claiming `GET /*`
+    // on the caller root. A declared τjs `/*` page is then a genuine exact route collision, and
+    // Fastify's router is global so encapsulation does not and should not hide it. The fix is
+    // `wildcard: false` on the caller mount or non-overlapping patterns, never registration order.
+    const host = await createStaticCoexistenceHost({ wildcard: true });
+
+    await expect(host.activate(createServer, taujsConfig({ wildcard: true }))).rejects.toMatchObject({ code: 'FST_ERR_DUPLICATED_ROUTE' });
+  });
+
+  it('keeps route payloads out of the selected logger', async () => {
+    const host = await createExplicitLoggerHost();
+    await host.activate(createServer);
+
+    const secret = observe(await host.app.inject(PATHS.taujsSecret));
+
+    expect(secret.body).toContain(OWNER.taujsSecret);
+    expect(JSON.stringify(host.logs)).not.toContain(OWNER.taujsSecret);
+  });
+});
+
+describe('RFC 0010 - τjs-created host', () => {
+  it('returns an app that is not yet listening and keeps the whole-server experience', async () => {
+    const host = await createCreatedHost();
+    const output = captureConsole();
+    let result: { app?: unknown };
+
+    try {
+      result = await host.activate(createServer);
+    } finally {
+      output.restore();
+    }
+
+    const app = host.app()!;
+
+    expect(result.app).toBe(app);
+    expect(app.server.listening).toBe(false);
+    // Presentation is a created-host convenience and stays.
+    expect(output.records.some((record) => record.args.join(' ').includes('configured in'))).toBe(true);
+
+    const page = observe(await app.inject(PATHS.taujsPage));
+    const hostRoute = observe(await app.inject(PATHS.createdHost));
+
+    expect(page.body).toContain(OWNER.taujsPage);
+    // Routes the caller adds to the instance τjs created inherit whole-server CSP and trace.
+    expect(hostRoute.csp).toContain("default-src 'rfc0010-taujs'");
+    expect(hostRoute.traceId).toBeTruthy();
+  });
+
+  it('retains the implicit application shell for unmatched URLs', async () => {
+    const host = await createCreatedHost();
+    await host.activate(createServer);
+
+    const missing = observe(await host.app()!.inject({ method: 'GET', url: '/rfc0010-missing', headers: { accept: 'text/html' } }));
+
+    expect(missing.status).toBe(200);
+    expect(missing.type).toContain('text/html');
+  });
+});

--- a/packages/server/src/test/HostOwnership.test.ts
+++ b/packages/server/src/test/HostOwnership.test.ts
@@ -21,6 +21,7 @@ import {
   CALLER_ASSET_PATH,
   CALLER_CSP,
   CALLER_REQUEST_ID,
+  NUMERIC_REQUEST_ID,
   OWNER,
   PATHS,
   TAUJS_ASSET_PATH,
@@ -30,6 +31,7 @@ import {
   createDefaultNotFoundHost,
   createEmbeddedHost,
   createExplicitLoggerHost,
+  createNumericRequestIdHost,
   createStaticCoexistenceHost,
   createStrictHost,
   observe,
@@ -207,6 +209,20 @@ describe('RFC 0010 - caller-owned host', () => {
     const host = await createStaticCoexistenceHost({ wildcard: true });
 
     await expect(host.activate(createServer, taujsConfig({ wildcard: true }))).rejects.toMatchObject({ code: 'FST_ERR_DUPLICATED_ROUTE' });
+  });
+
+  it('adopts the host request identity for its trace, including a numeric genReqId', async () => {
+    // Correlation is the point: a caller's own records bind `reqId`, τjs binds the same value as
+    // `traceId`, so the two sides join. A counter-based `genReqId` returns a number, and a
+    // string-only guard silently substituted a random UUID here.
+    const host = await createNumericRequestIdHost();
+    await host.activate(createServer);
+
+    const page = observe(await host.app.inject(PATHS.taujsPage));
+
+    expect(page.traceId).toBe(String(NUMERIC_REQUEST_ID));
+    expect(page.traceId).not.toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-/);
+    expect(JSON.stringify(host.logs)).toContain(String(NUMERIC_REQUEST_ID));
   });
 
   it('keeps route payloads out of the selected logger', async () => {

--- a/packages/server/src/test/HostOwnershipDevelopment.test.ts
+++ b/packages/server/src/test/HostOwnershipDevelopment.test.ts
@@ -1,0 +1,173 @@
+// @vitest-environment node
+//
+// RFC 0010 development ownership regressions: gates 3, 5 and 7 of the implementation plan.
+//
+// One real development boot proves the whole seam, because a real Vite server is expensive and the
+// assertions all depend on the same running host:
+//
+//   - the single caller-root Vite hook serves URLs Fastify did not route;
+//   - a caller route is unchanged by τjs being present;
+//   - boot-graph emission registers once inside the owned scope and reaches its terminal after a
+//     real `listen()`;
+//   - `app.close()` closes the real Vite server exactly once.
+//
+// Vite and the graph emitter are wrapped, never replaced: both call through to the real
+// implementation so the lifecycle assertions cannot pass vacuously.
+
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import fastify from 'fastify';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { CALLER_CSP, OWNER, PATHS, closeAll, developmentFixture, observe, taujsConfig } from './support/hostOwnership';
+
+import type { FastifyInstance } from 'fastify';
+
+const viteInstrument = vi.hoisted(() => ({ closeCount: 0 }));
+const graphInstrument = vi.hoisted(() => ({ registrations: 0 }));
+
+vi.mock('vite', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vite')>();
+
+  return {
+    ...actual,
+    // Wraps the REAL server so close counting measures real teardown.
+    createServer: async (...args: Parameters<typeof actual.createServer>) => {
+      const server = await actual.createServer(...args);
+      const close = server.close.bind(server);
+
+      server.close = async () => {
+        viteInstrument.closeCount += 1;
+
+        return close();
+      };
+
+      return server;
+    },
+  };
+});
+
+vi.mock('../core/introspection/EmitGraph', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../core/introspection/EmitGraph')>();
+
+  return {
+    ...actual,
+    registerBootGraphEmission: (...args: Parameters<typeof actual.registerBootGraphEmission>) => {
+      graphInstrument.registrations += 1;
+      actual.registerBootGraphEmission(...args);
+      // Registered immediately after the real emitter, so awaiting this resolves only once the
+      // graph hook itself has completed. Sampling when `listen()` resolves would be premature.
+      args[0].addHook('onListen', async () => {
+        graphTerminal.resolve();
+      });
+    },
+  };
+});
+
+let graphTerminal: { promise: Promise<void>; resolve: () => void };
+const freshTerminal = () => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+
+  graphTerminal = { promise, resolve };
+};
+freshTerminal();
+
+const loadDevelopmentCreateServer = async () => {
+  const original = process.env.NODE_ENV;
+  process.env.NODE_ENV = 'development';
+  vi.resetModules();
+
+  try {
+    return (await import('../CreateServer')).createServer;
+  } finally {
+    process.env.NODE_ENV = original;
+  }
+};
+
+const buildCallerHost = (): FastifyInstance => {
+  const app = fastify({ logger: false });
+
+  app.decorate('authenticate', async () => undefined);
+  app.addHook('onRequest', (_request, reply, done) => {
+    reply.header('Content-Security-Policy', CALLER_CSP);
+    done();
+  });
+  app.get(PATHS.callerBefore, async () => ({ owner: OWNER.callerBefore }));
+  app.setNotFoundHandler(async (_request, reply) => reply.status(404).type('application/json').send({ owner: OWNER.callerNotFound }));
+
+  return app;
+};
+
+/** The plan's frozen comparison fields. Volatile headers are excluded deliberately. */
+const frozen = (response: Parameters<typeof observe>[0]) => {
+  const seen = observe(response);
+
+  return { status: seen.status, body: seen.body, type: seen.type, csp: seen.csp, traceId: seen.traceId };
+};
+
+afterEach(async () => {
+  await closeAll();
+});
+
+describe('RFC 0010 - caller-owned development host', () => {
+  it('serves Vite, leaves caller routes untouched, emits the graph once and closes Vite once', async () => {
+    const cwd = process.cwd();
+    const { root, clientRoot } = await developmentFixture();
+    const closesBefore = viteInstrument.closeCount;
+    const registrationsBefore = graphInstrument.registrations;
+
+    freshTerminal();
+
+    // Control: the same caller host with τjs absent, for the frozen-field comparison.
+    const control = buildCallerHost();
+    await control.ready();
+    const controlRoute = frozen(await control.inject(PATHS.callerBefore));
+    await control.close();
+
+    const app = buildCallerHost();
+    process.chdir(root);
+
+    try {
+      const createServer = await loadDevelopmentCreateServer();
+      await createServer({ config: taujsConfig(), fastify: app, clientRoot, projectRoot: root, debug: ['ssr'] });
+
+      // Gate 5: a real listener, then wait for the emission terminal rather than for listen().
+      await app.listen({ host: '127.0.0.1', port: 0 });
+      await graphTerminal.promise;
+
+      expect(graphInstrument.registrations - registrationsBefore).toBe(1);
+
+      const graphPath = path.resolve(root, 'node_modules', '.taujs', 'graph.json');
+      expect(existsSync(graphPath)).toBe(true);
+      expect(JSON.parse(await readFile(graphPath, 'utf8'))).toMatchObject({ source: 'boot' });
+
+      // Gate 3a: the single caller-root hook reaches a URL Fastify routed nowhere, and Vite answers
+      // with its actual client module rather than merely a 200.
+      const viteClient = await app.inject('/@vite/client');
+      expect(viteClient.statusCode).toBe(200);
+      expect(viteClient.headers['content-type']).toContain('javascript');
+      expect(viteClient.body).toMatch(/createHotContext|__vite__|HMRClient/);
+
+      // Gate 3b: the caller's own route is behaviourally equivalent to τjs being absent, compared on
+      // the frozen fields. Not literal byte identity: volatile headers are excluded deliberately,
+      // because request IDs and runtime metadata would make this flaky without indicating leakage.
+      expect(frozen(await app.inject(PATHS.callerBefore))).toEqual(controlRoute);
+
+      // ...while τjs still owns its declared page.
+      const page = observe(await app.inject(PATHS.taujsPage));
+      expect(page.status).toBe(200);
+      expect(page.body).toContain(OWNER.taujsPage);
+    } finally {
+      process.chdir(cwd);
+      // Gate 7: not swallowed - a close failure must fail the test, not disappear.
+      await app.close();
+    }
+
+    expect(viteInstrument.closeCount - closesBefore).toBe(1);
+  }, 30_000);
+});

--- a/packages/server/src/test/RuntimeLoggerFallthrough.test.ts
+++ b/packages/server/src/test/RuntimeLoggerFallthrough.test.ts
@@ -41,12 +41,17 @@ describe('runtime logger fallthrough (real development server)', () => {
         bindings: {
           traceId: 'fallthrough-selected-logger-trace',
           reqId: 'fallthrough-fastify-request',
-          url: '/unmatched-page',
+          url: '/',
           method: 'GET',
         },
-        meta: { status: 200, category: 'ssr' },
-        message: 'Sending not-found fallback HTML',
+        meta: { category: 'ssr' },
+        message: 'ssr requested',
       },
+      // RFC 0010 (Q5/Q6) delta: the child supplies its own Fastify, so an unmatched URL belongs to
+      // the caller. It previously received a τjs 200 shell and a τjs trace header; it now falls to
+      // the caller's own not-found policy and opens no τjs trace episode.
+      unmatchedStatus: 404,
     });
+    expect(evidence.unmatchedTraceId).toBeUndefined();
   });
 });

--- a/packages/server/src/test/SSRServer.test.ts
+++ b/packages/server/src/test/SSRServer.test.ts
@@ -69,7 +69,10 @@ const {
   const handleNotFoundMock = vi.fn(async (_req: any, reply: any) => {
     reply.status(200).send('OK:notFound');
   });
-  const setupDevServerMock = vi.fn(async () => ({ name: 'vite-dev' }));
+  // RFC 0010: τjs creates the Vite server, so τjs closes it on Fastify closure. The double models
+  // that contract - a real `ViteDevServer` always has `close()`, and the product deliberately calls
+  // it unguarded so a missing close surfaces here rather than passing vacuously.
+  const setupDevServerMock = vi.fn(async () => ({ name: 'vite-dev', close: vi.fn(async () => undefined) }));
   const toHttpMock = vi.fn((_e: any) => ({ status: 499, body: { message: 'safe' } }));
   const resolveRouteDataMock = vi.fn<() => Promise<Record<string, unknown>>>(async () => ({ userId: 123, name: 'Test' }));
 
@@ -147,7 +150,12 @@ vi.mock('../utils/VitePlugins', () => ({
   reservedPluginMessage: (d: any) => `reserved:${d.name}`,
 }));
 
-import { SSRServer, TEMPLATE } from '../SSRServer';
+import { ssrServerPlugin, TEMPLATE } from '../SSRServer';
+
+// RFC 0010: this suite predates the ownership split and was written against the root-installing
+// plugin, so every registration below uses the τjs-created form. Caller-owned behaviour is proved
+// by the permanent ownership regressions, which drive the real public `createServer` path.
+const SSRServer = ssrServerPlugin({ callerOwnedHost: false });
 import { loadAssets } from '../utils/AssetManager';
 import { createAuthHook } from '../security/Auth';
 import { createLogger } from '../logging/Logger';

--- a/packages/server/src/test/SSRServerTraceContext.test.ts
+++ b/packages/server/src/test/SSRServerTraceContext.test.ts
@@ -42,9 +42,11 @@ vi.mock('../utils/AssetManager', () => ({
 vi.mock('../utils/StaticAssets', () => ({ registerStaticAssets: vi.fn(async () => {}) }));
 
 async function buildApp() {
-  const { SSRServer } = await import('../SSRServer');
+  const { ssrServerPlugin } = await import('../SSRServer');
   const app = fastify();
-  await app.register(SSRServer as any, {
+  // RFC 0010: this suite was written against the root-installing plugin, so the faithful
+  // translation is the τjs-created form. Trace context on τjs routes is identical in both.
+  await app.register(ssrServerPlugin({ callerOwnedHost: false }) as any, {
     configs: [{ appId: 'web', entryPoint: 'web' }],
     routes: [{ path: '/page', appId: 'web', attr: { render: 'ssr' } }],
     clientRoot: '/tmp/none',

--- a/packages/server/src/test/support/RuntimeLoggerFallthrough.child.ts
+++ b/packages/server/src/test/support/RuntimeLoggerFallthrough.child.ts
@@ -54,17 +54,27 @@ try {
     projectRoot: fixtureRoot,
   });
 
+  // RFC 0010: this child supplies its own Fastify, so τjs owns only its declared page routes. The
+  // logger-lineage evidence therefore rides a τjs-owned response rather than the implicit shell,
+  // which a caller-owned host no longer installs.
   const response = await app.inject({
     method: 'GET',
-    url: '/unmatched-page',
+    url: '/',
     headers: { 'x-trace-id': traceId },
   });
-  const record = records.find((candidate) => candidate.message === 'Sending not-found fallback HTML');
+  const record = records.find((candidate) => candidate.message === 'ssr requested');
+
+  // The same request matrix now also proves the ruled ownership delta: an unmatched URL is the
+  // caller's, gets no τjs shell and opens no τjs trace episode.
+  const unmatched = await app.inject({ method: 'GET', url: '/unmatched-page', headers: { 'x-trace-id': traceId } });
+
   const result = {
     status: response.statusCode,
     responseTraceId: response.headers['x-trace-id'],
     record,
-    recordCount: records.filter((candidate) => candidate.message === 'Sending not-found fallback HTML').length,
+    recordCount: records.filter((candidate) => candidate.message === 'ssr requested').length,
+    unmatchedStatus: unmatched.statusCode,
+    unmatchedTraceId: unmatched.headers['x-trace-id'],
   };
 
   process.stdout.write(`${RESULT_PREFIX}${JSON.stringify(result)}\n`);
@@ -77,8 +87,10 @@ try {
     record?.level === 'debug' &&
     record.bindings.traceId === traceId &&
     record.bindings.reqId === 'fallthrough-fastify-request' &&
-    record.bindings.url === '/unmatched-page' &&
-    record.bindings.method === 'GET';
+    record.bindings.url === '/' &&
+    record.bindings.method === 'GET' &&
+    result.unmatchedStatus === 404 &&
+    result.unmatchedTraceId === undefined;
 
   process.exit(passed ? 0 : 1);
 } catch (error) {

--- a/packages/server/src/test/support/hostOwnership.ts
+++ b/packages/server/src/test/support/hostOwnership.ts
@@ -45,6 +45,8 @@ export const PATHS = Object.freeze({
 export const CALLER_CSP = "default-src 'rfc0010-caller'";
 export const TAUJS_CSP_DIRECTIVE = "default-src 'rfc0010-taujs'";
 export const CALLER_REQUEST_ID = 'rfc0010-caller-request-id';
+/** A numeric request identity, which `genReqId` may legitimately return. */
+export const NUMERIC_REQUEST_ID = 4242;
 
 export type Observation = {
   status: number;
@@ -219,6 +221,7 @@ type CallerHostShape = {
   callerNotFound?: boolean;
   callerCsp?: boolean;
   explicitLogger?: boolean;
+  numericRequestId?: boolean;
 };
 
 const buildCallerHost = async (shape: CallerHostShape): Promise<CallerHost> => {
@@ -227,7 +230,7 @@ const buildCallerHost = async (shape: CallerHostShape): Promise<CallerHost> => {
   const app = track(
     fastify({
       logger: false,
-      genReqId: () => CALLER_REQUEST_ID,
+      genReqId: shape.numericRequestId ? () => NUMERIC_REQUEST_ID as unknown as string : () => CALLER_REQUEST_ID,
       ...(shape.strictErrorHandler ? { allowErrorHandlerOverride: false } : {}),
     }),
   );
@@ -288,6 +291,15 @@ export const createStrictHost = (): Promise<CallerHost> => buildCallerHost({ str
 
 /** A caller-owned host passing an explicit τjs logger, which must win over any Fastify logger. */
 export const createExplicitLoggerHost = (): Promise<CallerHost> => buildCallerHost({ explicitLogger: true });
+
+/**
+ * A caller-owned host whose `genReqId` returns a number.
+ *
+ * τjs adopts the host's request identity so both sides' records join on one value. A string-only
+ * guard used to fall through to a random UUID here, silently breaking that correlation, which is
+ * exactly the case a counter-based `genReqId` produces.
+ */
+export const createNumericRequestIdHost = (): Promise<CallerHost> => buildCallerHost({ numericRequestId: true, explicitLogger: true });
 
 /**
  * A caller-owned host with NO not-found handler of its own, and no caller static mount.

--- a/packages/server/src/test/support/hostOwnership.ts
+++ b/packages/server/src/test/support/hostOwnership.ts
@@ -1,0 +1,362 @@
+// RFC 0010 permanent ownership support.
+//
+// Deliberately smaller than the disposable candidate harness it descends from: named host factories
+// rather than a free-form option vector, so a regression cannot quietly change the host it is
+// measuring. Everything here drives the real public `createServer` path.
+
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import fastify from 'fastify';
+
+import { testRenderer } from './renderer';
+
+import type { FastifyInstance } from 'fastify';
+import type { TaujsConfig } from '../../Config';
+import type { BaseLogger } from '../../core/logging/types';
+import type { createServer } from '../../CreateServer';
+
+export type CreateServerFn = typeof createServer;
+
+/** Fixed markers so a response names its owner rather than merely succeeding. */
+export const OWNER = Object.freeze({
+  callerBefore: 'RFC0010_CALLER_BEFORE',
+  callerAfter: 'RFC0010_CALLER_AFTER',
+  callerError: 'RFC0010_CALLER_ERROR',
+  callerNotFound: 'RFC0010_CALLER_NOT_FOUND',
+  createdHost: 'RFC0010_CREATED_HOST',
+  taujsPage: 'RFC0010_TAUJS_PAGE',
+  taujsSecret: 'RFC0010_LOG_SECRET',
+});
+
+export const PATHS = Object.freeze({
+  callerBefore: '/host-before',
+  callerAfter: '/host-after',
+  callerBeforeError: '/host-before-error',
+  callerAfterError: '/host-after-error',
+  createdHost: '/created-host',
+  taujsPage: '/taujs-page',
+  taujsFailure: '/taujs-failure',
+  taujsSecret: '/taujs-secret',
+  taujsNoCsp: '/taujs-no-csp',
+});
+
+export const CALLER_CSP = "default-src 'rfc0010-caller'";
+export const TAUJS_CSP_DIRECTIVE = "default-src 'rfc0010-taujs'";
+export const CALLER_REQUEST_ID = 'rfc0010-caller-request-id';
+
+export type Observation = {
+  status: number;
+  type: string | undefined;
+  body: string;
+  csp: string | undefined;
+  traceId: string | undefined;
+};
+
+const header = (value: string | string[] | number | undefined): string | undefined =>
+  value === undefined ? undefined : Array.isArray(value) ? value.join(', ') : String(value);
+
+const normaliseNonce = (value: string | undefined): string | undefined =>
+  value
+    ?.replace(/'nonce-[^']+'/g, "'nonce-<normalised>'")
+    .replace(/nonce="[^"]+"/g, 'nonce="<normalised>"')
+    .replace(/nonce-[A-Za-z0-9+/=]+/g, 'nonce-<normalised>');
+
+export const observe = (response: { statusCode: number; body: string; headers: Record<string, string | string[] | number | undefined> }): Observation => ({
+  status: response.statusCode,
+  type: header(response.headers['content-type']),
+  body: normaliseNonce(response.body) ?? response.body,
+  csp: normaliseNonce(header(response.headers['content-security-policy'])),
+  traceId: header(response.headers['x-trace-id']),
+});
+
+export type CapturedLog = { level: string; meta: unknown; message: string | undefined };
+
+export const captureLogger = (records: CapturedLog[], bindings: Record<string, unknown> = {}): BaseLogger => {
+  const logger: BaseLogger = {};
+
+  for (const level of ['debug', 'info', 'warn', 'error'] as const) {
+    logger[level] = (meta?: unknown, message?: string) => {
+      const objectMeta = meta && typeof meta === 'object' && !Array.isArray(meta) ? meta : { value: meta };
+
+      records.push({ level, meta: { ...bindings, ...objectMeta }, message });
+    };
+  }
+  logger.child = (childBindings) => captureLogger(records, { ...bindings, ...childBindings });
+
+  return logger;
+};
+
+export const captureConsole = (): { records: Array<{ level: string; args: unknown[] }>; restore: () => void } => {
+  const records: Array<{ level: string; args: unknown[] }> = [];
+  const original = { log: console.log, warn: console.warn, error: console.error };
+  let restored = false;
+
+  console.log = (...args: unknown[]) => records.push({ level: 'log', args });
+  console.warn = (...args: unknown[]) => records.push({ level: 'warn', args });
+  console.error = (...args: unknown[]) => records.push({ level: 'error', args });
+
+  return {
+    records,
+    restore: () => {
+      if (restored) return;
+      restored = true;
+      Object.assign(console, original);
+    },
+  };
+};
+
+const RENDER_MODULE = [
+  "const tag = Symbol.for('taujs.render-contract/v1');",
+  "const brand = (fn) => Object.defineProperty(fn, tag, { value: { key: 'test', contractVersion: 'v1' } });",
+  `export const renderSSR = brand(async (_data, location) => ({ headContent: '<meta name="rfc0010" content="taujs">', appHtml: \`<main>${OWNER.taujsPage}:\${location}</main>\` }));`,
+  'export const renderStream = brand(() => ({ abort() {}, done: Promise.resolve() }));',
+].join('\n');
+
+const roots: string[] = [];
+
+/** A built production application: manifest, client asset and a branded server entry. */
+export const productionFixture = async (): Promise<string> => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'taujs-rfc0010-'));
+  roots.push(root);
+  const clientRoot = path.join(root, 'client');
+  const appRoot = path.join(clientRoot, 'app');
+  const ssrRoot = path.join(root, 'ssr', 'app');
+
+  await mkdir(path.join(appRoot, '.vite'), { recursive: true });
+  await mkdir(path.join(appRoot, 'assets'), { recursive: true });
+  await mkdir(path.join(ssrRoot, '.vite'), { recursive: true });
+  await writeFile(path.join(root, 'package.json'), '{"type":"module"}\n');
+  await writeFile(path.join(appRoot, 'index.html'), '<!doctype html><html><head><!--ssr-head--></head><body><div id="app"><!--ssr-html--></div></body></html>');
+  await writeFile(path.join(appRoot, '.vite', 'manifest.json'), JSON.stringify({ 'entry-client.ts': { file: 'assets/rfc0010-client.js' } }));
+  await writeFile(path.join(appRoot, 'assets', 'rfc0010-client.js'), `export const marker = ${JSON.stringify(OWNER.taujsPage)};\n`);
+  await writeFile(path.join(ssrRoot, '.vite', 'ssr-manifest.json'), '{}');
+  await writeFile(path.join(ssrRoot, 'entry-server.js'), RENDER_MODULE);
+
+  return clientRoot;
+};
+
+/**
+ * A development source application: real client and server entries for Vite to transform.
+ *
+ * Returns the project root as well, because boot-graph emission writes beneath `process.cwd()` and
+ * the development proof chdirs here so the artefact is observable and disposable.
+ */
+export const developmentFixture = async (): Promise<{ root: string; clientRoot: string }> => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'taujs-rfc0010-dev-'));
+  roots.push(root);
+  const clientRoot = path.join(root, 'client');
+  const appRoot = path.join(clientRoot, 'app');
+
+  await mkdir(path.join(root, 'node_modules'), { recursive: true });
+  await mkdir(appRoot, { recursive: true });
+  await writeFile(path.join(root, 'package.json'), '{"type":"module"}\n');
+  await writeFile(path.join(appRoot, 'index.html'), '<!doctype html><html><head><!--ssr-head--></head><body><div id="app"><!--ssr-html--></div></body></html>');
+  await writeFile(path.join(appRoot, 'entry-client.ts'), `export const marker = ${JSON.stringify(OWNER.taujsPage)};\n`);
+  await writeFile(path.join(appRoot, 'entry-server.ts'), RENDER_MODULE);
+
+  return { root, clientRoot };
+};
+
+export const disposeFixtures = async (): Promise<void> => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+};
+
+export const taujsConfig = ({ globalCsp = true, wildcard = false }: { globalCsp?: boolean; wildcard?: boolean } = {}): TaujsConfig => ({
+  apps: [
+    {
+      appId: 'rfc0010-app',
+      entryPoint: 'app',
+      renderer: testRenderer(),
+      routes: [
+        { path: PATHS.taujsPage, attr: { render: 'ssr' } },
+        { path: PATHS.taujsSecret, attr: { render: 'ssr', data: async () => ({ token: OWNER.taujsSecret }) } },
+        {
+          path: PATHS.taujsFailure,
+          attr: {
+            render: 'ssr',
+            data: async () => {
+              throw new Error('rfc0010-route-failure');
+            },
+          },
+        },
+        { path: PATHS.taujsNoCsp, attr: { render: 'ssr', middleware: { csp: false } } },
+        ...(wildcard ? [{ path: '/*', attr: { render: 'ssr' as const } }] : []),
+      ],
+    },
+  ],
+  ...(globalCsp ? { security: { csp: { directives: { 'default-src': ["'rfc0010-taujs'"], 'script-src': ["'self'"] } } } } : {}),
+});
+
+const openApps = new Set<FastifyInstance>();
+
+/** Teardown backstop: closes anything a test left open, then removes every temporary fixture. */
+export const closeAll = async (): Promise<void> => {
+  const apps = [...openApps];
+  openApps.clear();
+
+  await Promise.all(apps.map((app) => app.close().catch(() => undefined)));
+  await disposeFixtures();
+};
+
+const track = <T extends FastifyInstance>(app: T): T => {
+  openApps.add(app);
+
+  return app;
+};
+
+export type CallerHost = {
+  app: FastifyInstance;
+  clientRoot: string;
+  logs: CapturedLog[];
+  activate: (register: CreateServerFn, config?: TaujsConfig) => Promise<unknown>;
+  close: () => Promise<void>;
+};
+
+type CallerHostShape = {
+  strictErrorHandler?: boolean;
+  callerNotFound?: boolean;
+  callerCsp?: boolean;
+  explicitLogger?: boolean;
+};
+
+const buildCallerHost = async (shape: CallerHostShape): Promise<CallerHost> => {
+  const clientRoot = await productionFixture();
+  const logs: CapturedLog[] = [];
+  const app = track(
+    fastify({
+      logger: false,
+      genReqId: () => CALLER_REQUEST_ID,
+      ...(shape.strictErrorHandler ? { allowErrorHandlerOverride: false } : {}),
+    }),
+  );
+
+  app.decorate('authenticate', async () => undefined);
+
+  if (shape.callerCsp !== false) {
+    app.addHook('onRequest', (_request, reply, done) => {
+      reply.header('Content-Security-Policy', CALLER_CSP);
+      done();
+    });
+  }
+
+  app.get(PATHS.callerBefore, async () => ({ owner: OWNER.callerBefore }));
+  app.get(PATHS.callerBeforeError, async () => {
+    throw new Error(`${OWNER.callerError}:before`);
+  });
+  app.setErrorHandler(async (error: Error, _request, reply) =>
+    reply.status(599).type('application/json').send({ owner: OWNER.callerError, message: error.message }),
+  );
+
+  if (shape.callerNotFound !== false) {
+    app.setNotFoundHandler(async (_request, reply) => reply.status(404).type('application/json').send({ owner: OWNER.callerNotFound }));
+  }
+
+  return {
+    app,
+    clientRoot,
+    logs,
+    activate: async (register, config) => {
+      const result = await register({
+        config: config ?? taujsConfig(),
+        fastify: app,
+        clientRoot,
+        debug: ['ssr'],
+        ...(shape.explicitLogger ? { logger: captureLogger(logs) } : {}),
+      });
+
+      app.get(PATHS.callerAfter, async () => ({ owner: OWNER.callerAfter }));
+      app.get(PATHS.callerAfterError, async () => {
+        throw new Error(`${OWNER.callerError}:after`);
+      });
+
+      return result;
+    },
+    close: async () => {
+      openApps.delete(app);
+      await app.close();
+    },
+  };
+};
+
+/** An ordinary caller-owned host: its own CSP, error handler, not-found handler and routes. */
+export const createEmbeddedHost = (): Promise<CallerHost> => buildCallerHost({});
+
+/** A caller-owned host under Fastify's strict error-handler policy. */
+export const createStrictHost = (): Promise<CallerHost> => buildCallerHost({ strictErrorHandler: true });
+
+/** A caller-owned host passing an explicit τjs logger, which must win over any Fastify logger. */
+export const createExplicitLoggerHost = (): Promise<CallerHost> => buildCallerHost({ explicitLogger: true });
+
+/**
+ * A caller-owned host with NO not-found handler of its own, and no caller static mount.
+ *
+ * The most common real embedding, and the one silent failure mode in the design: Fastify keys
+ * not-found handlers by prefix, so a τjs scope registering one would become the 404 owner for the
+ * entire server. Caller static is omitted deliberately - a wildcard-enabled `@fastify/static` would
+ * answer unmatched URLs itself and mask what this host exists to measure.
+ */
+export const createDefaultNotFoundHost = (): Promise<CallerHost> => buildCallerHost({ callerNotFound: false, callerCsp: false });
+
+export const CALLER_ASSET = 'RFC0010_CALLER_ASSET';
+export const CALLER_ASSET_PATH = '/caller-asset.txt';
+/** τjs's own production static facility serves the client build from the fixture manifest. */
+export const TAUJS_ASSET_PATH = '/app/assets/rfc0010-client.js';
+
+/**
+ * A caller-owned host that has ALREADY registered real `@fastify/static` before τjs.
+ *
+ * P0 proved this combination could not boot: τjs decorated `sendFile` on the caller root and
+ * collided. The regression exists because that was a headline failure, so architectural inference
+ * is not good enough.
+ *
+ * `wildcard` is the caller's choice and matters: `@fastify/static` defaults it to `true`, which
+ * claims `GET /*` on the caller root and will collide with a declared τjs `/*` page.
+ */
+export const createStaticCoexistenceHost = async ({ wildcard = false }: { wildcard?: boolean } = {}): Promise<CallerHost> => {
+  const host = await buildCallerHost({});
+  const assetRoot = await mkdtemp(path.join(os.tmpdir(), 'taujs-rfc0010-caller-assets-'));
+  roots.push(assetRoot);
+
+  await writeFile(path.join(assetRoot, 'caller-asset.txt'), `${CALLER_ASSET}\n`);
+
+  const fastifyStatic = await import('@fastify/static');
+  await host.app.register(fastifyStatic.default, { root: assetRoot, prefix: '/', wildcard, index: false });
+
+  return host;
+};
+
+export type CreatedHost = {
+  app: () => FastifyInstance | undefined;
+  clientRoot: string;
+  activate: (register: CreateServerFn, config?: TaujsConfig) => Promise<{ app?: FastifyInstance }>;
+  close: () => Promise<void>;
+};
+
+/** τjs creates the Fastify instance: the complete experience. */
+export const createCreatedHost = async (): Promise<CreatedHost> => {
+  const clientRoot = await productionFixture();
+  let created: FastifyInstance | undefined;
+
+  return {
+    app: () => created,
+    clientRoot,
+    activate: async (register, config) => {
+      const result = await register({ config: config ?? taujsConfig(), clientRoot, debug: ['ssr'] });
+      created = result.app;
+
+      if (created) {
+        track(created);
+        created.get(PATHS.createdHost, async () => ({ owner: OWNER.createdHost }));
+      }
+
+      return result;
+    },
+    close: async () => {
+      if (!created) return;
+      openApps.delete(created);
+      await created.close();
+    },
+  };
+};

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1,6 +1,6 @@
 import type { Writable } from 'node:stream';
 
-import type { FastifyPluginAsync, FastifyPluginCallback } from 'fastify';
+import type { FastifyInstance, FastifyPluginAsync, FastifyPluginCallback } from 'fastify';
 
 import type { CoreTaujsConfig, Route, RouteParams } from './core/config/types';
 import type { DebugConfig, Logs } from './core/logging/types';
@@ -12,6 +12,19 @@ import type { StaticAssetsRegistration } from './utils/StaticAssets';
 import type { TaujsViteOverride } from './ViteConfig';
 
 export type SSRServerOptions = {
+  /**
+   * RFC 0010. Embedded development only. Owns the single caller-root `onRequest` hook which
+   * delegates otherwise-unmatched requests to the τjs-owned Vite server. `createServer` supplies it
+   * only when a caller instance was passed AND the process is in development, so production never
+   * receives the handle at all. It must not be used for routing, policy, tracing, errors or
+   * lifecycle.
+   *
+   * Typed as `Pick<FastifyInstance, 'addHook'>` rather than the whole instance: passing `app` still
+   * works structurally, but nothing downstream can reach `setErrorHandler`, `setNotFoundHandler`,
+   * `decorate` or `get` through this handle. The narrow authorisation is enforced by the compiler
+   * instead of by discipline, and it needs no wrapper or abstraction to do it.
+   */
+  viteRequestHookOwner?: Pick<FastifyInstance, 'addHook'>;
   alias?: Record<string, string>;
   clientRoot: string;
   /**

--- a/packages/server/src/utils/DevServer.ts
+++ b/packages/server/src/utils/DevServer.ts
@@ -21,6 +21,14 @@ import type { DebugConfig, Logs } from '../core/logging/types';
  */
 export type SetupDevServerOptions = {
   app: FastifyInstance;
+  /**
+   * RFC 0010. Embedded development only. Owns the single caller-root `onRequest` hook which
+   * delegates otherwise-unmatched requests to the τjs-owned Vite server, because root-level hooks
+   * are the only ones Fastify runs for a URL it did not route. Omitted on every other path, where
+   * the hook lands on `app` exactly as before. It must not be used for routing, policy, tracing,
+   * errors or lifecycle. Narrowed to `addHook` so that restriction is enforced by the compiler.
+   */
+  viteRequestHookOwner?: Pick<FastifyInstance, 'addHook'>;
   /** The shared client base root (dev `root` invariant + framework alias base). */
   clientRoot: string;
   /** Programmatic escape-hatch alias (`createServer({ alias })`) - the TOP alias layer (VS5). */
@@ -169,7 +177,7 @@ export const setupDevServer = async (options: SetupDevServerOptions): Promise<Vi
 
   overrideCSSHMRConsoleError();
 
-  app.addHook('onRequest', async (request, reply) => {
+  (options.viteRequestHookOwner ?? app).addHook('onRequest', async (request, reply) => {
     await new Promise<void>((resolve) => {
       viteDevServer.middlewares(request.raw, reply.raw, () => {
         if (!reply.sent) resolve();

--- a/packages/server/src/utils/Telemetry.ts
+++ b/packages/server/src/utils/Telemetry.ts
@@ -20,7 +20,13 @@ export function createRequestContext<L extends Logs>(
   deriveLogger?: (bindings: Record<string, unknown>) => L,
 ): RequestContext<L> {
   const raw = typeof req.headers['x-trace-id'] === 'string' ? req.headers['x-trace-id'] : '';
-  const traceId = raw && REGEX.SAFE_TRACE.test(raw) ? raw : typeof (req as any).id === 'string' ? (req as any).id : crypto.randomUUID();
+  // RFC 0010: τjs adopts the host's request identity rather than inventing a parallel one, so a
+  // caller's logs and τjs's records join on the same value. `genReqId` may legitimately return a
+  // number - an incrementing counter is a common choice - and a string-only guard silently fell
+  // through to a random UUID there, breaking correlation with no warning. Coerce both primitive
+  // shapes; anything else is not a usable identity and still gets a fresh UUID.
+  const hostRequestId = typeof (req as any).id === 'string' || typeof (req as any).id === 'number' ? String((req as any).id) : '';
+  const traceId = raw && REGEX.SAFE_TRACE.test(raw) ? raw : hostRequestId || crypto.randomUUID();
 
   reply.header('x-trace-id', traceId);
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -28,6 +28,7 @@ export default defineConfig({
           items: [
             { label: "Overview", slug: "guides/getting-started" },
             { label: "Architecture", slug: "guides/architecture" },
+            { label: "Host Ownership", slug: "guides/host-ownership" },
             {
               label: "Incremental Migration",
               slug: "guides/incremental-migration",

--- a/website/package.json
+++ b/website/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro build",
+    "build": "astro build --force",
+    "build:incremental": "astro build",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/website/src/content/docs/guides/host-ownership.md
+++ b/website/src/content/docs/guides/host-ownership.md
@@ -25,9 +25,14 @@ set Fastify options such as `routerOptions` or `genReqId`. In that case you stil
 shell, whole-server τjs CSP and `x-trace-id` on your own routes.
 
 τjs deliberately does not try to infer intent from how the instance was configured, because that
-guess would be unreliable. If you want τjs options *and* the complete experience, let τjs create the
-instance and configure what you need through `config.server`, or accept host ownership and declare a
-terminal wildcard page as described below.
+guess would be unreliable. There are two accurate ways forward:
+
+- **If those native options are not essential**, omit `fastify` entirely and keep the complete
+  τjs-created experience. Note that `config.server` covers only `host`, `port` and `hmrPort`; it is
+  not a place to configure `routerOptions`, `genReqId` or other Fastify construction options.
+- **If they are essential**, keep supplying the instance, accept host ownership, and establish the
+  behaviour you want explicitly: declare a terminal wildcard page for a shell, register host-wide
+  CSP on your own instance, and set your own request identity and tracing.
 :::
 
 ## What each side owns

--- a/website/src/content/docs/guides/host-ownership.md
+++ b/website/src/content/docs/guides/host-ownership.md
@@ -1,0 +1,100 @@
+---
+title: Host Ownership
+description: What τjs owns when you supply your own Fastify instance, and what it owns when it creates one for you.
+---
+
+τjs has one rule about the server it runs on:
+
+> Bring your own Fastify and τjs respects it. Let τjs create Fastify and it provides the complete experience.
+
+You choose between them by whether you pass `fastify` to `createServer`. There is no ownership option, mode or flag, and nothing extra to configure.
+
+```ts
+// τjs creates Fastify: whole-server shell, CSP and trace
+const { app, net } = await createServer({ config });
+
+// You own Fastify: τjs owns only its declared routes
+await createServer({ config, fastify: app });
+```
+
+The boot summary states which mode is in effect, so you never have to infer it.
+
+:::caution[Passing an instance is an ownership decision, whatever your reason for passing it]
+Supplying `fastify` always means you own the host, including when you created the instance solely to
+set Fastify options such as `routerOptions` or `genReqId`. In that case you still lose the implicit
+shell, whole-server τjs CSP and `x-trace-id` on your own routes.
+
+τjs deliberately does not try to infer intent from how the instance was configured, because that
+guess would be unreliable. If you want τjs options *and* the complete experience, let τjs create the
+instance and configure what you need through `config.server`, or accept host ownership and declare a
+terminal wildcard page as described below.
+:::
+
+## What each side owns
+
+| Concern | τjs-created Fastify | Your Fastify |
+| --- | --- | --- |
+| Page routes, data, rendering | τjs | τjs, in one encapsulated scope |
+| CSP and trace | Whole server | τjs responses only |
+| Auth | τjs routes | τjs routes |
+| Page errors | τjs root handler | τjs scoped handler |
+| Host route errors | τjs | You |
+| Not-found and shell | Implicit τjs shell | You, unless you declare `/*` |
+| Static facilities, decorators | τjs root | τjs scope |
+| Logging | Resolved τjs logger | Your `fastify.log` lineage |
+| Listening and shutdown | You | You |
+
+On a supplied instance τjs installs no root error handler, no root not-found handler, no root CSP or trace hook, claims no root decorator names, and writes no banner or presentation output. It does register under its own name, so it appears in your plugin tree where you would expect a mounted subsystem to be.
+
+Development has one deliberate exception: Vite must serve URLs that match no route, such as `/@vite/client` and transformed sources, and only a root-level hook observes those. τjs registers exactly one delegating `onRequest` hook for that purpose. It hands the request to the τjs-owned Vite server and otherwise returns control unchanged. It starts no trace, applies no policy and selects no route, and it does not exist in production.
+
+## Migrating an embedded application
+
+If you already call `createServer({ fastify })`, three behaviours that used to apply to your whole server now apply only to τjs responses.
+
+### Unmatched URLs are yours again
+
+Previously any URL that matched no route received a τjs HTML shell with status 200. Your own not-found policy now handles them.
+
+If you want τjs to render unmatched URLs, declare a terminal wildcard page. It is an ordinary τjs route with no special casing:
+
+```ts
+routes: [
+  { path: '/', attr: { render: 'ssr' } },
+  { path: '/*', attr: { render: 'ssr' } },
+];
+```
+
+Two differences are worth knowing.
+
+The old implicit shell delegated asset-like misses such as `/logo.png` to a 404, whereas an explicit `/*` owns and renders everything it matches. To keep assets 404ing, declare narrower page patterns instead of `/*`, or serve assets under a prefix the wildcard does not cover.
+
+If you also serve static files from your own instance, check how that mount is configured. `@fastify/static` defaults `wildcard` to `true`, which claims `GET /*` on your root, and Fastify's router is global, so a declared τjs `/*` page is then a genuine duplicate route and boot fails with `FST_ERR_DUPLICATED_ROUTE`. Registration order does not change this. Either register your static mount with `wildcard: false`, or keep the two patterns non-overlapping:
+
+```ts
+await app.register(fastifyStatic, { root: assets, prefix: '/', wildcard: false });
+```
+
+τjs's own static facility already uses `wildcard: false` for exactly this reason, so it never competes for that route.
+
+### Configured CSP no longer covers your routes
+
+`security.csp` now applies to τjs responses. Route-level `merge`, `replace` and `false`, and nonce plumbing, are unchanged.
+
+Host-wide policy belongs to Fastify. Register your preferred CSP plugin on your instance and it will cover your routes, while τjs continues to manage policy for the pages it renders.
+
+### `x-trace-id` no longer appears on your routes
+
+τjs opens a trace episode only for responses it owns, so your routes carry no `x-trace-id` and start no recorder episode.
+
+Correlation still spans both sides. τjs adopts an inbound `x-trace-id` header if present, and otherwise your Fastify `req.id`, so a request identity you set with `genReqId` flows into τjs logs and traces without any wiring.
+
+### Two boot failures are fixed
+
+Supplying an instance that already had a not-found handler, or that had already registered `@fastify/static`, previously stopped τjs from booting. Both now work.
+
+## Running τjs inside another runtime
+
+Because a supplied instance keeps its own lifecycle, τjs is usable as a subsystem of a larger Fastify application without special support. It never calls `listen()`, never touches process lifecycle, and releases what it owns, including the development Vite server, through ordinary `app.close()`.
+
+That is a property of being a well-behaved Fastify plugin rather than an integration with any particular platform, and τjs ships no provider-specific code.

--- a/website/src/content/docs/guides/host-ownership.md
+++ b/website/src/content/docs/guides/host-ownership.md
@@ -96,10 +96,6 @@ Correlation still works, in your logs. τjs adopts an inbound `x-trace-id` heade
 
 The shared identity appears in log records, not on the wire: your routes carry no `x-trace-id` response header, because τjs opens a trace episode only for responses it owns.
 
-### Two boot failures are fixed
-
-Supplying an instance that already had a not-found handler, or that had already registered `@fastify/static`, previously stopped τjs from booting. Both now work.
-
 ## Running τjs inside another runtime
 
 Because a supplied instance keeps its own lifecycle, τjs is usable as a subsystem of a larger Fastify application without special support. It never calls `listen()`, never touches process lifecycle, and releases what it owns, including the development Vite server, through ordinary `app.close()`.

--- a/website/src/content/docs/guides/host-ownership.md
+++ b/website/src/content/docs/guides/host-ownership.md
@@ -92,7 +92,9 @@ Host-wide policy belongs to Fastify. Register your preferred CSP plugin on your 
 
 τjs opens a trace episode only for responses it owns, so your routes carry no `x-trace-id` and start no recorder episode.
 
-Correlation still spans both sides. τjs adopts an inbound `x-trace-id` header if present, and otherwise your Fastify `req.id`, so a request identity you set with `genReqId` flows into τjs logs and traces without any wiring.
+Correlation still works, in your logs. τjs adopts an inbound `x-trace-id` header if present, and otherwise your Fastify `req.id`, whether `genReqId` returns a string or a number. Your own records bind that value as `reqId` and τjs binds the same value as `traceId`, so the two sides join on one identity with no wiring.
+
+The shared identity appears in log records, not on the wire: your routes carry no `x-trace-id` response header, because τjs opens a trace episode only for responses it owns.
 
 ### Two boot failures are fixed
 

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -65,7 +65,11 @@ import solidLogo from "../../assets/solid.svg";
 </div>
 
 
-τjs orchestrates routing, policy, services, data, rendering and trace before handing the resolved response to React, Vue or Solid for interaction.
+τjs orchestrates routing, policy, services, data, rendering and trace before handing the resolved response to React, Vue or Solid for interaction. Bring your own Fastify and τjs respects it. Let τjs create Fastify and it provides the complete experience.
+
+
+
+
 ## Leverage the ecosystems you already know
 
 τjs composes Fastify and Vite with React, Vue or Solid as parts of one coherent system architecture while preserving each ecosystem's native APIs.

--- a/website/src/content/docs/reference/taujs-config.md
+++ b/website/src/content/docs/reference/taujs-config.md
@@ -198,7 +198,14 @@ Those native options govern τjs routes and host-owned Fastify routes alike. Use
 
 This is a deliberate product boundary: the server package is Node/Fastify-native. The renderer packages retain their standalone uses, but the integrated server does not carry a second runtime-neutral HTTP or router abstraction.
 
-Route paths therefore use Fastify route syntax, not regular expressions. An exact path may be declared by only one τjs app. Ordinary Fastify routes can coexist beside τjs page routes, while unmatched document URLs continue through the τjs application-shell fallback.
+Route paths therefore use Fastify route syntax, not regular expressions. An exact path may be declared by only one τjs app. Ordinary Fastify routes can coexist beside τjs page routes.
+
+Who answers an unmatched URL depends on who owns the host, including in the example above, since supplying an instance is itself an ownership decision:
+
+- **τjs created the Fastify instance** - unmatched document URLs continue through the τjs application-shell fallback.
+- **You supplied the Fastify instance** - your own not-found policy owns unmatched URLs, unless you declare an explicit τjs terminal wildcard page (`path: '/*'`).
+
+See [Host Ownership](/guides/host-ownership/) for the full split and the embedded-host migration notes.
 
 When migrating an existing config, replace path-to-regexp-only forms such as
 `/app{/:feature}{/:id}`, `/app/:page*` and `/docs/*slug`. τjs rejects these known stale forms at


### PR DESCRIPTION
## What

τjs now derives one internal ownership fact from whether you passed `fastify` to `createServer`.

> Bring your own Fastify and τjs respects it. Let τjs create Fastify and it provides the complete experience.

**Supply an instance** and τjs registers its routes, CSP, trace, auth, static assets, introspection and error conversion into a single encapsulated Fastify scope. It no longer replaces your error handler or not-found handler, applies no CSP or trace to your routes, claims no root decorators, and prints no banner or presentation output. It still registers under its own name, so it appears in your plugin tree.

**Omit it** and nothing changes: whole-server CSP and trace, the implicit application shell, banner and configured line.

No new ownership option or mode. Nothing a standalone application writes changes.

## How

The ownership fact drives `fastify-plugin`'s own `encapsulate` switch, so there is one installer body and one registration path rather than two architectures:

```ts
export const ssrServerPlugin = ({ callerOwnedHost }) =>
  fp(async (scope, opts) => installOwnedScope(scope, opts, callerOwnedHost), {
    name: 'τjs-ssr-server',
    encapsulate: callerOwnedHost,
  });
```

Development has one deliberate exception. Vite must serve URLs Fastify routed nowhere, and only a root-level hook observes those, so `viteRequestHookOwner` carries the caller's root for exactly one delegating `onRequest` hook. It is supplied only when `callerOwnedHost && isDevelopment`, so production never receives the handle, and it is typed `Pick<FastifyInstance, 'addHook'>` so misuse is a compile error rather than a matter of discipline.

133 substantive lines of product change across four files.

## Breaking changes for embedded hosts

Three behaviours that applied to your whole server now apply only to τjs responses. Full migration notes in the new Host Ownership guide.

- **The implicit shell is gone.** Unmatched URLs fall to your own not-found policy. Declare a terminal wildcard page (`path: '/*'`) if you want τjs to render them.
- **Configured CSP no longer covers your routes.** Host-wide policy belongs to Fastify.
- **`x-trace-id` no longer appears on your routes.** For its own responses τjs still adopts an inbound `x-trace-id`, or otherwise your `req.id`, so your records and τjs's join on one identity in the logs. The shared value is not on the wire: your routes carry no trace header.

`req.id` adoption now also accepts a numeric `genReqId`. Previously only a string identity was adopted, so a counter-based `genReqId` silently fell through to an unrelated random UUID and correlation broke with no warning. Regression added, and verified load-bearing by reverting the coercion: `expected 'dee963e6-...' to be '4242'`.

Two boot failures are fixed: a caller that already owns a not-found handler, or has already registered `@fastify/static`, previously could not boot τjs at all.

## Evidence

| Suite | Coverage |
| --- | --- |
| `FastifyOwnershipArrangement.test.ts` | 8 - Fastify and fastify-plugin mechanics, no τjs, versions pinned |
| `HostOwnership.test.ts` | 16 - ownership outcomes through the public `createServer` path |
| `HostOwnershipDevelopment.test.ts` | 1 - real Vite boot: delegation, caller-route equivalence, graph emission, teardown |

Server 883/883 across 55 files. Workspace 1,615 passed with one accepted Solid skip. `pnpm -r typecheck`, `pnpm run build`, `check-format`, `check-exports` and `git diff --check` green.

Two tampers, each performed once, source restored and the tree verified:

- Removing the Vite `onClose` hook fails the teardown leg with `expected +0 to be 1` on the real close count.
- Reverting the request-id coercion fails the correlation leg with `expected 'dee963e6-...' to be '4242'`.

## Commits

| SHA | Change |
| --- | --- |
| `6a077a0` | The ownership split, permanent regressions, changeset and guide |
| `9d3c7e1` | Website corrections: `config.server` scope, and shell ownership in the routing reference |
| `791bdc7` | Adopt numeric host request ids for trace correlation, with the wording made precise |