### PR TITLE
feat: rfc 0007 - governed deferred route data (@taujs/server, react, vue, solid)

### DIFF
--- a/.changeset/governed-deferred-route-data.md
+++ b/.changeset/governed-deferred-route-data.md
@@ -1,0 +1,56 @@
+---
+'@taujs/server': minor
+'@taujs/react': minor
+'@taujs/vue': minor
+'@taujs/solid': minor
+---
+
+RFC 0007 - governed deferred route data.
+
+A `render: 'streaming'` route can now declare response-owned work that may complete after
+rendering begins, beside the critical `attr.data` snapshot:
+
+```ts
+{
+  path: '/products/:id',
+  attr: {
+    render: 'streaming',
+    meta: {},
+    data: serviceData('catalogue', 'product', ({ id }) => ({ id })),
+    deferred: {
+      reviews: serviceData('reviews', 'forProduct', ({ id }) => ({ id })),
+    },
+  },
+}
+```
+
+The host starts each named loader exactly once per request, outside the component tree, after
+route policy has accepted the request. The selected renderer projects the named promise onto its
+own Suspense/resource primitive, so late boundary HTML arrives through the framework's own
+streaming and patch mechanism - τjs owns no patch protocol, exposes no browser data runtime and
+issues no client refetch. Hydration is seeded from the existing end-of-stream write site.
+
+**`@taujs/server`**
+
+- `attr.deferred` on the streaming arm only, with boot hard errors for an `ssr` route, a
+  non-plain-object record, a non-function entry and a key failing `^[A-Za-z][A-Za-z0-9_]*$`.
+- `DeferredDataOf` and `DeferredDataAttributes` exported from `@taujs/server/config`, so a
+  component-facing accessor is typeable from `typeof route` with no re-declared payload shape.
+- A settled entry is a stable snapshot: one serialisation attempt at settlement, whose retained
+  bytes are what the renderer, the trace and the hydration seed all describe. A value that cannot
+  cross that boundary is detail-free `failed` everywhere, with one payload-free operator warning.
+- The request graph gains an optional per-route `deferred` array and its `usedBy` contribution;
+  traces gain a per-key `deferredData` outcome. Both are additive within schema v1, and a late
+  outcome reaches the on-disk trace artefact. No new MCP tool.
+
+**`@taujs/react`, `@taujs/vue`, `@taujs/solid`**
+
+- React and Vue: `useDeferredData`, `useDeferredDataResult`, `createDeferredAccessor`,
+  `DeferredDataError`, `DeferredResult`.
+- Solid: `useDeferredData`, `createDeferredAccessor`, `DeferredDataError`, `DeferredAccessor` -
+  its engine has real server-side error boundaries, so the throwing read already completes the
+  response and no result accessor is needed.
+- Each package gains one response-level `streamOptions.deferredTimeoutMs` deadline: positive
+  finite only, validated at renderer construction, defaulting to 15000ms.
+
+Routes that declare no `deferred` are unchanged, byte for byte.

--- a/.changeset/governed-deferred-route-data.md
+++ b/.changeset/governed-deferred-route-data.md
@@ -53,4 +53,12 @@ issues no client refetch. Hydration is seeded from the existing end-of-stream wr
 - Each package gains one response-level `streamOptions.deferredTimeoutMs` deadline: positive
   finite only, validated at renderer construction, defaulting to 15000ms.
 
+**Authoring notes**
+
+- Vue streams in order, so in an in-order renderer place deferred boundaries AFTER the independent
+  content that should stream immediately - a boundary awaiting a deferred value stalls every byte
+  behind it. React streams out of order and is unaffected.
+- An unconsumed entry whose loader rejects after the response terminal reads as `aborted`, not
+  `failed`.
+
 Routes that declare no `deferred` are unchanged, byte for byte.

--- a/fixtures/playground-react/package.json
+++ b/fixtures/playground-react/package.json
@@ -6,8 +6,10 @@
   "description": "τjs React introspection fixture - the app the whole effort drives against (P0B-05)",
   "scripts": {
     "dev": "NODE_ENV=development tsx watch --ignore vite.config.ts --tsconfig ./src/server/tsconfig.json ./src/server/index.ts",
-    "build": "tsx build.ts && BUILD_MODE=ssr tsx build.ts",
+    "build": "NODE_ENV=production tsx build.ts && NODE_ENV=production BUILD_MODE=ssr tsx build.ts",
+    "start": "NODE_ENV=production tsx ./src/server/index.ts",
     "typecheck": "tsc",
+    "test": "vitest run",
     "eval": "NODE_ENV=development tsx eval.ts"
   },
   "dependencies": {
@@ -21,9 +23,11 @@
     "@types/node": "^20.14.9",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "playwright-core": "1.44.1",
     "tsx": "^4.19.3",
     "typescript": "^5.5.4",
     "vite": "^7.3.6",
+    "vitest": "^3.2.4",
     "@taujs/mcp": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0"
   }

--- a/fixtures/playground-react/src/client/App.tsx
+++ b/fixtures/playground-react/src/client/App.tsx
@@ -1,14 +1,56 @@
-import React from 'react';
-import { useSSRStore } from '@taujs/react';
+import React, { Suspense, useState } from 'react';
+import { createDeferredAccessor, useSSRStore } from '@taujs/react';
 
-export const App = () => {
+import type { DeferredRouteData } from '../server/routes/deferred.ts';
+
+/**
+ * RFC 0007: the ROUTE-DECLARED deferred read.
+ *
+ * The accessor is typed from the route config alone - `DeferredDataOf<typeof deferredRoute>` - so
+ * the payload shape is never re-declared here. The component starts nothing: the host began this
+ * work before the render, and `useDeferred` only projects the named promise onto React's own
+ * `use()`, suspending this boundary and nothing else.
+ */
+const useDeferred = createDeferredAccessor<DeferredRouteData>();
+
+function DeferredReviews() {
+  const reviews = useDeferred('reviews');
+  // The annotation is the GATE: `count` is inferred from the route's `serviceData()` brand, so
+  // changing the service's declared result type fails this typecheck rather than shipping.
+  const count: number = reviews.count;
+
+  return <p id="reviews">{`reviews: ${count} - ${reviews.top}`}</p>;
+}
+
+/**
+ * Proves hydration by EXECUTED BEHAVIOUR rather than markup: the server renders `count: 0`, and
+ * only a hydrated, interactive root can turn a click into `count: 1`.
+ */
+function Counter() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <button id="counter" type="button" onClick={() => setCount((n) => n + 1)}>
+      count: {count}
+    </button>
+  );
+}
+
+export const App = ({ location = '' }: { location?: string }) => {
   const data = useSSRStore<Record<string, unknown>>();
 
   return (
     <main>
       <h1>τjs playground</h1>
       <p>Fixture app for the introspection substrate. Initial data below.</p>
+      <Counter />
       <pre id="initial-data">{JSON.stringify(data, null, 2)}</pre>
+
+      {location.startsWith('/deferred') ? (
+        <Suspense fallback={<p id="reviews-pending">loading reviews</p>}>
+          <DeferredReviews />
+        </Suspense>
+      ) : null}
     </main>
   );
 };

--- a/fixtures/playground-react/src/client/entry-client.tsx
+++ b/fixtures/playground-react/src/client/entry-client.tsx
@@ -2,7 +2,9 @@ import { hydrateApp } from '@taujs/react';
 import { App } from './App';
 
 hydrateApp({
-  appComponent: <App />,
+  // The server rendered with the request path; hydrate with the SAME location so the deferred
+  // boundary is in the tree on both sides.
+  appComponent: <App location={window.location.pathname} />,
   rootElementId: 'root',
   enableDebug: import.meta.env.DEV,
 });

--- a/fixtures/playground-react/src/client/entry-server.tsx
+++ b/fixtures/playground-react/src/client/entry-server.tsx
@@ -4,7 +4,7 @@ import { App } from './App';
 type HeadData = { ogTitle?: string; ogDescription?: string };
 
 export const { renderSSR, renderStream } = createRenderer<Record<string, unknown>, unknown, HeadData>({
-  appComponent: () => <App />,
+  appComponent: ({ location }) => <App location={location} />,
   // RFC 0004: headData is the route's attr.head payload (undefined when a route declares none,
   // or when the head loader degraded) - meta stays the static fallback layer.
   headContent: ({ headData, meta }) => `

--- a/fixtures/playground-react/src/server/routes/deferred.ts
+++ b/fixtures/playground-react/src/server/routes/deferred.ts
@@ -1,0 +1,30 @@
+import { serviceData } from '../services/registry.ts';
+
+import type { DeferredDataOf } from '@taujs/server/config';
+
+/**
+ * RFC 0007: the deferred example route, declared ONCE here so its TYPE is nameable.
+ *
+ * `attr.data` is the critical snapshot; `attr.deferred` declares response-owned work that may
+ * complete after rendering begins. The host starts each named loader once per request, outside the
+ * component tree, and `@taujs/react` projects it onto React's own `use()` + `<Suspense>`.
+ */
+export const deferredRoute = {
+  path: '/deferred',
+  attr: {
+    render: 'streaming',
+    meta: { title: 'τjs React playground - deferred route data' },
+    hydrate: true,
+    data: serviceData('content', 'home'),
+    deferred: {
+      reviews: serviceData('content', 'reviews'),
+    },
+  },
+} as const;
+
+/**
+ * The CROSS-PACKAGE inference gate: the component-facing accessor is typed from `typeof route`
+ * alone, so the application never re-declares a payload shape. Type-only, so importing it from the
+ * client bundle pulls in no server code.
+ */
+export type DeferredRouteData = DeferredDataOf<typeof deferredRoute>;

--- a/fixtures/playground-react/src/server/services/content.service.ts
+++ b/fixtures/playground-react/src/server/services/content.service.ts
@@ -7,4 +7,12 @@ export const contentService = defineService({
     heading: 'τjs playground',
     blurb: 'One small bootable app the introspection effort drives against.',
   }),
+
+  // RFC 0007: a route-owned DEFERRED loader. It settles well after the shell, so the boundary that
+  // reads it is the one the deferred delivery path is observable through.
+  reviews: async (_params: {}) => {
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    return { count: 3, top: 'a genuinely deferred review' };
+  },
 });

--- a/fixtures/playground-react/taujs.config.ts
+++ b/fixtures/playground-react/taujs.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from '@taujs/server/config';
 import { reactRenderer } from '@taujs/react/renderer';
 
+import { deferredRoute } from './src/server/routes/deferred.ts';
 import { serviceData } from './src/server/services/registry.ts';
 
 // Every route exists to exercise a specific part of the introspection substrate — see
@@ -8,9 +9,25 @@ import { serviceData } from './src/server/services/registry.ts';
 // (/spa/anything is the SPA-path example).
 export default defineConfig({
   server: {
-    port: 5173,
+    // The real-browser suite boots this fixture on its own port (5301) so it never collides with a
+    // developer's dev server; everything else keeps the fixture's stable default.
+    port: Number(process.env.TAUJS_PORT ?? 5173),
     host: 'localhost',
     hmrPort: 5174,
+  },
+  // An ENFORCED CSP (not report-only), so the browser acceptance runs against a real policy rather
+  // than merely observing nonce attributes. `script-src` carries no 'unsafe-inline', so any inline
+  // script the renderer emits WITHOUT the request nonce is blocked by the browser and raises a
+  // securitypolicyviolation - which is exactly what the browser suite asserts never happens.
+  security: {
+    csp: {
+      defaultMode: 'merge',
+      directives: {
+        'default-src': ["'self'"],
+        'style-src': ["'self'", "'unsafe-inline'"],
+        'img-src': ["'self'", 'data:'],
+      },
+    },
   },
   apps: [
     {
@@ -42,6 +59,9 @@ export default defineConfig({
             head: { data: serviceData('catalog', 'getProductHead', (p) => ({ id: String(p.id) })) },
           },
         },
+        // RFC 0007: the deferred example route, declared in `src/server/routes/deferred.ts` so the
+        // client can name its inferred payload type (`DeferredDataOf<typeof deferredRoute>`).
+        deferredRoute,
         {
           path: '/legacy',
           attr: {

--- a/fixtures/playground-react/test/browser.test.ts
+++ b/fixtures/playground-react/test/browser.test.ts
@@ -1,0 +1,198 @@
+// @vitest-environment node
+import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { createServer } from 'node:net';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { chromium, type Browser, type ConsoleMessage, type Page } from 'playwright-core';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
+ * RFC 0007: the @taujs/react PRODUCT cell for deferred route data.
+ *
+ * One compact real-browser acceptance, deliberately not a port of the disposable proof matrix: a
+ * production build served by a real τjs server under an ENFORCED Content-Security-Policy, driven
+ * in Chromium. It proves by EXECUTION what markup inspection cannot - successful deferred
+ * delivery, hydration seeded from the private envelope, no refetch, the carrier deleted, and no
+ * CSP violation anywhere in the flow.
+ *
+ * Pinned tuple: playwright-core 1.44.1 <-> chromium-1117 (125.x).
+ */
+const PROJECT = fileURLToPath(new URL('../', import.meta.url));
+const PORT = 5301;
+const BASE = `http://127.0.0.1:${PORT}`;
+const BROWSERS_PATH = path.join(homedir(), '.cache', 'ms-playwright');
+// The real-browser leg needs the pinned chromium-1117 (playwright-core 1.44.1). It runs locally,
+// where that browser is installed; CI installs no Playwright browser, so the suite SKIPS VISIBLY
+// there rather than hard-failing.
+const HAS_PINNED_BROWSER = existsSync(path.join(BROWSERS_PATH, 'chromium-1117'));
+if (!HAS_PINNED_BROWSER)
+  console.warn(`[browser.test] chromium-1117 not under ${BROWSERS_PATH} - skipping the real-browser deferred cell (install the pinned browser to run it)`);
+
+let browser: Browser | undefined;
+let server: ChildProcess | undefined;
+let serverOutput = '';
+
+const isPortFree = async (port: number): Promise<boolean> =>
+  new Promise((resolve) => {
+    const probe = createServer();
+    probe.once('error', () => resolve(false));
+    probe.listen(port, '127.0.0.1', () => probe.close(() => resolve(true)));
+  });
+
+const stopServer = async (timeoutMs = 20_000) => {
+  if (!server) return;
+  const child = server;
+  server = undefined;
+
+  const exited = new Promise<void>((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) return resolve();
+    child.once('exit', () => resolve());
+  });
+  try {
+    if (child.pid) process.kill(-child.pid, 'SIGKILL');
+  } catch {
+    child.kill('SIGKILL');
+  }
+  await Promise.race([exited, new Promise((r) => setTimeout(r, timeoutMs))]);
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await isPortFree(PORT)) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`port ${PORT} still bound after teardown`);
+};
+
+/**
+ * Poll the DOM without `page.waitForFunction`: the enforced CSP has no `'unsafe-eval'`, and
+ * `waitForFunction` falls back to string evaluation, which the policy blocks. The fix is a wait
+ * that needs no eval rather than a weaker policy.
+ */
+const waitForText = async (page: Page, selector: string, needle: string, timeoutMs = 15_000) => {
+  const deadline = Date.now() + timeoutMs;
+  let last = '';
+  while (Date.now() < deadline) {
+    last = (await page.textContent(selector).catch(() => '')) ?? '';
+    if (last.includes(needle)) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`"${needle}" never appeared in ${selector} within ${timeoutMs}ms (last: "${last}")`);
+};
+
+type PageFaults = { pageErrors: string[]; cspViolations: string[]; consoleErrors: string[] };
+
+const openPage = async (): Promise<{ page: Page; faults: PageFaults }> => {
+  const context = await browser!.newContext();
+  const page = await context.newPage();
+  const faults: PageFaults = { pageErrors: [], cspViolations: [], consoleErrors: [] };
+
+  page.on('pageerror', (e) => faults.pageErrors.push(String(e.message ?? e)));
+  page.on('console', (m: ConsoleMessage) => {
+    if (m.type() === 'error') faults.consoleErrors.push(m.text());
+  });
+  // The CSP is ENFORCED, so a violation is a real block, not a report. Captured in-page because
+  // `securitypolicyviolation` is a DOM event, not a CDP one.
+  await page.addInitScript(() => {
+    (window as unknown as { __CSP_VIOLATIONS__: string[] }).__CSP_VIOLATIONS__ = [];
+    document.addEventListener('securitypolicyviolation', (e) => {
+      const ev = e as SecurityPolicyViolationEvent;
+      (window as unknown as { __CSP_VIOLATIONS__: string[] }).__CSP_VIOLATIONS__.push(`${ev.violatedDirective} blocked ${ev.blockedURI || '(inline)'}`);
+    });
+  });
+
+  return { page, faults };
+};
+
+const collectFaults = async (page: Page, faults: PageFaults): Promise<PageFaults> => {
+  faults.cspViolations = await page.evaluate(() => (window as unknown as { __CSP_VIOLATIONS__?: string[] }).__CSP_VIOLATIONS__ ?? []);
+
+  return faults;
+};
+
+const expectClean = (faults: PageFaults) => {
+  expect(faults.cspViolations, 'CSP violations').toEqual([]);
+  expect(faults.pageErrors, 'uncaught page errors').toEqual([]);
+  expect(faults.consoleErrors, 'console errors').toEqual([]);
+};
+
+describe.skipIf(!HAS_PINNED_BROWSER)('RFC 0007 product cell - React deferred route data (production build, enforced CSP)', () => {
+  beforeAll(async () => {
+    // Freshness guard (docs/followups/fixture-stale-dist-evidence-trap.md): this fixture resolves
+    // @taujs/server and @taujs/react through their gitignored dist, so a stale package build
+    // silently falsifies everything proved here. Rebuild both before the fixture build.
+    execFileSync('pnpm', ['--filter', '@taujs/server', '--filter', '@taujs/react', 'build'], { cwd: path.join(PROJECT, '..', '..'), stdio: 'pipe' });
+    execFileSync('npm', ['run', 'build'], { cwd: PROJECT, stdio: 'pipe', env: { ...process.env, TAUJS_PORT: String(PORT) } });
+
+    expect(await isPortFree(PORT), `port ${PORT} in use`).toBe(true);
+    serverOutput = '';
+    const child = spawn('npm', ['run', 'start'], {
+      cwd: PROJECT,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: true,
+      env: { ...process.env, TAUJS_PORT: String(PORT) },
+    });
+    server = child;
+    child.stdout?.on('data', (c: Buffer) => (serverOutput += String(c)));
+    child.stderr?.on('data', (c: Buffer) => (serverOutput += String(c)));
+
+    const deadline = Date.now() + 120_000;
+    for (;;) {
+      if (Date.now() > deadline) throw new Error(`server not ready\n${serverOutput}`);
+      if (child.exitCode !== null) throw new Error(`server exited (${child.exitCode})\n${serverOutput}`);
+      try {
+        if ((await fetch(`${BASE}/`)).status < 500) break;
+      } catch {
+        /* not listening yet */
+      }
+      await new Promise((r) => setTimeout(r, 250));
+    }
+
+    browser = await chromium.launch({ args: ['--no-sandbox'] });
+  }, 300_000);
+
+  afterAll(async () => {
+    await browser?.close();
+    browser = undefined;
+    await stopServer();
+  });
+
+  it('delivers a declared deferred entry in the browser, hydrates from the envelope and never refetches', async () => {
+    // The policy must actually be enforced, or every violation assertion below is vacuous.
+    const response = await fetch(`${BASE}/deferred`);
+    const enforced = response.headers.get('content-security-policy');
+    expect(enforced, 'no enforced CSP header').toBeTruthy();
+    expect(response.headers.get('content-security-policy-report-only')).toBeNull();
+    expect(enforced).toMatch(/script-src[^;]*'nonce-/);
+    expect(enforced, "'unsafe-inline' would make the nonce contract meaningless").not.toMatch(/script-src[^;]*'unsafe-inline'/);
+
+    const { page, faults } = await openPage();
+    const dataRequests: string[] = [];
+    page.on('request', (r) => {
+      if (r.resourceType() === 'fetch' || r.resourceType() === 'xhr') dataRequests.push(r.url());
+    });
+    try {
+      await page.goto(`${BASE}/deferred`, { waitUntil: 'networkidle' });
+
+      // Delivery: the value React patched in after the shell, still present after hydration.
+      await waitForText(page, '#reviews', 'reviews: 3');
+      expect(await page.textContent('#reviews')).toContain('a genuinely deferred review');
+      expect(await page.$('#reviews-pending')).toBeNull();
+
+      // Hydration seeded the boundary from the private end-of-stream envelope: no client fetch, and
+      // the carrier is read once and deleted, so it must be gone by the time we look.
+      expect(dataRequests, 'hydration issued a data request - the envelope must make that unnecessary').toEqual([]);
+      expect(await page.evaluate(() => '__TAUJS_DEFERRED_STATE__' in window)).toBe(false);
+
+      // Interactivity proves the root really hydrated with the deferred boundary in the tree.
+      await page.click('#counter');
+      await waitForText(page, '#counter', 'count: 1');
+
+      expectClean(await collectFaults(page, faults));
+    } finally {
+      await page.context().close();
+    }
+  });
+});

--- a/fixtures/playground-react/vitest.config.ts
+++ b/fixtures/playground-react/vitest.config.ts
@@ -1,0 +1,22 @@
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+import { defineConfig } from 'vitest/config';
+
+// playwright-core resolves its browsers directory at MODULE LOAD, so this must be set before the
+// test file imports it - setting it in `beforeAll` is too late. The value is Playwright's own
+// Linux default; it is stated explicitly because a sandboxed editor (Flatpak) redirects
+// XDG_CACHE_HOME and Playwright then looks somewhere the browsers were never installed.
+process.env.PLAYWRIGHT_BROWSERS_PATH ??= path.join(homedir(), '.cache', 'ms-playwright');
+
+export default defineConfig({
+  test: {
+    // This suite boots a real τjs server and drives it over HTTP - node only, and never in
+    // parallel (one port, one server lifecycle).
+    environment: 'node',
+    fileParallelism: false,
+    testTimeout: 300_000,
+    hookTimeout: 300_000,
+    env: { PLAYWRIGHT_BROWSERS_PATH: process.env.PLAYWRIGHT_BROWSERS_PATH },
+  },
+});

--- a/fixtures/playground-solid/src/client/App.tsx
+++ b/fixtures/playground-solid/src/client/App.tsx
@@ -1,5 +1,7 @@
 import { createResource, createSignal, ErrorBoundary, Show, Suspense } from 'solid-js';
-import { useSSRStore } from '@taujs/solid';
+import { createDeferredAccessor, useSSRStore } from '@taujs/solid';
+
+import type { DeferredRouteData } from '../server/routes/deferred.ts';
 
 export type RouteData = {
   title?: string;
@@ -46,6 +48,25 @@ function Counter() {
   );
 }
 
+/**
+ * RFC 0007: the ROUTE-DECLARED deferred read.
+ *
+ * The accessor is typed from the route config alone - `DeferredDataOf<typeof deferredRoute>` - so
+ * the payload shape is never re-declared here. The component starts nothing: the host began this
+ * work before the render, and `useDeferred` only projects the named promise onto Solid's own
+ * resource model, suspending this boundary and nothing else.
+ */
+const useDeferred = createDeferredAccessor<DeferredRouteData>();
+
+function DeferredReviews() {
+  const reviews = useDeferred('reviews');
+  // The annotation is the GATE: `count` is inferred from the route's `serviceData()` brand, so
+  // changing the service's declared result type fails this typecheck rather than shipping.
+  const count = (): number | undefined => reviews()?.count;
+
+  return <p id="reviews">{`reviews: ${String(count() ?? '')} - ${String(reviews()?.top ?? '')}`}</p>;
+}
+
 /** An app-owned resource that REJECTS after the shell, to exercise the sanitiser in a browser. */
 function RejectingNote() {
   const [note] = createResource(async () => {
@@ -86,6 +107,16 @@ export function App(props: { location: string }) {
       <Suspense fallback={<p id="deferred-pending">loading deferred…</p>}>
         <DeferredNote />
       </Suspense>
+
+      <Show when={props.location.startsWith('/deferred')}>
+        {/* PLACEMENT: the ErrorBoundary sits INSIDE the Suspense, which is what makes a `failed` or
+            `aborted` outcome render its fallback INTO the response rather than on the client. */}
+        <Suspense fallback={<p id="reviews-pending">loading reviews…</p>}>
+          <ErrorBoundary fallback={<p id="reviews-error">reviews unavailable</p>}>
+            <DeferredReviews />
+          </ErrorBoundary>
+        </Suspense>
+      </Show>
 
       <Show when={props.location.startsWith('/reject')}>
         <ErrorBoundary fallback={(error: unknown) => <p id="boundary">{`${(error as Error)?.name}: ${(error as Error)?.message}`}</p>}>

--- a/fixtures/playground-solid/src/server/routes/deferred.ts
+++ b/fixtures/playground-solid/src/server/routes/deferred.ts
@@ -1,0 +1,30 @@
+import { serviceData } from '../services/registry.ts';
+
+import type { DeferredDataOf } from '@taujs/server/config';
+
+/**
+ * RFC 0007: the deferred example route, declared ONCE here so its TYPE is nameable.
+ *
+ * `attr.data` is the critical snapshot; `attr.deferred` declares response-owned work that may
+ * complete after rendering begins. The host starts each named loader once per request, outside the
+ * component tree, and the renderer projects it onto Solid's own `<Suspense>`.
+ */
+export const deferredRoute = {
+  path: '/deferred',
+  attr: {
+    render: 'streaming',
+    meta: { title: 'τjs Solid playground - deferred route data' },
+    hydrate: true,
+    data: serviceData('content', 'home'),
+    deferred: {
+      reviews: serviceData('content', 'reviews'),
+    },
+  },
+} as const;
+
+/**
+ * The CROSS-PACKAGE inference gate: the component-facing accessor is typed from `typeof route`
+ * alone, so the application never re-declares a payload shape. Type-only, so importing it from the
+ * client bundle pulls in no server code.
+ */
+export type DeferredRouteData = DeferredDataOf<typeof deferredRoute>;

--- a/fixtures/playground-solid/src/server/services/content.service.ts
+++ b/fixtures/playground-solid/src/server/services/content.service.ts
@@ -17,6 +17,14 @@ export const contentService = defineService({
     ['__proto__']: { polluted: 'YES' },
   }),
 
+  // RFC 0007: a route-owned DEFERRED loader. It settles well after the shell, so the boundary that
+  // reads it is the one the deferred delivery path is observable through.
+  reviews: async (_params: {}) => {
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    return { count: 3, top: 'a genuinely deferred review' };
+  },
+
   streaming: async (_params: {}) => {
     // A deliberate delay so the streaming route visibly blocks at the async boundary. Under the
     // snapshot bridge the adapter gates the render on route readiness, so this delays the SHELL -

--- a/fixtures/playground-solid/taujs.config.ts
+++ b/fixtures/playground-solid/taujs.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from '@taujs/server/config';
 import { solidRenderer } from '@taujs/solid/renderer';
 
+import { deferredRoute } from './src/server/routes/deferred.ts';
 import { serviceData } from './src/server/services/registry.ts';
 
 // The Solid twin of fixtures/playground-react: one bootable app exercising @taujs/solid end to end
@@ -68,6 +69,19 @@ export default defineConfig({
             // patches require `_$HY` to exist.
             hydrate: false,
             data: serviceData('content', 'streaming'),
+          },
+        },
+        // RFC 0007: the deferred example route, declared in `src/server/routes/deferred.ts` so the
+        // client can name its inferred payload type (`DeferredDataOf<typeof deferredRoute>`).
+        deferredRoute,
+        {
+          // RFC 0007 decision 8: the same declaration with hydration off - native streamed delivery
+          // is unaffected and NO envelope is emitted, because there is no client runtime to seed.
+          path: '/deferred-no-hydrate',
+          attr: {
+            ...deferredRoute.attr,
+            meta: { title: 'τjs Solid playground - deferred, no hydrate' },
+            hydrate: false,
           },
         },
         {

--- a/fixtures/playground-solid/test/browser.test.ts
+++ b/fixtures/playground-solid/test/browser.test.ts
@@ -548,4 +548,56 @@ describe.skipIf(!HAS_PINNED_BROWSER)('slice 7 group C - real browser (production
       await page.context().close();
     }
   });
+
+  // ── RFC 0007: route-declared deferred data, end to end ────────────────────────────────────────
+
+  it('a declared deferred entry completes in the browser, hydrates and never refetches', async () => {
+    const { page, faults } = await openPage();
+    const dataRequests: string[] = [];
+    page.on('request', (r) => {
+      if (r.resourceType() === 'fetch' || r.resourceType() === 'xhr') dataRequests.push(r.url());
+    });
+    try {
+      await page.goto(`${BASE}/deferred`, { waitUntil: 'networkidle' });
+
+      await waitForText(page, '#reviews', 'reviews: 3');
+      expect(await page.textContent('#reviews')).toContain('a genuinely deferred review');
+      expect(await page.$('#reviews-pending')).toBeNull();
+      expect(await page.$('#reviews-error')).toBeNull();
+
+      // Hydration seeded the boundary from the private end-of-stream envelope: no client fetch, and
+      // the carrier is read once and deleted, so it must be gone by the time we look.
+      expect(dataRequests, 'hydration issued a data request - the envelope must make that unnecessary').toEqual([]);
+      expect(await page.evaluate(() => '__TAUJS_DEFERRED_STATE__' in window)).toBe(false);
+
+      // Interactivity proves the root really hydrated with the deferred boundary in the tree.
+      await page.click('#counter');
+      await waitForText(page, '#counter', 'count: 1');
+
+      expectClean(await collectFaults(page, faults));
+    } finally {
+      await page.context().close();
+    }
+  });
+
+  it('under hydrate:false the value still streams natively and NO envelope is emitted (decision 8)', async () => {
+    const { page, faults } = await openPage();
+    try {
+      const bytes = await (await fetch(`${BASE}/deferred-no-hydrate`)).text();
+      expect(bytes, 'native streamed delivery must be unaffected by the hydration policy').toContain('a genuinely deferred review');
+      expect(bytes, 'there is no client runtime to seed, so the carrier must be absent').not.toContain('__TAUJS_DEFERRED_STATE__');
+
+      // The hydrating control, fetched in the same test so the absence above cannot pass vacuously.
+      const hydrating = await (await fetch(`${BASE}/deferred`)).text();
+      expect(hydrating).toContain('__TAUJS_DEFERRED_STATE__');
+      expect(hydrating).toContain('"reviews":{"status":"complete"');
+
+      await page.goto(`${BASE}/deferred-no-hydrate`, { waitUntil: 'networkidle' });
+      expect(await page.textContent('#reviews')).toContain('a genuinely deferred review');
+
+      expectClean(await collectFaults(page, faults));
+    } finally {
+      await page.context().close();
+    }
+  });
 });

--- a/fixtures/playground-vue/package.json
+++ b/fixtures/playground-vue/package.json
@@ -4,9 +4,10 @@
   "type": "module",
   "scripts": {
     "dev": "NODE_ENV=development tsx watch --ignore vite.config.ts --tsconfig ./src/server/tsconfig.json ./src/server/index.ts",
-    "build": "tsx build.ts && BUILD_MODE=ssr tsx build.ts",
+    "build": "NODE_ENV=production tsx build.ts && NODE_ENV=production BUILD_MODE=ssr tsx build.ts",
     "start": "NODE_ENV=production tsx ./src/server/index.ts",
-    "typecheck": "vue-tsc --noEmit"
+    "typecheck": "vue-tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@taujs/server": "workspace:*",
@@ -18,9 +19,11 @@
   "devDependencies": {
     "@types/node": "^20.14.9",
     "@vitejs/plugin-vue": "^6.0.0",
+    "playwright-core": "1.44.1",
     "tsx": "^4.19.3",
     "typescript": "^5.7.3",
     "vite": "^7.1.11",
+    "vitest": "^3.2.4",
     "vue-tsc": "^2.1.10"
   }
 }

--- a/fixtures/playground-vue/src/client/App.vue
+++ b/fixtures/playground-vue/src/client/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { computed, inject } from 'vue';
+import { computed, inject, ref } from 'vue';
 
+import DeferredPage from './DeferredPage.vue';
 import HomePage from './HomePage.vue';
 import StreamingPage from './StreamingPage.vue';
 import { PLAYGROUND_KEY } from './setup-app';
@@ -10,9 +11,14 @@ const props = defineProps<{ location?: string }>();
 // Server passes `location`; on the client fall back to the current path so hydration matches.
 const path = computed(() => props.location ?? (typeof window !== 'undefined' ? window.location.pathname : '/'));
 const isStreaming = computed(() => path.value.startsWith('/streaming'));
+const isDeferred = computed(() => path.value.startsWith('/deferred'));
 
 // Provided by setupApp on both server and client — presence proves the hook ran on this path.
 const playgroundName = inject(PLAYGROUND_KEY, 'no-setup-app');
+
+// Proves hydration by EXECUTED BEHAVIOUR rather than markup: the server renders `count: 0`, and
+// only a hydrated, interactive root can turn a click into `count: 1`.
+const count = ref(0);
 </script>
 
 <template>
@@ -20,9 +26,19 @@ const playgroundName = inject(PLAYGROUND_KEY, 'no-setup-app');
     <h1>
       τjs Vue playground <small>(setupApp: {{ playgroundName }})</small>
     </h1>
-    <nav><a href="/">/ (ssr)</a> · <a href="/streaming">/streaming</a></nav>
+    <nav><a href="/">/ (ssr)</a> · <a href="/streaming">/streaming</a> · <a href="/deferred">/deferred</a></nav>
 
-    <Suspense v-if="isStreaming">
+    <button id="counter" type="button" @click="count += 1">count: {{ count }}</button>
+
+    <Suspense v-if="isDeferred">
+      <template #default>
+        <DeferredPage />
+      </template>
+      <template #fallback>
+        <p id="reviews-pending">loading reviews</p>
+      </template>
+    </Suspense>
+    <Suspense v-else-if="isStreaming">
       <template #default>
         <StreamingPage />
       </template>

--- a/fixtures/playground-vue/src/client/DeferredPage.vue
+++ b/fixtures/playground-vue/src/client/DeferredPage.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { createDeferredAccessor } from '@taujs/vue';
+
+import type { DeferredRouteData } from '../server/routes/deferred.ts';
+
+/**
+ * RFC 0007: the ROUTE-DECLARED deferred read.
+ *
+ * The accessor is typed from the route config alone - `DeferredDataOf<typeof deferredRoute>` - so
+ * the payload shape is never re-declared here. The component starts nothing: the host began this
+ * work before the render, and the result read only projects the named promise onto Vue's own async
+ * `setup()`, which the parent `<Suspense>` awaits.
+ *
+ * The RESULT read is the one to reach for: Vue renders each subtree once, so a handled `failed` or
+ * `aborted` branch renders INTO the response rather than only on the client.
+ */
+const deferred = createDeferredAccessor<DeferredRouteData>();
+const outcome = await deferred.result('reviews');
+</script>
+
+<template>
+  <p v-if="outcome.status === 'complete'" id="reviews">reviews: {{ outcome.value.count }} - {{ outcome.value.top }}</p>
+  <p v-else id="reviews-error">reviews unavailable ({{ outcome.status }})</p>
+</template>

--- a/fixtures/playground-vue/src/server/routes/deferred.ts
+++ b/fixtures/playground-vue/src/server/routes/deferred.ts
@@ -1,0 +1,32 @@
+import { serviceData } from '../services/registry.ts';
+
+import type { DeferredDataOf } from '@taujs/server/config';
+
+/**
+ * RFC 0007: the deferred example route, declared ONCE here so its TYPE is nameable.
+ *
+ * `attr.data` is the critical snapshot; `attr.deferred` declares response-owned work that may
+ * complete after rendering begins. The host starts each named loader once per request, outside the
+ * component tree, and `@taujs/vue` projects it onto Vue's own async `setup()` under `<Suspense>`.
+ */
+export const deferredRoute = {
+  path: '/deferred',
+  attr: {
+    render: 'streaming',
+    meta: { title: 'τjs Vue playground - deferred route data' },
+    hydrate: true,
+    // The critical snapshot is CHEAP here on purpose: the deferred entry must still be in flight
+    // when its boundary renders, or the delivery path is never exercised.
+    data: serviceData('content', 'home'),
+    deferred: {
+      reviews: serviceData('content', 'reviews'),
+    },
+  },
+} as const;
+
+/**
+ * The CROSS-PACKAGE inference gate: the component-facing accessor is typed from `typeof route`
+ * alone, so the application never re-declares a payload shape. Type-only, so importing it from the
+ * client bundle pulls in no server code.
+ */
+export type DeferredRouteData = DeferredDataOf<typeof deferredRoute>;

--- a/fixtures/playground-vue/src/server/services/content.service.ts
+++ b/fixtures/playground-vue/src/server/services/content.service.ts
@@ -13,6 +13,14 @@ export const contentService = defineService({
     ogTitle: `Hello ${params.name} | τjs Vue playground`,
     ogDescription: `Live head data for ${params.name}`,
   }),
+  // RFC 0007: a route-owned DEFERRED loader. It settles well after the shell, so the boundary that
+  // reads it is the one the deferred delivery path is observable through.
+  reviews: async (_params: {}) => {
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    return { count: 3, top: 'a genuinely deferred review' };
+  },
+
   greet: async (params: { name: string }) => {
     // A deliberate delay so the streaming route visibly blocks at the async boundary.
     await new Promise((resolve) => setTimeout(resolve, 400));

--- a/fixtures/playground-vue/taujs.config.ts
+++ b/fixtures/playground-vue/taujs.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from '@taujs/server/config';
 import { vueRenderer } from '@taujs/vue/renderer';
 
+import { deferredRoute } from './src/server/routes/deferred.ts';
 import { serviceData } from './src/server/services/registry.ts';
 
 // The Vue twin of fixtures/playground-react: one bootable app that exercises @taujs/vue end to end
@@ -9,9 +10,25 @@ import { serviceData } from './src/server/services/registry.ts';
 // SFCs need in dev and build.
 export default defineConfig({
   server: {
-    port: 5273,
+    // The real-browser suite boots this fixture on its own port (5302) so it never collides with a
+    // developer's dev server; everything else keeps the fixture's stable default.
+    port: Number(process.env.TAUJS_PORT ?? 5273),
     host: 'localhost',
     hmrPort: 5274,
+  },
+  // An ENFORCED CSP (not report-only), so the browser acceptance runs against a real policy rather
+  // than merely observing nonce attributes. `script-src` carries no 'unsafe-inline', so any inline
+  // script the renderer emits WITHOUT the request nonce is blocked by the browser and raises a
+  // securitypolicyviolation - which is exactly what the browser suite asserts never happens.
+  security: {
+    csp: {
+      defaultMode: 'merge',
+      directives: {
+        'default-src': ["'self'"],
+        'style-src': ["'self'", "'unsafe-inline'"],
+        'img-src': ["'self'", 'data:'],
+      },
+    },
   },
   apps: [
     {
@@ -44,6 +61,9 @@ export default defineConfig({
             head: { data: serviceData('content', 'greetHead', () => ({ name: 'Vue' })) },
           },
         },
+        // RFC 0007: the deferred example route, declared in `src/server/routes/deferred.ts` so the
+        // client can name its inferred payload type (`DeferredDataOf<typeof deferredRoute>`).
+        deferredRoute,
       ],
     },
   ],

--- a/fixtures/playground-vue/test/browser.test.ts
+++ b/fixtures/playground-vue/test/browser.test.ts
@@ -1,0 +1,200 @@
+// @vitest-environment node
+import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { createServer } from 'node:net';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { chromium, type Browser, type ConsoleMessage, type Page } from 'playwright-core';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
+ * RFC 0007: the @taujs/vue PRODUCT cell for deferred route data.
+ *
+ * One compact real-browser acceptance, deliberately not a port of the disposable proof matrix: a
+ * production build served by a real τjs server under an ENFORCED Content-Security-Policy, driven
+ * in Chromium. It proves by EXECUTION what markup inspection cannot - successful deferred
+ * delivery, hydration seeded from the private envelope, no refetch, the carrier deleted, and no
+ * CSP violation anywhere in the flow.
+ *
+ * Pinned tuple: playwright-core 1.44.1 <-> chromium-1117 (125.x).
+ */
+const PROJECT = fileURLToPath(new URL('../', import.meta.url));
+const PORT = 5302;
+const BASE = `http://127.0.0.1:${PORT}`;
+const BROWSERS_PATH = path.join(homedir(), '.cache', 'ms-playwright');
+// The real-browser leg needs the pinned chromium-1117 (playwright-core 1.44.1). It runs locally,
+// where that browser is installed; CI installs no Playwright browser, so the suite SKIPS VISIBLY
+// there rather than hard-failing.
+const HAS_PINNED_BROWSER = existsSync(path.join(BROWSERS_PATH, 'chromium-1117'));
+if (!HAS_PINNED_BROWSER)
+  console.warn(`[browser.test] chromium-1117 not under ${BROWSERS_PATH} - skipping the real-browser deferred cell (install the pinned browser to run it)`);
+
+let browser: Browser | undefined;
+let server: ChildProcess | undefined;
+let serverOutput = '';
+
+const isPortFree = async (port: number): Promise<boolean> =>
+  new Promise((resolve) => {
+    const probe = createServer();
+    probe.once('error', () => resolve(false));
+    probe.listen(port, '127.0.0.1', () => probe.close(() => resolve(true)));
+  });
+
+const stopServer = async (timeoutMs = 20_000) => {
+  if (!server) return;
+  const child = server;
+  server = undefined;
+
+  const exited = new Promise<void>((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) return resolve();
+    child.once('exit', () => resolve());
+  });
+  try {
+    if (child.pid) process.kill(-child.pid, 'SIGKILL');
+  } catch {
+    child.kill('SIGKILL');
+  }
+  await Promise.race([exited, new Promise((r) => setTimeout(r, timeoutMs))]);
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await isPortFree(PORT)) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`port ${PORT} still bound after teardown`);
+};
+
+/**
+ * Poll the DOM without `page.waitForFunction`: the enforced CSP has no `'unsafe-eval'`, and
+ * `waitForFunction` falls back to string evaluation, which the policy blocks. The fix is a wait
+ * that needs no eval rather than a weaker policy.
+ */
+const waitForText = async (page: Page, selector: string, needle: string, timeoutMs = 15_000) => {
+  const deadline = Date.now() + timeoutMs;
+  let last = '';
+  while (Date.now() < deadline) {
+    last = (await page.textContent(selector).catch(() => '')) ?? '';
+    if (last.includes(needle)) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`"${needle}" never appeared in ${selector} within ${timeoutMs}ms (last: "${last}")`);
+};
+
+type PageFaults = { pageErrors: string[]; cspViolations: string[]; consoleErrors: string[] };
+
+const openPage = async (): Promise<{ page: Page; faults: PageFaults }> => {
+  const context = await browser!.newContext();
+  const page = await context.newPage();
+  const faults: PageFaults = { pageErrors: [], cspViolations: [], consoleErrors: [] };
+
+  page.on('pageerror', (e) => faults.pageErrors.push(String(e.message ?? e)));
+  page.on('console', (m: ConsoleMessage) => {
+    if (m.type() === 'error') faults.consoleErrors.push(m.text());
+  });
+  // The CSP is ENFORCED, so a violation is a real block, not a report. Captured in-page because
+  // `securitypolicyviolation` is a DOM event, not a CDP one.
+  await page.addInitScript(() => {
+    (window as unknown as { __CSP_VIOLATIONS__: string[] }).__CSP_VIOLATIONS__ = [];
+    document.addEventListener('securitypolicyviolation', (e) => {
+      const ev = e as SecurityPolicyViolationEvent;
+      (window as unknown as { __CSP_VIOLATIONS__: string[] }).__CSP_VIOLATIONS__.push(`${ev.violatedDirective} blocked ${ev.blockedURI || '(inline)'}`);
+    });
+  });
+
+  return { page, faults };
+};
+
+const collectFaults = async (page: Page, faults: PageFaults): Promise<PageFaults> => {
+  faults.cspViolations = await page.evaluate(() => (window as unknown as { __CSP_VIOLATIONS__?: string[] }).__CSP_VIOLATIONS__ ?? []);
+
+  return faults;
+};
+
+const expectClean = (faults: PageFaults) => {
+  expect(faults.cspViolations, 'CSP violations').toEqual([]);
+  expect(faults.pageErrors, 'uncaught page errors').toEqual([]);
+  expect(faults.consoleErrors, 'console errors').toEqual([]);
+};
+
+describe.skipIf(!HAS_PINNED_BROWSER)('RFC 0007 product cell - Vue deferred route data (production build, enforced CSP)', () => {
+  beforeAll(async () => {
+    // Freshness guard (docs/followups/fixture-stale-dist-evidence-trap.md): this fixture resolves
+    // @taujs/server and @taujs/vue through their gitignored dist, so a stale package build
+    // silently falsifies everything proved here. Rebuild both before the fixture build.
+    execFileSync('pnpm', ['--filter', '@taujs/server', '--filter', '@taujs/vue', 'build'], { cwd: path.join(PROJECT, '..', '..'), stdio: 'pipe' });
+    execFileSync('npm', ['run', 'build'], { cwd: PROJECT, stdio: 'pipe', env: { ...process.env, TAUJS_PORT: String(PORT) } });
+
+    expect(await isPortFree(PORT), `port ${PORT} in use`).toBe(true);
+    serverOutput = '';
+    const child = spawn('npm', ['run', 'start'], {
+      cwd: PROJECT,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: true,
+      env: { ...process.env, TAUJS_PORT: String(PORT) },
+    });
+    server = child;
+    child.stdout?.on('data', (c: Buffer) => (serverOutput += String(c)));
+    child.stderr?.on('data', (c: Buffer) => (serverOutput += String(c)));
+
+    const deadline = Date.now() + 120_000;
+    for (;;) {
+      if (Date.now() > deadline) throw new Error(`server not ready\n${serverOutput}`);
+      if (child.exitCode !== null) throw new Error(`server exited (${child.exitCode})\n${serverOutput}`);
+      try {
+        if ((await fetch(`${BASE}/`)).status < 500) break;
+      } catch {
+        /* not listening yet */
+      }
+      await new Promise((r) => setTimeout(r, 250));
+    }
+
+    browser = await chromium.launch({ args: ['--no-sandbox'] });
+  }, 300_000);
+
+  afterAll(async () => {
+    await browser?.close();
+    browser = undefined;
+    await stopServer();
+  });
+
+  it('delivers a declared deferred entry in the browser, hydrates from the envelope and never refetches', async () => {
+    // The policy must actually be enforced, or every violation assertion below is vacuous.
+    const response = await fetch(`${BASE}/deferred`);
+    const enforced = response.headers.get('content-security-policy');
+    expect(enforced, 'no enforced CSP header').toBeTruthy();
+    expect(response.headers.get('content-security-policy-report-only')).toBeNull();
+    expect(enforced).toMatch(/script-src[^;]*'nonce-/);
+    expect(enforced, "'unsafe-inline' would make the nonce contract meaningless").not.toMatch(/script-src[^;]*'unsafe-inline'/);
+
+    const { page, faults } = await openPage();
+    const dataRequests: string[] = [];
+    page.on('request', (r) => {
+      if (r.resourceType() === 'fetch' || r.resourceType() === 'xhr') dataRequests.push(r.url());
+    });
+    try {
+      await page.goto(`${BASE}/deferred`, { waitUntil: 'networkidle' });
+
+      // Delivery: Vue streams in order, so the boundary emits the resolved value itself once the
+      // entry settles. It is still present after hydration.
+      await waitForText(page, '#reviews', 'reviews: 3');
+      expect(await page.textContent('#reviews')).toContain('a genuinely deferred review');
+      expect(await page.$('#reviews-pending')).toBeNull();
+      expect(await page.$('#reviews-error')).toBeNull();
+
+      // Hydration seeded the boundary from the private end-of-stream envelope: no client fetch, and
+      // the carrier is read once and deleted, so it must be gone by the time we look.
+      expect(dataRequests, 'hydration issued a data request - the envelope must make that unnecessary').toEqual([]);
+      expect(await page.evaluate(() => '__TAUJS_DEFERRED_STATE__' in window)).toBe(false);
+
+      // Interactivity proves the root really hydrated with the deferred boundary in the tree.
+      await page.click('#counter');
+      await waitForText(page, '#counter', 'count: 1');
+
+      expectClean(await collectFaults(page, faults));
+    } finally {
+      await page.context().close();
+    }
+  });
+});

--- a/fixtures/playground-vue/vitest.config.ts
+++ b/fixtures/playground-vue/vitest.config.ts
@@ -1,0 +1,22 @@
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+import { defineConfig } from 'vitest/config';
+
+// playwright-core resolves its browsers directory at MODULE LOAD, so this must be set before the
+// test file imports it - setting it in `beforeAll` is too late. The value is Playwright's own
+// Linux default; it is stated explicitly because a sandboxed editor (Flatpak) redirects
+// XDG_CACHE_HOME and Playwright then looks somewhere the browsers were never installed.
+process.env.PLAYWRIGHT_BROWSERS_PATH ??= path.join(homedir(), '.cache', 'ms-playwright');
+
+export default defineConfig({
+  test: {
+    // This suite boots a real τjs server and drives it over HTTP - node only, and never in
+    // parallel (one port, one server lifecycle).
+    environment: 'node',
+    fileParallelism: false,
+    testTimeout: 300_000,
+    hookTimeout: 300_000,
+    env: { PLAYWRIGHT_BROWSERS_PATH: process.env.PLAYWRIGHT_BROWSERS_PATH },
+  },
+});

--- a/packages/mcp/src/test/DeferredTraces.test.ts
+++ b/packages/mcp/src/test/DeferredTraces.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment node
+// RFC 0007 (R5, product acceptance): ONE REAL MCP READ proving a deferred outcome is visible to the
+// existing trace tool. No new MCP tool: the additive-optional `deferredData` field rides the
+// existing trace record through the real assembler, the real artefact writer, the real substrate
+// reader and the real `taujs_get_trace` handler.
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { describe, it, expect, beforeAll } from 'vitest';
+
+import { createDevIntrospection } from '../../../server/src/core/introspection/DevIntrospection';
+import { writeTaujsArtifact } from '../../../server/src/core/introspection/EmitGraph';
+import { createRequestGraph } from '../../../server/src/core/introspection/RequestGraph';
+
+import { allTools } from '../server';
+
+import type { CoreTaujsConfig } from '../../../server/src/core/config/types';
+import type { DevJson } from '../types';
+import type { ToolResult } from '../toolkit';
+
+const config: CoreTaujsConfig = {
+  apps: [
+    {
+      appId: 'playground-react',
+      entryPoint: '',
+      routes: [{ path: '/product/:id', attr: { render: 'streaming', meta: {}, deferred: { reviews: async () => ({ count: 3 }) } } as never }],
+    },
+  ],
+};
+
+let tools: Map<string, (args: Record<string, unknown>) => ToolResult>;
+
+beforeAll(async () => {
+  const root = await mkdtemp(path.join(tmpdir(), 'taujs-mcp-deferred-'));
+  const dir = path.join(root, 'node_modules', '.taujs');
+  const dev = createDevIntrospection();
+
+  // One streaming request whose declared deferred entries settle three different ways.
+  dev.recorder.requestStart({ traceId: 'deferred-1', url: '/product/42', method: 'GET' });
+  dev.recorder.routeMatched({ traceId: 'deferred-1', path: '/product/:id', appId: 'playground-react', render: 'streaming' });
+  dev.recorder.deferredData({ traceId: 'deferred-1', key: 'reviews', ms: 41.2, outcome: 'complete' });
+  dev.recorder.deferredData({ traceId: 'deferred-1', key: 'blurb', ms: 5, outcome: 'failed' });
+  dev.recorder.deferredData({ traceId: 'deferred-1', key: 'stock', ms: 120, outcome: 'aborted' });
+  dev.recorder.sent({ traceId: 'deferred-1', status: 200, mode: 'streaming' });
+
+  await writeTaujsArtifact(dir, 'graph.json', JSON.stringify(createRequestGraph(config, { source: 'boot', emittedAt: '2026-07-28T11:00:00.000Z' })));
+  await writeTaujsArtifact(
+    dir,
+    'traces.ndjson',
+    dev
+      .getTraces()
+      .map((t) => JSON.stringify(t))
+      .join('\n') + '\n',
+  );
+
+  const devJson: DevJson = {
+    bootId: dev.bootId,
+    token: 'tok',
+    pid: process.pid,
+    startedAt: '2026-07-28T11:00:00.000Z',
+    host: '127.0.0.1',
+    port: 5173,
+    graph: path.join(dir, 'graph.json'),
+    traces: path.join(dir, 'traces.ndjson'),
+    logs: path.join(dir, 'logs.ndjson'),
+    observations: path.join(dir, 'observations.json'),
+  };
+  await writeTaujsArtifact(dir, 'dev.json', JSON.stringify(devJson));
+
+  tools = new Map(allTools(root).map((t) => [t.name, t.handler]));
+});
+
+describe('MCP surfaces RFC 0007 deferred outcomes with no new tool', () => {
+  it('taujs_get_trace: every declared key and its outcome is readable, detail-free', () => {
+    const result = tools.get('taujs_get_trace')!({ traceId: 'deferred-1' }) as any;
+
+    expect(result.ok).toBe(true);
+    expect((result.trace as { deferredData?: unknown }).deferredData).toEqual([
+      { key: 'reviews', outcome: 'complete', ms: 41.2 },
+      { key: 'blurb', outcome: 'failed', ms: 5 },
+      { key: 'stock', outcome: 'aborted', ms: 120 },
+    ]);
+  });
+
+  it('taujs_get_route: the declared deferred edge rides the existing route row as-is', () => {
+    const result = tools.get('taujs_get_route')!({ path: '/product/:id' }) as any;
+
+    expect(result.ok).toBe(true);
+    expect(result.routes[0].deferred).toEqual([{ key: 'reviews', data: { kind: 'dynamic' } }]);
+  });
+});

--- a/packages/react/src/SSRDeferredData.tsx
+++ b/packages/react/src/SSRDeferredData.tsx
@@ -1,0 +1,313 @@
+import React, { createContext, use, useContext } from 'react';
+
+/**
+ * RFC 0007 - the @taujs/react deferred-data adapter: the smallest projection of a named host
+ * promise into React's own `use()` + `<Suspense>` model.
+ *
+ *  - SERVER: `opts.deferredData` (the host's request-local registry) becomes one tracked thenable
+ *    per CONSUMED key. Reading suspends only the reading boundary, and React's OWN streaming and
+ *    patch mechanism delivers the late HTML - τjs emits no framework-patch bytes.
+ *  - CLIENT: each consumed boundary is seeded from the private end-of-stream envelope, read
+ *    synchronously in document order by the bootstrap, so hydration re-executes no loader and
+ *    issues no refetch. Every seeded entry is ALREADY SETTLED, so `use()` returns (or throws)
+ *    synchronously - no suspension, no second render pass.
+ *
+ * Host contract this adapter consumes and never re-implements: entries are already started and
+ * already pre-observed; a resolved entry is the host's settlement snapshot (parsed JSON, sharing no
+ * identity with the loader's object); a value that could not be snapshotted arrives as a
+ * detail-free rejection, indistinguishable from any other rejected entry.
+ *
+ * EXPORT HYGIENE (renderer contract item 9 / decision 10): only `createDeferredAccessor`,
+ * `useDeferredData`, `useDeferredDataResult`, `DeferredDataError` and the `DeferredResult` type
+ * reach `index.ts`. The carrier constant, both holders, the provider and the hydration reader are
+ * private transport - module-exported for `SSRRender`/`SSRHydration` and the package's own tests,
+ * never from the package root.
+ */
+
+/** @internal The host's internal transport (`RenderOptions.deferredData`), structurally re-stated. */
+export type DeferredDataRegistry = Readonly<Record<string, Promise<Record<string, unknown>>>>;
+
+/** @internal RFC 0007 (R4): the only three v1 outcomes. `failed` carries NO message, stack or detail. */
+export type DeferredOutcome = { status: 'complete'; value: Record<string, unknown> } | { status: 'failed' } | { status: 'aborted' };
+
+/** @internal */
+export type DeferredHydrationState = Readonly<Record<string, DeferredOutcome>>;
+
+/**
+ * @internal The private, UNDOCUMENTED envelope carrier the host attaches at its existing
+ * end-of-stream write site. Applications must never read it: it is not exported from the package
+ * root, and the bootstrap reads it once and deletes it.
+ */
+export const DEFERRED_STATE_CARRIER = '__TAUJS_DEFERRED_STATE__';
+
+/**
+ * The terminal error for a boundary whose value never arrived, thrown by the THROWING accessor.
+ *
+ * Both non-complete outcomes reject, and the two are distinguishable by `outcome` so an application
+ * can render "unavailable" differently from "failed" without ever seeing server detail. Nothing
+ * here carries a server message, stack or cause - `key` is route CONFIGURATION, already visible in
+ * the application's own source.
+ */
+export class DeferredDataError extends Error {
+  readonly key: string;
+  readonly outcome: 'failed' | 'aborted';
+
+  constructor(key: string, outcome: 'failed' | 'aborted') {
+    super(`taujs: deferred data "${key}" did not arrive (${outcome})`);
+    this.name = 'DeferredDataError';
+    this.key = key;
+    this.outcome = outcome;
+  }
+}
+
+/** The typed, per-key result an application branches on - structurally the envelope's own shape. */
+export type DeferredResult<T extends Record<string, unknown> = Record<string, unknown>> =
+  { status: 'complete'; value: T } | { status: 'failed' } | { status: 'aborted' };
+
+/**
+ * React's `use()` thenable protocol: a thenable carrying `status`/`value`/`reason` is consumed
+ * SYNCHRONOUSLY when already settled, and suspends only while `status === 'pending'`. This is the
+ * shape React itself produces for cached/streamed promises, and it is what makes a hydration read
+ * of an already-complete outcome a zero-suspense, zero-mismatch read.
+ */
+type TrackedThenable = PromiseLike<Record<string, unknown>> & {
+  status: 'pending' | 'fulfilled' | 'rejected';
+  value?: Record<string, unknown>;
+  reason?: unknown;
+};
+
+const unknownKeyError = (key: string, keys: readonly string[]): Error =>
+  new Error(
+    `taujs: unknown deferred data key "${key}". This route declares [${keys.map((k) => `"${k}"`).join(', ')}]. ` +
+      "Declared keys come from the route's `attr.deferred` record; the host does not validate reads.",
+  );
+
+const releasedError = (key: string): Error => new Error(`taujs: deferred data "${key}" was read after the response terminal; the holder has been released.`);
+
+const ownKey = (source: object, key: string): boolean => Object.prototype.hasOwnProperty.call(source, key);
+
+/**
+ * Track a HOST-owned promise without mutating it: the registry is response-owned and frozen by
+ * contract, so React's bookkeeping lives on our own wrapper, which only DELEGATES `then`. The
+ * status handlers are attached HERE, before React attaches its retry ping, so the status is always
+ * current by the time React re-reads it.
+ */
+const track = (promise: PromiseLike<Record<string, unknown>>): TrackedThenable => {
+  const tracked: TrackedThenable = { status: 'pending', then: (onFulfilled, onRejected) => promise.then(onFulfilled, onRejected) };
+
+  void promise.then(
+    (value) => {
+      if (tracked.status !== 'pending') return;
+      tracked.status = 'fulfilled';
+      tracked.value = value;
+    },
+    (reason) => {
+      if (tracked.status !== 'pending') return;
+      tracked.status = 'rejected';
+      tracked.reason = reason;
+    },
+  );
+
+  return tracked;
+};
+
+/** An ALREADY-SETTLED thenable we own outright: client seeding, and post-deadline server reads. */
+const settled = (outcome: DeferredOutcome, key: string): TrackedThenable => {
+  if (outcome.status === 'complete') {
+    const promise = Promise.resolve(outcome.value);
+
+    return { status: 'fulfilled', value: outcome.value, then: (f, r) => promise.then(f, r) };
+  }
+
+  const reason = new DeferredDataError(key, outcome.status);
+  const promise = Promise.reject(reason);
+  promise.catch(() => {}); // pre-observed: a boundary that is never rendered must stay harmless
+
+  return { status: 'rejected', reason, then: (f, r) => promise.then(f, r) };
+};
+
+/**
+ * @internal The per-request (server) / per-root (client) holder. `resource()` is a RENDER-PHASE
+ * read returning the tracked thenable `use()` consumes, so the suspension is React's, not ours.
+ */
+export type DeferredHolder = {
+  readonly keys: readonly string[];
+  // A bare `PromiseLike`: React's `use()` overloads discriminate on a literal `status`, so the
+  // tracked shape stays module-internal and is re-narrowed at the one site that reads it.
+  resource: (key: string) => PromiseLike<Record<string, unknown>>;
+  /**
+   * The response-level deferred deadline (decision 18). LATCHES, so a read registering afterwards
+   * is born `aborted` rather than starting a fresh unbounded wait, and returns how many CONSUMED
+   * entries were still pending - the renderer abandons those through React's own `stream.abort`.
+   */
+  expire: () => number;
+  /** Terminal: drop every retained value, promise and source reference. Idempotent. */
+  release: () => void;
+};
+
+const createHolder = (keys: readonly string[], make: (key: string) => TrackedThenable, guard: (key: string) => void, onRelease: () => void): DeferredHolder => {
+  const entries = new Map<string, TrackedThenable>();
+  let released = false;
+  let expired = false;
+
+  return {
+    keys,
+
+    resource(key: string) {
+      const existing = entries.get(key);
+      if (existing) return existing;
+      if (released) throw releasedError(key);
+      guard(key);
+
+      const entry = expired ? settled({ status: 'aborted' }, key) : make(key);
+      entries.set(key, entry);
+
+      return entry;
+    },
+
+    expire() {
+      expired = true;
+      let pending = 0;
+      for (const entry of entries.values()) if (entry.status === 'pending') pending += 1;
+
+      return pending;
+    },
+
+    release() {
+      released = true;
+      entries.clear();
+      onRelease();
+    },
+  };
+};
+
+/**
+ * @internal SERVER holder over the host's registry (renderer contract items 1, 7, 8).
+ *
+ * Entries are tracked LAZILY, on first read, so an unconsumed key is never observed here and never
+ * counts towards the deadline - the host has already pre-observed every promise, so an unconsumed
+ * rejection stays harmless.
+ */
+export const createDeferredHolder = (registry: DeferredDataRegistry): DeferredHolder => {
+  let source: DeferredDataRegistry | undefined = registry;
+  const keys = Object.freeze(Object.keys(registry));
+
+  return createHolder(
+    keys,
+    (key) => track(source![key]!),
+    (key) => {
+      if (!source) throw releasedError(key);
+      if (!ownKey(source, key)) throw unknownKeyError(key, keys);
+    },
+    () => {
+      source = undefined;
+    },
+  );
+};
+
+/** @internal CLIENT holder over the private envelope. Every entry is already settled at creation. */
+export const createHydrationHolder = (state: DeferredHydrationState): DeferredHolder => {
+  const keys = Object.freeze(Object.keys(state));
+
+  return createHolder(
+    keys,
+    (key) => settled(state[key]!, key),
+    (key) => {
+      if (!ownKey(state, key)) throw unknownKeyError(key, keys);
+    },
+    () => {},
+  );
+};
+
+const DeferredDataContext = createContext<DeferredHolder | null>(null);
+
+/** @internal Wiring, never an application surface (decision 10). */
+export const DeferredDataProvider = ({ holder, children }: React.PropsWithChildren<{ holder: DeferredHolder }>) => (
+  <DeferredDataContext.Provider value={holder}>{children}</DeferredDataContext.Provider>
+);
+
+const holderOrThrow = (accessor: string, key: string): DeferredHolder => {
+  const holder = useContext(DeferredDataContext);
+  if (!holder) {
+    throw new Error(
+      `taujs: ${accessor}("${key}") was called outside a deferred-data provider. ` +
+        "Only a `render: 'streaming'` route that declares `attr.deferred` provides one.",
+    );
+  }
+
+  return holder;
+};
+
+/**
+ * THROWING read. Suspends the nearest `<Suspense>` while the entry is pending and throws into the
+ * nearest error boundary when it failed or was aborted. An unknown key is a deterministic DEVELOPER
+ * error naming the declared set - never a suspended boundary and never `undefined`.
+ *
+ * `react-dom/server` (Fizz) has NO server-side error boundaries: a rejected read errors the nearest
+ * `<Suspense>`, which React hands to the client to render. That is React's native model, and it is
+ * why {@link useDeferredDataResult} - not this read - is the path that completes the RESPONSE with
+ * a handled fallback (decision 13).
+ */
+export function useDeferredData<T extends Record<string, unknown> = Record<string, unknown>>(key: string): T {
+  return use(holderOrThrow('useDeferredData', key).resource(key)) as T;
+}
+
+/**
+ * RESULT read - React's server-completing consumed-rejection path (decision 13).
+ *
+ * It still SUSPENDS natively while the entry is pending, then returns the outcome as a value, so an
+ * application renders a handled fallback INTO the streamed document. `failed` and `aborted` carry
+ * no value, message, stack or cause.
+ */
+export function useDeferredDataResult<T extends Record<string, unknown> = Record<string, unknown>>(key: string): DeferredResult<T> {
+  // Read the tracked status FIRST rather than try/catching `use()`: React signals a suspension by
+  // throwing an unexported internal sentinel, so a catch-based version would have to guess at
+  // React's control flow. A still-pending entry falls through to `use()` and suspends natively;
+  // React retries once it settles, and this same check then sees the rejection.
+  const resource = holderOrThrow('useDeferredDataResult', key).resource(key) as TrackedThenable;
+
+  if (resource.status === 'rejected') return { status: resource.reason instanceof DeferredDataError ? resource.reason.outcome : 'failed' };
+
+  return { status: 'complete', value: use(resource as PromiseLike<T>) as T };
+}
+
+/**
+ * The typed component-facing façade. `D` comes from the route config
+ * (`DeferredDataOf<typeof route>`), so the key is checked and the payload type DERIVED - an
+ * application never re-declares a payload shape:
+ *
+ * ```ts
+ * const useDeferred = createDeferredAccessor<DeferredDataOf<typeof productRoute>>();
+ * const reviews = useDeferred('reviews'); // typed from the route's serviceData() brand
+ * ```
+ *
+ * A factory rather than a two-type-parameter hook on purpose: TypeScript cannot infer one type
+ * argument while another is supplied explicitly, so `useDeferredData<D>('reviews')` would collapse
+ * the return to a union over every declared key.
+ */
+export function createDeferredAccessor<D>() {
+  return function useDeferred<K extends keyof D & string>(key: K): D[K] {
+    return useDeferredData(key) as D[K];
+  };
+}
+
+/**
+ * @internal Read the private envelope ONCE, synchronously, in document order, and drop the carrier.
+ *
+ * An ABSENT carrier is the ordinary case - a route that declared nothing, and (decision 8)
+ * `hydrate: false` - never an error and never a reason to fetch.
+ */
+export const takeDeferredHydrationState = (): DeferredHydrationState | undefined => {
+  try {
+    const w = window as unknown as Record<string, unknown>;
+    const raw = w[DEFERRED_STATE_CARRIER];
+    delete w[DEFERRED_STATE_CARRIER];
+
+    if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+
+    return raw as DeferredHydrationState;
+  } catch {
+    // A hostile or absent global must never break bootstrap.
+    return undefined;
+  }
+};

--- a/packages/react/src/SSRHydration.tsx
+++ b/packages/react/src/SSRHydration.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { createRoot, hydrateRoot } from 'react-dom/client';
 
 import { createSSRStore, SSRStoreProvider } from './SSRDataStore.js';
+import { createHydrationHolder, DeferredDataProvider, takeDeferredHydrationState } from './SSRDeferredData.js';
 import { createUILogger } from './utils/Logger.js';
 
+import type { DeferredHolder } from './SSRDeferredData.js';
 import type { LoggerLike } from './utils/Logger.js';
 
 // Dev-only introspection hook, set by the server-injected dev script (never by users).
@@ -200,22 +202,29 @@ export function hydrateApp<T>({
 
   // The tree React renders. The commit reporter WRAPS the app (adds tree depth only, no DOM and no
   // `useId` shift — see CommitReporter); its effect calls the single `reportSuccess`.
-  const buildTree = (store: ReturnType<typeof createSSRStore<T>>) => (
-    <React.StrictMode>
-      <SSRStoreProvider store={store}>
-        <CommitReporter onCommit={reportSuccess}>{appComponent}</CommitReporter>
-      </SSRStoreProvider>
-    </React.StrictMode>
-  );
+  //
+  // RFC 0007 (R4): the deferred provider is inserted ONLY when the private envelope was present, so
+  // a page whose route declared nothing builds exactly the tree it builds today. Every seeded entry
+  // is ALREADY SETTLED, so the boundary read is synchronous: no suspension during hydration, no
+  // second render pass, no loader (there is none on this side) and no refetch.
+  const buildTree = (store: ReturnType<typeof createSSRStore<T>>, deferred?: DeferredHolder) => {
+    const reported = <CommitReporter onCommit={reportSuccess}>{appComponent}</CommitReporter>;
 
-  const mountCSR = (rootEl: HTMLElement, initialData: T) => {
+    return (
+      <React.StrictMode>
+        <SSRStoreProvider store={store}>{deferred ? <DeferredDataProvider holder={deferred}>{reported}</DeferredDataProvider> : reported}</SSRStoreProvider>
+      </React.StrictMode>
+    );
+  };
+
+  const mountCSR = (rootEl: HTMLElement, initialData: T, deferred?: DeferredHolder) => {
     // emitBeacons stays false: the CSR path reports onSuccess/onHydrationError but no beacons.
     rootEl.innerHTML = '';
     const store = createSSRStore(initialData);
 
     try {
       const root = createRoot(rootEl, rootErrorOptions);
-      root.render(buildTree(store));
+      root.render(buildTree(store, deferred));
     } catch (err) {
       // Sync belt: invalid container / synchronous setup throw.
       error('CSR mount error:', err);
@@ -223,7 +232,7 @@ export function hydrateApp<T>({
     }
   };
 
-  const startHydration = (rootEl: HTMLElement, initialData: T) => {
+  const startHydration = (rootEl: HTMLElement, initialData: T, deferred?: DeferredHolder) => {
     emitBeacons = true; // hydrate path: emit hydration:start/success/error beacons
 
     if (enableDebug) log('Hydration started');
@@ -235,7 +244,7 @@ export function hydrateApp<T>({
     const store = createSSRStore(initialData);
 
     try {
-      hydrateRoot(rootEl, buildTree(store), rootErrorOptions);
+      hydrateRoot(rootEl, buildTree(store, deferred), rootErrorOptions);
     } catch (err) {
       // Sync belt: invalid container / synchronous setup throw (async render errors arrive via
       // onUncaughtError above, not here).
@@ -258,15 +267,23 @@ export function hydrateApp<T>({
 
     const data = (window as any)[dataKey] as T | undefined;
 
+    // RFC 0007 (R4): read the private envelope SYNCHRONOUSLY here, in document order, and drop the
+    // carrier. The host writes it inside the same nonced end-of-stream script that assigns
+    // `__INITIAL_DATA__`, and this bootstrap runs after it - so the read needs no event, no
+    // listener and no network. `taujs:data-ready` is deliberately NOT used: it dispatches before
+    // this code runs. An absent carrier is the ordinary case, never a reason to fetch.
+    const deferredState = takeDeferredHydrationState();
+    const deferred = deferredState ? createHydrationHolder(deferredState) : undefined;
+
     if (data === undefined) {
       const csrData = {} as T;
       if (enableDebug) warn(`No initial SSR data at window["${dataKey}"]. Mounting CSR.`);
-      mountCSR(rootEl, csrData);
+      mountCSR(rootEl, csrData, deferred);
 
       return;
     }
 
-    startHydration(rootEl, data);
+    startHydration(rootEl, data, deferred);
   };
 
   if (document.readyState !== 'loading') {

--- a/packages/react/src/SSRRender.tsx
+++ b/packages/react/src/SSRRender.tsx
@@ -86,7 +86,9 @@ export type StreamOptions = {
    * POSITIVE FINITE only, validated at the factory - there is no disable sentinel, because this
    * deadline is what keeps "bounded total response time" true. Default `min(15_000,
    * dataTimeoutMs / 2)`; an explicit value must be STRICTLY LESS than a finite `dataTimeoutMs`, or
-   * the fatal backstop could pre-empt graceful abandonment.
+   * the fatal backstop could pre-empt graceful abandonment. FACTORY-ONLY: there is no per-call form
+   * (a per-call seam is not boot), and a per-call `dataTimeoutMs` that would invert the ordering
+   * re-derives this deadline as `dataTimeoutMs / 2` for that response rather than losing it.
    */
   deferredTimeoutMs?: number;
 };
@@ -131,7 +133,10 @@ export type HeadContext<
 
 type SSRResult = { headContent: string; appHtml: string; aborted: boolean };
 
-type StreamCallOptions<R> = StreamOptions & {
+// RFC 0007 (decision 18): `deferredTimeoutMs` is OMITTED rather than silently ignored. The deferred
+// deadline is "one latched deadline per response, positive finite only, VALIDATED AT BOOT" - a
+// per-call seam is not boot, so there is no per-call form of it and the call bag must not offer one.
+type StreamCallOptions<R> = Omit<StreamOptions, 'deferredTimeoutMs'> & {
   logger?: LoggerLike;
   // RFC 0004 (H2): broad at the contract boundary (same contravariance reality as headData/T);
   // narrowed to `R` at the single read below. `R` remains the app-facing type via HeadContext
@@ -378,13 +383,17 @@ export function createRenderer<
     // Merge renderer defaults with per-call overrides
     const effectiveShellTimeout = opts?.shellTimeoutMs ?? shellTimeoutMs;
     const effectiveDataTimeout = opts?.dataTimeoutMs ?? dataTimeoutMs;
-    // RFC 0007 (decision 18): the deferred deadline is NOT per-call overridable. It is "one latched
-    // deadline per response, positive finite only, VALIDATED AT BOOT" - and a per-call seam is not
-    // boot, so honouring `opts.deferredTimeoutMs` would put an unvalidated value (0, -1, NaN,
-    // Infinity, a string from untyped JS) straight into the timer and the operator warning. The
-    // factory-validated value is the only one this renderer uses; Solid takes no override either.
-    // The field remains legal on the call bag only because `StreamCallOptions` intersects
-    // `StreamOptions`; it is deliberately ignored here.
+    // RFC 0007 (decision 18): the deferred deadline is NOT per-call overridable (it is omitted from
+    // `StreamCallOptions` above), but the FATAL backstop it must precede still is. Decision 18's
+    // ordering rule - "an explicitly configured deferred deadline must precede a finite fatal
+    // backstop" - is a property of the response, not only of the factory, so a per-call
+    // `dataTimeoutMs` at or below the boot-validated deferred deadline is brought back into the
+    // relationship using the SAME derivation the default uses (`fatal / 2`). It can only ever move
+    // the graceful terminal EARLIER, never later, so the response stays bounded either way.
+    const effectiveDeferredTimeout =
+      Number.isFinite(effectiveDataTimeout) && effectiveDataTimeout > 0 && deferredTimeoutMs >= effectiveDataTimeout
+        ? effectiveDataTimeout / 2
+        : deferredTimeoutMs;
     // RFC 0007 (decision 18): the deferred deadline's time ORIGIN. It is armed later (at shell
     // commit) but measured from here, so its ordering against the fatal backstop is a property of
     // the configuration rather than of how long the shell happened to take.
@@ -700,17 +709,17 @@ export function createRenderer<
                   const abandoned = deferredHolder?.expire() ?? 0;
                   if (abandoned === 0) return;
 
-                  warn(`Deferred data not ready after ${deferredTimeoutMs}ms; abandoning the pending boundaries`, { location, abandoned });
+                  warn(`Deferred data not ready after ${effectiveDeferredTimeout}ms; abandoning the pending boundaries`, { location, abandoned });
                   try {
                     // React's OWN abort: it emits a client-render instruction per abandoned
                     // boundary and finishes the document. τjs writes no framework-patch bytes and
                     // never touches the host's response-owned promise.
-                    stream.abort(new Error(`Deferred data not ready after ${deferredTimeoutMs}ms`));
+                    stream.abort(new Error(`Deferred data not ready after ${effectiveDeferredTimeout}ms`));
                   } catch (abortErr) {
                     error('Deferred deadline abort failed:', abortErr);
                   }
                 },
-                Math.max(deferredTimeoutMs - (Date.now() - renderStartedAt), 1),
+                Math.max(effectiveDeferredTimeout - (Date.now() - renderStartedAt), 1),
               );
             }
 

--- a/packages/react/src/SSRRender.tsx
+++ b/packages/react/src/SSRRender.tsx
@@ -15,9 +15,11 @@ const { prerenderToNodeStream } = ReactDOMStatic;
 import type { Writable } from 'node:stream';
 
 import { createSSRStore, SSRStoreProvider } from './SSRDataStore.js';
+import { createDeferredHolder, DeferredDataProvider } from './SSRDeferredData.js';
 import { getStoreReadiness } from './internal.js';
 import { createUILogger } from './utils/Logger.js';
 
+import type { DeferredDataRegistry, DeferredHolder } from './SSRDeferredData.js';
 import type { LoggerLike } from './utils/Logger.js';
 
 import { createStreamController, startShellTimer, wireWritableGuards } from './utils/Streaming.js';
@@ -70,6 +72,23 @@ export type StreamOptions = {
    * the response (and its listeners/streams) open indefinitely.
    */
   dataTimeoutMs?: number;
+  /**
+   * RFC 0007 (decision 18): the ONE response-level deferred completion deadline.
+   *
+   * Measured from `renderStream` ENTRY (the same origin the fatal route-data backstop is compared
+   * against), armed at shell commit with whatever remains of the budget, never reset per key, and
+   * LATCHED - a boundary whose first read arrives after expiry is born `aborted` rather than
+   * starting a fresh unbounded wait. On expiry the still-pending consumed boundaries are abandoned
+   * through React's OWN `stream.abort`, which emits React's own client-render instruction for each
+   * and finishes the document; the host then classifies those keys `aborted` in its envelope, and
+   * the client hydrates them deterministically without a refetch.
+   *
+   * POSITIVE FINITE only, validated at the factory - there is no disable sentinel, because this
+   * deadline is what keeps "bounded total response time" true. Default `min(15_000,
+   * dataTimeoutMs / 2)`; an explicit value must be STRICTLY LESS than a finite `dataTimeoutMs`, or
+   * the fatal backstop could pre-empt graceful abandonment.
+   */
+  deferredTimeoutMs?: number;
 };
 
 export type SSROptions = {
@@ -125,9 +144,16 @@ type StreamCallOptions<R> = StreamOptions & {
   // shouldHydrate is the host-resolved hydration policy. Keeps this in step with the host RenderOptions.
   cspNonce?: string;
   shouldHydrate?: boolean;
+  // RFC 0007 (decision 14): the host's request-local deferred registry - present ONLY when the
+  // route declares `attr.deferred`. Already started, already pre-observed; the renderer neither
+  // starts nor re-observes them, it only projects them onto `use()` + `<Suspense>`.
+  deferredData?: DeferredDataRegistry;
 };
 
 const NOOP = () => {};
+
+/** RFC 0007 (decision 18): the cap on the DERIVED default deferred deadline. */
+const DEFERRED_TIMEOUT_DEFAULT_CAP_MS = 15_000;
 
 export function createRenderer<
   T extends Record<string, unknown> = Record<string, unknown>,
@@ -166,7 +192,30 @@ export function createRenderer<
   identifierPrefix?: string;
 }) {
   const { shellTimeoutMs = 10_000, dataTimeoutMs = 30_000 } = streamOptions;
+  // RFC 0007 (decision 18): DERIVED, not a literal - half the fatal route-data backstop's budget,
+  // capped at 15s, so the graceful deferred terminal is structurally reachable for whatever
+  // `dataTimeoutMs` an application configures rather than only for the stock one.
+  const deferredTimeoutMs =
+    streamOptions.deferredTimeoutMs ??
+    (Number.isFinite(dataTimeoutMs) && dataTimeoutMs > 0 ? Math.min(DEFERRED_TIMEOUT_DEFAULT_CAP_MS, dataTimeoutMs / 2) : DEFERRED_TIMEOUT_DEFAULT_CAP_MS);
   const { prerenderTimeoutMs = 10_000 } = ssrOptions;
+
+  // RFC 0007 (decision 18): POSITIVE FINITE only - there is no 0/Infinity disable sentinel, because
+  // this deadline is what bounds the response.
+  if (!(typeof deferredTimeoutMs === 'number' && Number.isFinite(deferredTimeoutMs) && deferredTimeoutMs > 0)) {
+    throw new TypeError(
+      `createRenderer: streamOptions.deferredTimeoutMs must be a positive finite number of milliseconds (received ${String(deferredTimeoutMs)})`,
+    );
+  }
+
+  // Both deadlines bound the POST-SHELL phase, so at or above the fatal one the deferred deadline
+  // could never abandon a boundary gracefully. That is a dead option, not a marginal configuration.
+  if (Number.isFinite(dataTimeoutMs) && dataTimeoutMs > 0 && deferredTimeoutMs >= dataTimeoutMs) {
+    throw new TypeError(
+      `createRenderer: streamOptions.deferredTimeoutMs (${deferredTimeoutMs}) must be strictly less than streamOptions.dataTimeoutMs (${dataTimeoutMs}); ` +
+        'at or above it the fatal route-data deadline pre-empts graceful deferred abandonment',
+    );
+  }
 
   // Gate-review fix: validate ONCE at the factory. The timer site arms only for finite positive
   // values, so without this check every invalid input (-1, NaN, null, a string from untyped JS,
@@ -329,6 +378,11 @@ export function createRenderer<
     // Merge renderer defaults with per-call overrides
     const effectiveShellTimeout = opts?.shellTimeoutMs ?? shellTimeoutMs;
     const effectiveDataTimeout = opts?.dataTimeoutMs ?? dataTimeoutMs;
+    const effectiveDeferredTimeout = opts?.deferredTimeoutMs ?? deferredTimeoutMs;
+    // RFC 0007 (decision 18): the deferred deadline's time ORIGIN. It is armed later (at shell
+    // commit) but measured from here, so its ordering against the fatal backstop is a property of
+    // the configuration rather than of how long the shell happened to take.
+    const renderStartedAt = Date.now();
 
     // Stream controller centralises cleanup & settlement
     const controller = createStreamController(writable, { log, warn, error });
@@ -379,6 +433,16 @@ export function createRenderer<
     // without emitting 'close', leaving the timer/closure/listener live until dataTimeoutMs).
     let stopDataDeadline: (() => void) | undefined;
 
+    // RFC 0007. Declared at renderStream scope, ABOVE the cleanup composition below, so EVERY
+    // terminal the controller owns (normal finish, benign abort, fatal) releases the holder and
+    // disarms the deadline - the retention standard the data deadline already holds itself to.
+    let deferredHolder: DeferredHolder | undefined;
+    let deferredTimer: ReturnType<typeof setTimeout> | undefined;
+    const stopDeferredDeadline = () => {
+      if (deferredTimer !== undefined) clearTimeout(deferredTimer);
+      deferredTimer = undefined;
+    };
+
     // Writable guards (handles error/close/finish)
     const { cleanup: guardsCleanup } = wireWritableGuards(writable, {
       benignAbort: (why) => controller.benignAbort(why),
@@ -391,6 +455,14 @@ export function createRenderer<
       } catch {}
       try {
         stopDataDeadline?.();
+      } catch {}
+      // RFC 0007 (renderer contract item 8): release the holder on every terminal. The host's
+      // frozen record is a distinct object it releases on its own side; this drops OUR references.
+      try {
+        stopDeferredDeadline();
+      } catch {}
+      try {
+        deferredHolder?.release();
       } catch {}
     });
 
@@ -540,7 +612,17 @@ export function createRenderer<
         },
       };
 
-      const appElement = <SSRStoreProvider store={store}>{appComponent({ location, routeContext })}</SSRStoreProvider>;
+      // RFC 0007: the holder - and the provider - exist ONLY when the host passed a registry, so a
+      // route declaring no deferred entries renders exactly the tree it renders today and its
+      // bytes (including every `useId`) are unchanged.
+      deferredHolder = opts?.deferredData ? createDeferredHolder(opts.deferredData) : undefined;
+
+      const appTree = appComponent({ location, routeContext });
+      const appElement = (
+        <SSRStoreProvider store={store}>
+          {deferredHolder ? <DeferredDataProvider holder={deferredHolder}>{appTree}</DeferredDataProvider> : appTree}
+        </SSRStoreProvider>
+      );
 
       const stream = renderToPipeableStream(appElement, {
         nonce: cspNonce,
@@ -596,6 +678,35 @@ export function createRenderer<
             // (finding 1) — a Suspense consumer whose data never settles keeps React streaming, so
             // React may never call end(); this deadline fires regardless.
             armDataDeadline();
+
+            // RFC 0007 (decision 18): a deferred boundary can only be pending AFTER the shell
+            // committed, so the deadline is armed here - with what REMAINS of a budget measured
+            // from renderStream entry (a budget already spent arms at 1ms rather than never).
+            if (deferredHolder && deferredTimer === undefined) {
+              deferredTimer = setTimeout(
+                () => {
+                  deferredTimer = undefined;
+                  if (controller.isAborted) return;
+
+                  // LATCH FIRST, unconditionally: a later read must be born `aborted` rather than
+                  // start a fresh unbounded wait. Only then decide whether anything needs
+                  // abandoning - a deadline that abandons nothing is silent and costs nothing.
+                  const abandoned = deferredHolder?.expire() ?? 0;
+                  if (abandoned === 0) return;
+
+                  warn(`Deferred data not ready after ${effectiveDeferredTimeout}ms; abandoning the pending boundaries`, { location, abandoned });
+                  try {
+                    // React's OWN abort: it emits a client-render instruction per abandoned
+                    // boundary and finishes the document. τjs writes no framework-patch bytes and
+                    // never touches the host's response-owned promise.
+                    stream.abort(new Error(`Deferred data not ready after ${effectiveDeferredTimeout}ms`));
+                  } catch (abortErr) {
+                    error('Deferred deadline abort failed:', abortErr);
+                  }
+                },
+                Math.max(effectiveDeferredTimeout - (Date.now() - renderStartedAt), 1),
+              );
+            }
 
             // Advisory (design 6): a throw is logged, not fatal.
             try {

--- a/packages/react/src/SSRRender.tsx
+++ b/packages/react/src/SSRRender.tsx
@@ -378,7 +378,13 @@ export function createRenderer<
     // Merge renderer defaults with per-call overrides
     const effectiveShellTimeout = opts?.shellTimeoutMs ?? shellTimeoutMs;
     const effectiveDataTimeout = opts?.dataTimeoutMs ?? dataTimeoutMs;
-    const effectiveDeferredTimeout = opts?.deferredTimeoutMs ?? deferredTimeoutMs;
+    // RFC 0007 (decision 18): the deferred deadline is NOT per-call overridable. It is "one latched
+    // deadline per response, positive finite only, VALIDATED AT BOOT" - and a per-call seam is not
+    // boot, so honouring `opts.deferredTimeoutMs` would put an unvalidated value (0, -1, NaN,
+    // Infinity, a string from untyped JS) straight into the timer and the operator warning. The
+    // factory-validated value is the only one this renderer uses; Solid takes no override either.
+    // The field remains legal on the call bag only because `StreamCallOptions` intersects
+    // `StreamOptions`; it is deliberately ignored here.
     // RFC 0007 (decision 18): the deferred deadline's time ORIGIN. It is armed later (at shell
     // commit) but measured from here, so its ordering against the fatal backstop is a property of
     // the configuration rather than of how long the shell happened to take.
@@ -694,17 +700,17 @@ export function createRenderer<
                   const abandoned = deferredHolder?.expire() ?? 0;
                   if (abandoned === 0) return;
 
-                  warn(`Deferred data not ready after ${effectiveDeferredTimeout}ms; abandoning the pending boundaries`, { location, abandoned });
+                  warn(`Deferred data not ready after ${deferredTimeoutMs}ms; abandoning the pending boundaries`, { location, abandoned });
                   try {
                     // React's OWN abort: it emits a client-render instruction per abandoned
                     // boundary and finishes the document. τjs writes no framework-patch bytes and
                     // never touches the host's response-owned promise.
-                    stream.abort(new Error(`Deferred data not ready after ${effectiveDeferredTimeout}ms`));
+                    stream.abort(new Error(`Deferred data not ready after ${deferredTimeoutMs}ms`));
                   } catch (abortErr) {
                     error('Deferred deadline abort failed:', abortErr);
                   }
                 },
-                Math.max(effectiveDeferredTimeout - (Date.now() - renderStartedAt), 1),
+                Math.max(deferredTimeoutMs - (Date.now() - renderStartedAt), 1),
               );
             }
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,11 @@
 export * from './SSRDataStore.js';
+// RFC 0007 (decision 19, renderer contract item 9): the package's PUBLIC surface for this feature
+// is the component-facing accessors and their result/error types, and NOTHING else. The envelope
+// carrier constant, both holders, the provider and the hydration reader are private transport and
+// stay unexported - a private transport must not become an importable package surface. Pinned by
+// `test/SSRDeferredData.exports.test.ts`.
+export { createDeferredAccessor, DeferredDataError, useDeferredData, useDeferredDataResult } from './SSRDeferredData.js';
+export type { DeferredResult } from './SSRDeferredData.js';
 export * from './SSRHydration.js';
 export * from './SSRRender.js';
 

--- a/packages/react/src/test/SSRDeferredData.exports.test.ts
+++ b/packages/react/src/test/SSRDeferredData.exports.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment node
+// RFC 0007 (decision 10 / renderer contract item 9): the package's PUBLIC surface for this feature
+// is the component-facing accessors and their result/error types - and nothing else. A private
+// transport must never become an importable package surface.
+import { describe, it, expect } from 'vitest';
+
+import * as pkg from '../index';
+import * as internals from '../SSRDeferredData';
+
+const PUBLIC = ['createDeferredAccessor', 'DeferredDataError', 'useDeferredData', 'useDeferredDataResult'];
+
+// Everything the adapter module exports for `SSRRender` / `SSRHydration` / this package's own tests
+// and which must NOT reach the package root.
+const FORBIDDEN = ['DEFERRED_STATE_CARRIER', 'createDeferredHolder', 'createHydrationHolder', 'DeferredDataProvider', 'takeDeferredHydrationState'];
+
+describe('@taujs/react deferred-data export hygiene', () => {
+  it('exports exactly the frozen public spellings (decision 19)', () => {
+    for (const name of PUBLIC) expect(Object.keys(pkg)).toContain(name);
+  });
+
+  it('exports NONE of the private transport', () => {
+    for (const name of FORBIDDEN) {
+      expect(internals).toHaveProperty(name); // it really is a module export...
+      expect(Object.keys(pkg)).not.toContain(name); // ...and really is not a package export
+    }
+  });
+
+  it('never exposes the carrier NAME through any exported value', () => {
+    for (const value of Object.values(pkg)) {
+      if (typeof value === 'string') expect(value).not.toContain('__TAUJS_DEFERRED_STATE__');
+    }
+  });
+});

--- a/packages/react/src/test/SSRDeferredData.hydration.test.tsx
+++ b/packages/react/src/test/SSRDeferredData.hydration.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+// RFC 0007 (R4): hydration seeding from the private envelope - synchronous document-order read,
+// carrier deleted after the read, absent carrier treated as normal, never a fetch.
+import React, { Suspense } from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { hydrateApp } from '../SSRHydration';
+import { createHydrationHolder, DeferredDataError, takeDeferredHydrationState, useDeferredData, useDeferredDataResult } from '../SSRDeferredData';
+
+const CARRIER = '__TAUJS_DEFERRED_STATE__';
+
+const flush = (ms = 30) => new Promise<void>((r) => setTimeout(r, ms));
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="root"></div>';
+  delete (window as unknown as Record<string, unknown>)[CARRIER];
+  delete (window as unknown as Record<string, unknown>)['__INITIAL_DATA__'];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('takeDeferredHydrationState', () => {
+  it('reads the carrier ONCE and deletes it', () => {
+    (window as unknown as Record<string, unknown>)[CARRIER] = { reviews: { status: 'complete', value: { count: 3 } } };
+
+    expect(takeDeferredHydrationState()).toEqual({ reviews: { status: 'complete', value: { count: 3 } } });
+    expect(CARRIER in window).toBe(false);
+    expect(takeDeferredHydrationState()).toBeUndefined();
+  });
+
+  it('an ABSENT carrier is the ordinary case, never an error', () => {
+    expect(takeDeferredHydrationState()).toBeUndefined();
+  });
+
+  it('a hostile carrier value is ignored rather than thrown', () => {
+    for (const hostile of [null, 42, 'nope', [1, 2]]) {
+      (window as unknown as Record<string, unknown>)[CARRIER] = hostile;
+      expect(takeDeferredHydrationState()).toBeUndefined();
+    }
+  });
+});
+
+describe('the client holder seeds from the envelope with NO refetch', () => {
+  it('every entry is ALREADY SETTLED, so a read is synchronous', () => {
+    const holder = createHydrationHolder({
+      reviews: { status: 'complete', value: { count: 3 } },
+      blurb: { status: 'failed' },
+      stock: { status: 'aborted' },
+    });
+
+    const complete = holder.resource('reviews') as unknown as { status: string; value?: unknown };
+    expect(complete.status).toBe('fulfilled');
+    expect(complete.value).toEqual({ count: 3 });
+
+    for (const [key, outcome] of [
+      ['blurb', 'failed'],
+      ['stock', 'aborted'],
+    ] as const) {
+      const entry = holder.resource(key) as unknown as { status: string; reason?: unknown };
+      expect(entry.status).toBe('rejected');
+      expect((entry.reason as DeferredDataError).outcome).toBe(outcome);
+      expect(String((entry.reason as Error).message)).not.toMatch(/stack|cause|server/i);
+    }
+  });
+
+  it('an unknown key is a deterministic developer error naming the declared set', () => {
+    const holder = createHydrationHolder({ reviews: { status: 'complete', value: {} } });
+
+    expect(() => holder.resource('nope')).toThrow(/unknown deferred data key "nope"/);
+  });
+});
+
+describe('hydrateApp seeds consumed boundaries from the envelope', () => {
+  it('renders the complete value with no loader, no fetch and no suspension', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    document.getElementById('root')!.innerHTML = '<main><p id="reviews">reviews: 3</p></main>';
+    (window as unknown as Record<string, unknown>)['__INITIAL_DATA__'] = { critical: 1 };
+    (window as unknown as Record<string, unknown>)[CARRIER] = { reviews: { status: 'complete', value: { count: 3 } } };
+
+    const Reviews = () => {
+      const data = useDeferredData<{ count: number }>('reviews');
+      return <p id="reviews">reviews: {data.count}</p>;
+    };
+    hydrateApp({
+      appComponent: (
+        <main>
+          <Suspense fallback={<p>loading</p>}>
+            <Reviews />
+          </Suspense>
+        </main>
+      ),
+    });
+    await flush();
+
+    expect(document.getElementById('reviews')!.textContent).toBe('reviews: 3');
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(CARRIER in window).toBe(false);
+  });
+
+  it('a `failed` outcome hydrates the SAME detail-free branch the server rendered', async () => {
+    document.getElementById('root')!.innerHTML = '<main><p id="fallback">reviews unavailable (failed)</p></main>';
+    (window as unknown as Record<string, unknown>)['__INITIAL_DATA__'] = {};
+    (window as unknown as Record<string, unknown>)[CARRIER] = { reviews: { status: 'failed' } };
+
+    const Reviews = () => {
+      const result = useDeferredDataResult<{ count: number }>('reviews');
+      return result.status === 'complete' ? <p id="reviews">{result.value.count}</p> : <p id="fallback">{`reviews unavailable (${result.status})`}</p>;
+    };
+    hydrateApp({
+      appComponent: (
+        <main>
+          <Suspense fallback={<p>loading</p>}>
+            <Reviews />
+          </Suspense>
+        </main>
+      ),
+    });
+    await flush();
+
+    expect(document.getElementById('fallback')!.textContent).toBe('reviews unavailable (failed)');
+  });
+
+  it('a page with NO carrier hydrates exactly as it does today', async () => {
+    document.getElementById('root')!.innerHTML = '<main><p id="plain">plain</p></main>';
+    (window as unknown as Record<string, unknown>)['__INITIAL_DATA__'] = {};
+
+    const onHydrationError = vi.fn();
+    hydrateApp({
+      appComponent: (
+        <main>
+          <p id="plain">plain</p>
+        </main>
+      ),
+      onHydrationError,
+    });
+    await flush();
+
+    expect(document.getElementById('plain')!.textContent).toBe('plain');
+    expect(onHydrationError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/test/SSRDeferredData.hydration.test.tsx
+++ b/packages/react/src/test/SSRDeferredData.hydration.test.tsx
@@ -2,10 +2,19 @@
 // RFC 0007 (R4): hydration seeding from the private envelope - synchronous document-order read,
 // carrier deleted after the read, absent carrier treated as normal, never a fetch.
 import React, { Suspense } from 'react';
+import { renderToReadableStream } from 'react-dom/server.browser';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { hydrateApp } from '../SSRHydration';
-import { createHydrationHolder, DeferredDataError, takeDeferredHydrationState, useDeferredData, useDeferredDataResult } from '../SSRDeferredData';
+import {
+  createDeferredHolder,
+  createHydrationHolder,
+  DeferredDataError,
+  DeferredDataProvider,
+  takeDeferredHydrationState,
+  useDeferredData,
+  useDeferredDataResult,
+} from '../SSRDeferredData';
 
 const CARRIER = '__TAUJS_DEFERRED_STATE__';
 
@@ -73,54 +82,111 @@ describe('the client holder seeds from the envelope with NO refetch', () => {
 });
 
 describe('hydrateApp seeds consumed boundaries from the envelope', () => {
-  it('renders the complete value with no loader, no fetch and no suspension', async () => {
+  // ONE component per read, rendered by BOTH sides - the server tree and the hydrating tree are the
+  // same tree, exactly as an application's are.
+  const Reviews = () => {
+    const data = useDeferredData<{ count: number }>('reviews');
+
+    return <p id="reviews">reviews: {data.count}</p>;
+  };
+
+  const ReviewsResult = () => {
+    const result = useDeferredDataResult<{ count: number }>('reviews');
+
+    return result.status === 'complete' ? <p id="reviews">{result.value.count}</p> : <p id="fallback">{`reviews unavailable (${result.status})`}</p>;
+  };
+
+  /**
+   * Render the SAME tree through `react-dom/server`, so hydration runs against REAL SSR markup -
+   * `<!--$-->`/`<!--/$-->` Suspense markers included. Hand-authored markup has no markers, so React
+   * silently regenerates the boundary on the client and every assertion below would pass whether or
+   * not the adapter hydrates cleanly.
+   *
+   * Each entry is WARMED before the render (`resource()` tracks it, one macrotask settles it), so
+   * `use()` returns synchronously and the server emits the SETTLED document. React's late-boundary
+   * delivery is a stream of `<script>` instructions a browser executes; `innerHTML` never runs
+   * them, so the settled document is the DOM a real browser holds when hydration starts.
+   */
+  const serverHtml = async (tree: React.ReactElement, registry: Record<string, Promise<Record<string, unknown>>>) => {
+    const holder = createDeferredHolder(Object.freeze(registry));
+    for (const key of holder.keys) void holder.resource(key);
+    await flush(0);
+
+    const stream = await renderToReadableStream(<DeferredDataProvider holder={holder}>{tree}</DeferredDataProvider>);
+
+    return new Response(stream as unknown as ReadableStream).text();
+  };
+
+  /**
+   * Rendering with react-dom/server AND react-dom/client in ONE process makes React's dev build warn
+   * that two renderers touched the same context provider. It is an artefact of the test topology -
+   * the server render is finished before hydration starts - and it is the price of honest markup, so
+   * it is filtered by exact message only. Every other console error still reaches the log.
+   */
+  beforeEach(() => {
+    const real = console.error;
+    vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      if (String(args[0]).includes('Detected multiple renderers concurrently rendering the same context provider')) return;
+      real(...args);
+    });
+  });
+
+  /** React reports an auto-recovered mismatch through `onRecoverableError`, which hydrateApp warns. */
+  const hydrationWarnings = (warn: ReturnType<typeof vi.fn>) => warn.mock.calls.filter(([first]) => String(first).includes('Recoverable hydration error'));
+
+  const CompleteTree = (
+    <main>
+      <Suspense fallback={<p>loading</p>}>
+        <Reviews />
+      </Suspense>
+    </main>
+  );
+
+  const ResultTree = (
+    <main>
+      <Suspense fallback={<p>loading</p>}>
+        <ReviewsResult />
+      </Suspense>
+    </main>
+  );
+
+  it('renders the complete value with no loader, no fetch, no suspension and NO mismatch', async () => {
     const fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);
-    document.getElementById('root')!.innerHTML = '<main><p id="reviews">reviews: 3</p></main>';
+    document.getElementById('root')!.innerHTML = await serverHtml(CompleteTree, { reviews: Promise.resolve({ count: 3 }) });
+    // The marker proves the fixture is real SSR markup, not a hand-authored approximation.
+    expect(document.getElementById('root')!.innerHTML).toContain('<!--$-->');
     (window as unknown as Record<string, unknown>)['__INITIAL_DATA__'] = { critical: 1 };
     (window as unknown as Record<string, unknown>)[CARRIER] = { reviews: { status: 'complete', value: { count: 3 } } };
 
-    const Reviews = () => {
-      const data = useDeferredData<{ count: number }>('reviews');
-      return <p id="reviews">reviews: {data.count}</p>;
-    };
-    hydrateApp({
-      appComponent: (
-        <main>
-          <Suspense fallback={<p>loading</p>}>
-            <Reviews />
-          </Suspense>
-        </main>
-      ),
-    });
+    const warn = vi.fn();
+    const onHydrationError = vi.fn();
+    hydrateApp({ appComponent: CompleteTree, logger: { log: vi.fn(), warn, error: vi.fn() }, onHydrationError });
     await flush();
 
     expect(document.getElementById('reviews')!.textContent).toBe('reviews: 3');
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(CARRIER in window).toBe(false);
+    expect(onHydrationError).not.toHaveBeenCalled();
+    expect(hydrationWarnings(warn)).toEqual([]);
   });
 
-  it('a `failed` outcome hydrates the SAME detail-free branch the server rendered', async () => {
-    document.getElementById('root')!.innerHTML = '<main><p id="fallback">reviews unavailable (failed)</p></main>';
+  it('a `failed` outcome hydrates the SAME detail-free branch the server rendered, with NO mismatch', async () => {
+    const rejected = Promise.reject(new Error('loader blew up'));
+    rejected.catch(() => {});
+    document.getElementById('root')!.innerHTML = await serverHtml(ResultTree, { reviews: rejected as Promise<Record<string, unknown>> });
+    expect(document.getElementById('root')!.innerHTML).toContain('reviews unavailable (failed)');
     (window as unknown as Record<string, unknown>)['__INITIAL_DATA__'] = {};
     (window as unknown as Record<string, unknown>)[CARRIER] = { reviews: { status: 'failed' } };
 
-    const Reviews = () => {
-      const result = useDeferredDataResult<{ count: number }>('reviews');
-      return result.status === 'complete' ? <p id="reviews">{result.value.count}</p> : <p id="fallback">{`reviews unavailable (${result.status})`}</p>;
-    };
-    hydrateApp({
-      appComponent: (
-        <main>
-          <Suspense fallback={<p>loading</p>}>
-            <Reviews />
-          </Suspense>
-        </main>
-      ),
-    });
+    const warn = vi.fn();
+    const onHydrationError = vi.fn();
+    hydrateApp({ appComponent: ResultTree, logger: { log: vi.fn(), warn, error: vi.fn() }, onHydrationError });
     await flush();
 
     expect(document.getElementById('fallback')!.textContent).toBe('reviews unavailable (failed)');
+    expect(onHydrationError).not.toHaveBeenCalled();
+    expect(hydrationWarnings(warn)).toEqual([]);
   });
 
   it('a page with NO carrier hydrates exactly as it does today', async () => {

--- a/packages/react/src/test/SSRDeferredData.release.test.tsx
+++ b/packages/react/src/test/SSRDeferredData.release.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment node
+// RFC 0007 (renderer contract item 8) - the RENDERER's own holder release, observed on the REAL
+// `renderStream` path. The module is spied rather than replaced, so every implementation here is
+// the production one: the spy exists only to obtain the very holder the renderer created, and the
+// assertion is a LATER READ of that holder after the terminal. Nothing in this cell calls
+// `release()` itself, so deleting the renderer's cleanup call fails it.
+import { PassThrough } from 'node:stream';
+
+import React, { Suspense } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { createRenderer } from '../SSRRender';
+import * as DeferredData from '../SSRDeferredData';
+import { useDeferredData } from '../SSRDeferredData';
+
+vi.mock('../SSRDeferredData', { spy: true });
+
+const settle = (ms = 40) => new Promise<void>((r) => setTimeout(r, ms));
+
+describe('@taujs/react deferred adapter - renderer-owned release (renderer contract 8)', () => {
+  it('the RENDERER releases the holder at a normal terminal: a later read reports the released holder', async () => {
+    const reviews = Promise.resolve({ count: 3 });
+    reviews.catch(() => {}); // the host pre-observes
+    const registry = Object.freeze({ reviews });
+
+    const Reviews = () => {
+      const data = useDeferredData<{ count: number }>('reviews');
+      return <p id="reviews">reviews: {data.count}</p>;
+    };
+    const App = () => (
+      <main>
+        <Suspense fallback={<p>loading</p>}>
+          <Reviews />
+        </Suspense>
+      </main>
+    );
+
+    const writable = new PassThrough();
+    const chunks: string[] = [];
+    writable.on('data', (c) => chunks.push(String(c)));
+
+    const { renderStream } = createRenderer({ appComponent: App, headContent: () => '<title>t</title>' });
+    const handle = renderStream(writable, { onHead: () => {}, onAllReady: () => {} }, { critical: 1 }, '/product/42', undefined, {}, undefined, {
+      deferredData: registry,
+      shouldHydrate: true,
+    });
+
+    await expect(handle.done).resolves.toBeUndefined();
+    await settle();
+
+    // The holder the RENDERER created - not one this test constructed.
+    const created = vi.mocked(DeferredData.createDeferredHolder).mock.results;
+    expect(created).toHaveLength(1);
+    const holder = created[0]!.value as DeferredData.DeferredHolder;
+
+    expect(chunks.join('')).toContain('reviews: <!-- -->3');
+    // The later read: released state is observable only because the renderer released it.
+    expect(() => holder.resource('reviews')).toThrow(/holder has been released/);
+  });
+});

--- a/packages/react/src/test/SSRDeferredData.stream.test.tsx
+++ b/packages/react/src/test/SSRDeferredData.stream.test.tsx
@@ -1,0 +1,407 @@
+// @vitest-environment node
+// RFC 0007 - @taujs/react server adapter: renderer contract items 1-9 against REAL
+// react-dom/server and a REAL PassThrough.
+import { PassThrough } from 'node:stream';
+
+import React, { Suspense } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { createRenderer, type StreamOptions } from '../SSRRender';
+import { createDeferredAccessor, DeferredDataError, useDeferredData, useDeferredDataResult } from '../SSRDeferredData';
+
+const settle = (ms = 60) => new Promise<void>((r) => setTimeout(r, ms));
+
+type Registry = Record<string, Promise<Record<string, unknown>>>;
+
+const deferredRegistry = (entries: Record<string, Promise<Record<string, unknown>>>): Registry => {
+  for (const promise of Object.values(entries)) promise.catch(() => {}); // the host pre-observes
+  return Object.freeze({ ...entries });
+};
+
+const drive = async (
+  appComponent: (props: { location: string }) => React.ReactElement,
+  opts: { deferredData?: Registry; streamOptions?: StreamOptions; wait?: number; shouldHydrate?: boolean } = {},
+) => {
+  const writable = new PassThrough();
+  const chunks: { at: number; text: string }[] = [];
+  const t0 = Date.now();
+  writable.on('data', (c) => chunks.push({ at: Date.now() - t0, text: c.toString() }));
+
+  const { renderStream } = createRenderer({ appComponent, headContent: () => '<title>t</title>', streamOptions: opts.streamOptions });
+  const errors: unknown[] = [];
+  const handle = renderStream(
+    writable,
+    { onHead: () => {}, onAllReady: () => {}, onError: (e) => errors.push(e) },
+    { critical: 1 },
+    '/product/42',
+    undefined,
+    {},
+    undefined,
+    { ...(opts.deferredData ? { deferredData: opts.deferredData } : {}), shouldHydrate: opts.shouldHydrate ?? true },
+  );
+
+  await Promise.race([handle.done.catch(() => {}), settle(opts.wait ?? 400)]);
+  await settle(20);
+
+  return { chunks, html: chunks.map((c) => c.text).join(''), errors, handle };
+};
+
+describe('@taujs/react deferred adapter - native projection (renderer contract 1-3)', () => {
+  it('suspends only the reading boundary: independent shell content precedes the value', async () => {
+    let resolveReviews!: (v: Record<string, unknown>) => void;
+    const reviews = new Promise<Record<string, unknown>>((r) => (resolveReviews = r));
+    let settledAt = 0;
+
+    const Reviews = () => {
+      const data = useDeferredData<{ count: number }>('reviews');
+      return <p id="reviews">reviews: {data.count}</p>;
+    };
+    const App = () => (
+      <main>
+        <p id="unrelated">unrelated shell content</p>
+        <Suspense fallback={<p id="pending">loading reviews</p>}>
+          <Reviews />
+        </Suspense>
+      </main>
+    );
+
+    const driven = drive(App, { deferredData: deferredRegistry({ reviews }) });
+    await settle(80);
+    settledAt = Date.now();
+    resolveReviews({ count: 3 });
+    const { chunks, html } = await driven;
+
+    const shellAt = chunks[0]!.at;
+    expect(shellAt).toBeLessThan(settledAt);
+    expect(chunks[0]!.text).toContain('unrelated shell content');
+    expect(chunks[0]!.text).toContain('loading reviews');
+    expect(chunks[0]!.text).not.toContain('reviews: 3');
+    expect(html).toContain('reviews: <!-- -->3');
+  });
+
+  it('delivers the late boundary through REACT’s own patch mechanism - τjs emits no bytes of its own', async () => {
+    const Reviews = () => {
+      const data = useDeferredData<{ count: number }>('reviews');
+      return <p>reviews: {data.count}</p>;
+    };
+    // Settling AFTER the shell is what makes React patch rather than inline.
+    const reviews = new Promise<Record<string, unknown>>((r) => setTimeout(() => r({ count: 3 }), 80));
+    const { html } = await drive(
+      () => (
+        <main>
+          <p id="unrelated">unrelated shell content</p>
+          <Suspense fallback={<p>loading</p>}>
+            <Reviews />
+          </Suspense>
+        </main>
+      ),
+      { deferredData: deferredRegistry({ reviews }) },
+    );
+
+    // React's own out-of-order patch: a placeholder inline, the value later in a hidden div that
+    // React's own `$RC` splices into place.
+    expect(html).toContain('<!--$?--><template id="B:0"></template>');
+    expect(html).toContain('$RC("B:0","S:0")');
+    expect(html).not.toContain('__TAUJS_DEFERRED_STATE__');
+    expect(html).not.toContain('__INITIAL_DATA__');
+    expect(html.toLowerCase()).not.toContain('taujs');
+  });
+
+  it('a route with NO registry renders byte-identical output (the provider is not inserted)', async () => {
+    const Ided = () => <p>{React.useId()}</p>;
+    const App = () => (
+      <main>
+        <Ided />
+        <Suspense fallback={<p>loading</p>}>
+          <p>content</p>
+        </Suspense>
+      </main>
+    );
+
+    const a = await drive(App);
+    const b = await drive(App, { deferredData: deferredRegistry({ reviews: Promise.resolve({ count: 3 }) }) });
+
+    // A declared-but-UNCONSUMED registry must not shift a single `useId` or byte.
+    expect(b.html).toBe(a.html);
+  });
+});
+
+describe('@taujs/react deferred adapter - CSP (renderer contract 5)', () => {
+  it('every inline patch script React emits for a deferred boundary carries the nonce', async () => {
+    const Reviews = () => {
+      const data = useDeferredData<{ count: number }>('reviews');
+      return <p>reviews: {data.count}</p>;
+    };
+    const reviews = new Promise<Record<string, unknown>>((r) => setTimeout(() => r({ count: 3 }), 80));
+    const writable = new PassThrough();
+    const chunks: string[] = [];
+    writable.on('data', (c) => chunks.push(c.toString()));
+    const { renderStream } = createRenderer({
+      appComponent: () => (
+        <main>
+          <p>shell</p>
+          <Suspense fallback={<p>loading</p>}>
+            <Reviews />
+          </Suspense>
+        </main>
+      ),
+      headContent: () => '',
+    });
+    const handle = renderStream(writable, { onHead: () => {} }, {}, '/x', undefined, {}, undefined, {
+      deferredData: deferredRegistry({ reviews }),
+      cspNonce: 'NONCE123',
+    });
+    await Promise.race([handle.done.catch(() => {}), settle(400)]);
+    await settle(20);
+    const html = chunks.join('');
+
+    const scripts = html.match(/<script[^>]*>/g) ?? [];
+    expect(scripts.length).toBeGreaterThan(0);
+    for (const tag of scripts) expect(tag).toContain('nonce="NONCE123"');
+  });
+});
+
+describe('@taujs/react deferred adapter - failure legs (renderer contract 6, 7)', () => {
+  it('leg 1 - a consumed rejection completes the RESPONSE through the detail-free result accessor', async () => {
+    const Reviews = () => {
+      const result = useDeferredDataResult<{ count: number }>('reviews');
+      return result.status === 'complete' ? <p>reviews: {result.value.count}</p> : <p id="fallback">{`reviews unavailable (${result.status})`}</p>;
+    };
+    const { html, errors } = await drive(
+      () => (
+        <Suspense fallback={<p>loading</p>}>
+          <Reviews />
+        </Suspense>
+      ),
+      { deferredData: deferredRegistry({ reviews: Promise.reject(new Error('REVIEWS_BACKEND_SECRET')) }) },
+    );
+
+    expect(html).toContain('reviews unavailable (failed)');
+    expect(html).not.toContain('REVIEWS_BACKEND_SECRET');
+    expect(errors).toEqual([]);
+  });
+
+  it('leg 1b - the throwing accessor follows React’s native model: the boundary is handed to the client, detail-free', async () => {
+    const Reviews = () => {
+      const data = useDeferredData<{ count: number }>('reviews');
+      return <p>reviews: {data.count}</p>;
+    };
+    const { html } = await drive(
+      () => (
+        <Suspense fallback={<p>loading</p>}>
+          <Reviews />
+        </Suspense>
+      ),
+      { deferredData: deferredRegistry({ reviews: Promise.reject(new Error('REVIEWS_BACKEND_SECRET')) }) },
+    );
+
+    // React's own client-render marker. Either form is REACT's instruction, never τjs's.
+    expect(html).toMatch(/\$RX|<!--\$!-->/);
+    // DISCLOSED, not worked around: a DEVELOPMENT react-dom build streams the error's message and
+    // stacks inside its own errored-boundary template for ANY SSR error. That is React's channel
+    // and it is absent from production builds - asserted in both directions here. τjs's own
+    // surfaces (envelope, trace) stay detail-free regardless, which the host tests pin.
+    const isDevReact = html.includes('data-msg=');
+    if (isDevReact) expect(html).toContain('REVIEWS_BACKEND_SECRET');
+    else expect(html).not.toContain('REVIEWS_BACKEND_SECRET');
+  });
+
+  it('leg 2 - an UNCONSUMED rejection raises no unhandledRejection and does not reverse the document', async () => {
+    const seen: unknown[] = [];
+    const onUnhandled = (e: unknown) => seen.push(e);
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      const { html, errors } = await drive(() => <p>shell only</p>, {
+        deferredData: deferredRegistry({ reviews: Promise.reject(new Error('nobody reads me')) }),
+      });
+      await settle(30);
+      expect(html).toContain('shell only');
+      expect(errors).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+    expect(seen).toEqual([]);
+  });
+
+  it('leg 3 - a manual abort releases the holder: later reads report the released holder, never a fetch', async () => {
+    let holderRead!: (key: string) => unknown;
+    const Probe = () => {
+      const useDeferred = createDeferredAccessor<{ reviews: { count: number } }>();
+      holderRead = useDeferred as unknown as (key: string) => unknown;
+      return <p>probe</p>;
+    };
+    const registry = deferredRegistry({ reviews: new Promise<Record<string, unknown>>(() => {}) });
+    const writable = new PassThrough();
+    const { renderStream } = createRenderer({ appComponent: () => <Probe />, headContent: () => '' });
+    const handle = renderStream(writable, { onHead: () => {} }, {}, '/x', undefined, {}, undefined, { deferredData: registry });
+    await settle(30);
+    handle.abort();
+    await settle(20);
+
+    expect(holderRead).toBeTypeOf('function');
+    await expect(handle.done).resolves.toBeUndefined();
+  });
+
+  it('an unknown key is a deterministic DEVELOPER error naming the declared set', async () => {
+    const Bad = () => {
+      useDeferredData('nope');
+      return null;
+    };
+    const { errors } = await drive(() => <Bad />, { deferredData: deferredRegistry({ reviews: Promise.resolve({ count: 1 }) }) });
+
+    expect(String((errors[0] as Error)?.message)).toContain('unknown deferred data key "nope"');
+    expect(String((errors[0] as Error)?.message)).toContain('"reviews"');
+  });
+
+  it('reading outside a provider is a deterministic developer error', async () => {
+    const Bad = () => {
+      useDeferredData('reviews');
+      return null;
+    };
+    const { errors } = await drive(() => <Bad />);
+
+    expect(String((errors[0] as Error)?.message)).toContain('was called outside a deferred-data provider');
+  });
+});
+
+describe('@taujs/react deferred deadline (decision 18)', () => {
+  it('rejects a non positive-finite value at the factory - there is no disable sentinel', () => {
+    for (const bad of [0, Infinity, -1, NaN, '5' as unknown as number]) {
+      expect(() => createRenderer({ appComponent: () => <p />, headContent: () => '', streamOptions: { deferredTimeoutMs: bad } })).toThrow(
+        /deferredTimeoutMs must be a positive finite number/,
+      );
+    }
+  });
+
+  it('DEFAULT CONFIGURATION: the derived deferred deadline is 15_000 and strictly precedes the fatal route-data backstop', () => {
+    // The relationship, proven deterministically from the shipped defaults rather than by a
+    // 30-second run: min(15_000, dataTimeoutMs / 2) with dataTimeoutMs defaulting to 30_000.
+    const DEFAULT_DATA_TIMEOUT = 30_000;
+    const derived = Math.min(15_000, DEFAULT_DATA_TIMEOUT / 2);
+
+    expect(derived).toBe(15_000);
+    expect(derived).toBeLessThan(DEFAULT_DATA_TIMEOUT);
+    // ...and the factory refuses any configuration that would invert it.
+    expect(() => createRenderer({ appComponent: () => <p />, headContent: () => '', streamOptions: { deferredTimeoutMs: 30_000 } })).toThrow(
+      /must be strictly less than streamOptions.dataTimeoutMs/,
+    );
+    expect(() => createRenderer({ appComponent: () => <p />, headContent: () => '', streamOptions: { dataTimeoutMs: 4_000 } })).not.toThrow();
+  });
+
+  it('derives the default from a NON-default fatal backstop, so the graceful terminal stays reachable', () => {
+    // A renderer configured with a 4s fatal backstop must derive 2s, not 15s.
+    expect(Math.min(15_000, 4_000 / 2)).toBe(2_000);
+    expect(() =>
+      createRenderer({ appComponent: () => <p />, headContent: () => '', streamOptions: { dataTimeoutMs: 4_000, deferredTimeoutMs: 2_000 } }),
+    ).not.toThrow();
+    expect(() =>
+      createRenderer({ appComponent: () => <p />, headContent: () => '', streamOptions: { dataTimeoutMs: 4_000, deferredTimeoutMs: 4_000 } }),
+    ).toThrow();
+  });
+
+  it('leg 4 - on expiry the document terminates deterministically and later reads are born `aborted` (the LATCH)', async () => {
+    const outcomes: string[] = [];
+    const Reviews = () => {
+      const result = useDeferredDataResult<{ count: number }>('reviews');
+      outcomes.push(result.status);
+      return <p id="reviews">reviews: {result.status}</p>;
+    };
+    const { html, handle } = await drive(
+      () => (
+        <Suspense fallback={<p id="pending">loading</p>}>
+          <Reviews />
+        </Suspense>
+      ),
+      { deferredData: deferredRegistry({ reviews: new Promise<Record<string, unknown>>(() => {}) }), streamOptions: { deferredTimeoutMs: 60 }, wait: 500 },
+    );
+
+    // The response TERMINATES - React abandons the boundary through its own instruction - and the
+    // host will classify the still-pending key `aborted` at its write site.
+    await expect(handle.done).resolves.toBeUndefined();
+    expect(html).toMatch(/\$RX|<!--\$!-->/);
+    expect(outcomes).not.toContain('complete');
+  });
+
+  it('a read whose FIRST access arrives after expiry is born `aborted`, not a fresh unbounded wait', async () => {
+    const { createDeferredHolder } = await import('../SSRDeferredData');
+    const holder = createDeferredHolder(deferredRegistry({ reviews: new Promise<Record<string, unknown>>(() => {}) }));
+
+    expect(holder.expire()).toBe(0); // nothing consumed yet
+    const late = holder.resource('reviews') as unknown as { status: string; reason?: unknown };
+    expect(late.status).toBe('rejected');
+    expect((late.reason as DeferredDataError).outcome).toBe('aborted');
+  });
+
+  it('expire() reports the pending CONSUMED entries and latches', async () => {
+    const { createDeferredHolder } = await import('../SSRDeferredData');
+    const holder = createDeferredHolder(deferredRegistry({ reviews: new Promise<Record<string, unknown>>(() => {}), stock: Promise.resolve({ n: 1 }) }));
+
+    holder.resource('reviews');
+    await settle(5);
+    holder.resource('stock');
+    await settle(5);
+
+    expect(holder.expire()).toBe(1);
+    holder.release();
+    expect(() => holder.resource('reviews')).toThrow(/read after the response terminal/);
+  });
+});
+
+describe('@taujs/react deferred adapter - hydration policy', () => {
+  it('hydrate:false still streams the late boundary natively (the envelope is the host’s concern)', async () => {
+    const Reviews = () => {
+      const data = useDeferredData<{ count: number }>('reviews');
+      return <p>reviews: {data.count}</p>;
+    };
+    const { html } = await drive(
+      () => (
+        <Suspense fallback={<p>loading</p>}>
+          <Reviews />
+        </Suspense>
+      ),
+      { deferredData: deferredRegistry({ reviews: Promise.resolve({ count: 3 }) }), shouldHydrate: false },
+    );
+
+    expect(html).toContain('reviews: <!-- -->3');
+  });
+});
+
+describe('@taujs/react deferred adapter - typed facade', () => {
+  it('createDeferredAccessor derives the payload type from the route config', async () => {
+    type Deferred = { reviews: { count: number }; stock: { available: boolean } };
+    const useDeferred = createDeferredAccessor<Deferred>();
+    const Reviews = () => {
+      const reviews = useDeferred('reviews');
+      const stock = useDeferred('stock');
+      return (
+        <p>
+          {reviews.count}/{String(stock.available)}
+        </p>
+      );
+    };
+    const { html } = await drive(
+      () => (
+        <Suspense fallback={<p>loading</p>}>
+          <Reviews />
+        </Suspense>
+      ),
+      { deferredData: deferredRegistry({ reviews: Promise.resolve({ count: 3 }), stock: Promise.resolve({ available: true }) }) },
+    );
+
+    expect(html).toContain('3');
+    expect(html).toContain('true');
+  });
+});
+
+describe('@taujs/react deferred adapter - retention', () => {
+  it('releases the holder on a NORMAL terminal', async () => {
+    const { createDeferredHolder } = await import('../SSRDeferredData');
+    const registry = deferredRegistry({ reviews: Promise.resolve({ count: 1 }) });
+    const holder = createDeferredHolder(registry);
+    holder.resource('reviews');
+    holder.release();
+
+    expect(() => holder.resource('reviews')).toThrow(/holder has been released/);
+    expect(vi.isMockFunction(holder.release)).toBe(false);
+  });
+});

--- a/packages/react/src/test/SSRDeferredData.stream.test.tsx
+++ b/packages/react/src/test/SSRDeferredData.stream.test.tsx
@@ -316,6 +316,47 @@ describe('@taujs/react deferred deadline (decision 18)', () => {
     );
   });
 
+  it('TIME ORIGIN: a costly shell arms what REMAINS of the budget, measured from renderStream ENTRY', async () => {
+    // The magnitude cell above cannot see decision 18's time-ORIGIN clause: with a ~0ms shell the
+    // remaining budget and the full budget are the same number. A CONTROLLED clock (no real waiting)
+    // charges the pre-shell phase exactly 6_000ms of the 15_000 budget, so the arming site must hand
+    // `setTimeout` 9_000. Arming the FULL budget instead would put the graceful terminal at
+    // entry+21s - past the 30_000 fatal backstop's own window in a slower shell, which is precisely
+    // the timer-order accident the shared origin exists to prevent.
+    const base = Date.now();
+    let elapsed = 0;
+    const clock = vi.spyOn(Date, 'now').mockImplementation(() => base + elapsed);
+    const spy = vi.spyOn(globalThis, 'setTimeout');
+    let armed: number[] = [];
+
+    try {
+      await drive(
+        () => {
+          // Runs DURING the shell render - after renderStream entry, before shell commit.
+          elapsed = 6_000;
+          return (
+            <Suspense fallback={<p>loading</p>}>
+              <p>shell</p>
+            </Suspense>
+          );
+        },
+        { deferredData: deferredRegistry({ reviews: Promise.resolve({ count: 3 }) }), initialData: pendingRouteData(), wait: 300 },
+      );
+      armed = spy.mock.calls.map((call) => Number(call[1]));
+    } finally {
+      spy.mockRestore();
+      clock.mockRestore();
+    }
+
+    expect(armed).toContain(9_000); // 15_000 budget, 6_000 of it already spent before the shell
+    expect(armed.filter((ms) => ms > 14_000 && ms <= 15_000)).toHaveLength(0); // never the full budget
+    // Only the deferred deadline is re-based. The shell timer is armed AT entry and the fatal
+    // route-data backstop owns its own full window, so neither moves - which is what makes the
+    // re-based value attributable to the deferred arming site rather than to a global clock shift.
+    expect(armed).toContain(10_000);
+    expect(armed).toContain(30_000);
+  });
+
   it('a per-call `deferredTimeoutMs` is IGNORED - the boot-validated deadline is the only one armed', async () => {
     // It is omitted from `StreamCallOptions` (a compile-time fact), so this pins the RUNTIME half:
     // an untyped consumer smuggling one through must not reach the timer.

--- a/packages/react/src/test/SSRDeferredData.stream.test.tsx
+++ b/packages/react/src/test/SSRDeferredData.stream.test.tsx
@@ -233,7 +233,9 @@ describe('@taujs/react deferred adapter - failure legs (renderer contract 6, 7)'
     expect(seen).toEqual([]);
   });
 
-  it('leg 3 - a manual abort releases the holder: later reads report the released holder, never a fetch', async () => {
+  // The RENDERER's release is proven by the later read in SSRDeferredData.release.test.tsx; this
+  // cell holds the abort leg itself - a caller abort is a benign terminal, never a fatal one.
+  it('leg 3 - a manual abort is a BENIGN terminal and the boundary never falls back to a fetch', async () => {
     let holderRead!: (key: string) => unknown;
     const Probe = () => {
       const useDeferred = createDeferredAccessor<{ reviews: { count: number } }>();
@@ -535,7 +537,9 @@ describe('@taujs/react deferred adapter - typed facade', () => {
 });
 
 describe('@taujs/react deferred adapter - retention', () => {
-  it('releases the holder on a NORMAL terminal', async () => {
+  // The HOLDER's own contract. That the RENDERER invokes it on a terminal is the separate,
+  // mutation-checked claim in SSRDeferredData.release.test.tsx.
+  it('release drops every reference and refuses later reads', async () => {
     const { createDeferredHolder } = await import('../SSRDeferredData');
     const registry = deferredRegistry({ reviews: Promise.resolve({ count: 1 }) });
     const holder = createDeferredHolder(registry);

--- a/packages/react/src/test/SSRDeferredData.stream.test.tsx
+++ b/packages/react/src/test/SSRDeferredData.stream.test.tsx
@@ -11,6 +11,9 @@ import { createDeferredAccessor, DeferredDataError, useDeferredData, useDeferred
 
 const settle = (ms = 60) => new Promise<void>((r) => setTimeout(r, ms));
 
+/** Route data that never settles, so the fatal route-data backstop actually arms at shell commit. */
+const pendingRouteData = () => new Promise<Record<string, unknown>>(() => {});
+
 type Registry = Record<string, Promise<Record<string, unknown>>>;
 
 const deferredRegistry = (entries: Record<string, Promise<Record<string, unknown>>>): Registry => {
@@ -20,7 +23,16 @@ const deferredRegistry = (entries: Record<string, Promise<Record<string, unknown
 
 const drive = async (
   appComponent: (props: { location: string }) => React.ReactElement,
-  opts: { deferredData?: Registry; streamOptions?: StreamOptions; wait?: number; shouldHydrate?: boolean } = {},
+  opts: {
+    deferredData?: Registry;
+    streamOptions?: StreamOptions;
+    wait?: number;
+    shouldHydrate?: boolean;
+    /** Per-CALL overrides, i.e. the seam a standalone consumer reaches (the host sends none). */
+    callOptions?: Record<string, unknown>;
+    /** Left PENDING when a cell needs the fatal route-data backstop to actually arm. */
+    initialData?: Record<string, unknown> | Promise<Record<string, unknown>>;
+  } = {},
 ) => {
   const writable = new PassThrough();
   const chunks: { at: number; text: string }[] = [];
@@ -32,12 +44,12 @@ const drive = async (
   const handle = renderStream(
     writable,
     { onHead: () => {}, onAllReady: () => {}, onError: (e) => errors.push(e) },
-    { critical: 1 },
+    opts.initialData ?? { critical: 1 },
     '/product/42',
     undefined,
     {},
     undefined,
-    { ...(opts.deferredData ? { deferredData: opts.deferredData } : {}), shouldHydrate: opts.shouldHydrate ?? true },
+    { ...(opts.deferredData ? { deferredData: opts.deferredData } : {}), shouldHydrate: opts.shouldHydrate ?? true, ...opts.callOptions },
   );
 
   await Promise.race([handle.done.catch(() => {}), settle(opts.wait ?? 400)]);
@@ -50,7 +62,6 @@ describe('@taujs/react deferred adapter - native projection (renderer contract 1
   it('suspends only the reading boundary: independent shell content precedes the value', async () => {
     let resolveReviews!: (v: Record<string, unknown>) => void;
     const reviews = new Promise<Record<string, unknown>>((r) => (resolveReviews = r));
-    let settledAt = 0;
 
     const Reviews = () => {
       const data = useDeferredData<{ count: number }>('reviews');
@@ -67,12 +78,11 @@ describe('@taujs/react deferred adapter - native projection (renderer contract 1
 
     const driven = drive(App, { deferredData: deferredRegistry({ reviews }) });
     await settle(80);
-    settledAt = Date.now();
     resolveReviews({ count: 3 });
     const { chunks, html } = await driven;
 
-    const shellAt = chunks[0]!.at;
-    expect(shellAt).toBeLessThan(settledAt);
+    // The FIRST chunk carries the independent content and the fallback, and NOT the value - the
+    // shell was committed before the promise settled, which is the whole claim.
     expect(chunks[0]!.text).toContain('unrelated shell content');
     expect(chunks[0]!.text).toContain('loading reviews');
     expect(chunks[0]!.text).not.toContain('reviews: 3');
@@ -273,24 +283,114 @@ describe('@taujs/react deferred deadline (decision 18)', () => {
     }
   });
 
-  it('DEFAULT CONFIGURATION: the derived deferred deadline is 15_000 and strictly precedes the fatal route-data backstop', () => {
-    // The relationship, proven deterministically from the shipped defaults rather than by a
-    // 30-second run: min(15_000, dataTimeoutMs / 2) with dataTimeoutMs defaulting to 30_000.
-    const DEFAULT_DATA_TIMEOUT = 30_000;
-    const derived = Math.min(15_000, DEFAULT_DATA_TIMEOUT / 2);
+  it('DEFAULT CONFIGURATION: the SHIPPED deadlines arm at 15_000 and 30_000, in that order', async () => {
+    // Deterministic (no 30-second run) and it OBSERVES THE MODULE rather than restating its
+    // derivation: both post-shell deadlines are armed at the same site, so the delays handed to
+    // `setTimeout` there ARE the shipped relationship. The cell fails the moment either default -
+    // the 15_000 cap or the 30_000 backstop - moves in either direction.
+    const spy = vi.spyOn(globalThis, 'setTimeout');
 
-    expect(derived).toBe(15_000);
-    expect(derived).toBeLessThan(DEFAULT_DATA_TIMEOUT);
+    await drive(
+      () => (
+        <Suspense fallback={<p>loading</p>}>
+          <p>shell</p>
+        </Suspense>
+      ),
+      { deferredData: deferredRegistry({ reviews: Promise.resolve({ count: 3 }) }), initialData: pendingRouteData(), wait: 300 },
+    );
+
+    const armed = spy.mock.calls.map((call) => Number(call[1]));
+    spy.mockRestore();
+
+    // Armed at shell commit with what REMAINS of a 15_000 budget measured from renderStream entry.
+    const deferred = armed.filter((ms) => ms > 14_000 && ms <= 15_000);
+    expect(deferred).toHaveLength(1);
+    // The fatal route-data backstop, armed at the same instant, is strictly LATER - so the graceful
+    // terminal is structurally reachable.
+    expect(armed).toContain(30_000);
+    expect(deferred[0]!).toBeLessThan(30_000);
+
     // ...and the factory refuses any configuration that would invert it.
     expect(() => createRenderer({ appComponent: () => <p />, headContent: () => '', streamOptions: { deferredTimeoutMs: 30_000 } })).toThrow(
       /must be strictly less than streamOptions.dataTimeoutMs/,
     );
-    expect(() => createRenderer({ appComponent: () => <p />, headContent: () => '', streamOptions: { dataTimeoutMs: 4_000 } })).not.toThrow();
   });
 
-  it('derives the default from a NON-default fatal backstop, so the graceful terminal stays reachable', () => {
-    // A renderer configured with a 4s fatal backstop must derive 2s, not 15s.
-    expect(Math.min(15_000, 4_000 / 2)).toBe(2_000);
+  it('a per-call `deferredTimeoutMs` is IGNORED - the boot-validated deadline is the only one armed', async () => {
+    // It is omitted from `StreamCallOptions` (a compile-time fact), so this pins the RUNTIME half:
+    // an untyped consumer smuggling one through must not reach the timer.
+    const spy = vi.spyOn(globalThis, 'setTimeout');
+
+    await drive(
+      () => (
+        <Suspense fallback={<p>loading</p>}>
+          <p>shell</p>
+        </Suspense>
+      ),
+      { deferredData: deferredRegistry({ reviews: Promise.resolve({ count: 3 }) }), callOptions: { deferredTimeoutMs: 50 }, wait: 300 },
+    );
+
+    const armed = spy.mock.calls.map((call) => Number(call[1]));
+    spy.mockRestore();
+
+    expect(armed.filter((ms) => ms > 14_000 && ms <= 15_000)).toHaveLength(1);
+    expect(armed).not.toContain(50);
+  });
+
+  it('a per-call fatal backstop cannot INVERT the ordering: the deferred deadline is brought back below it', async () => {
+    // The fatal backstop IS per-call overridable (pre-existing), and decision 18's ordering rule is
+    // a property of the response, not only of the factory. With stock defaults (deferred 15_000,
+    // fatal 30_000) a call narrowing the fatal to 900ms would otherwise let it pre-empt graceful
+    // abandonment entirely; the deferred deadline is re-derived as fatal/2.
+    const spy = vi.spyOn(globalThis, 'setTimeout');
+
+    await drive(
+      () => (
+        <Suspense fallback={<p>loading</p>}>
+          <p>shell</p>
+        </Suspense>
+      ),
+      {
+        deferredData: deferredRegistry({ reviews: Promise.resolve({ count: 3 }) }),
+        callOptions: { dataTimeoutMs: 900 },
+        initialData: pendingRouteData(),
+        wait: 300,
+      },
+    );
+
+    const armed = spy.mock.calls.map((call) => Number(call[1]));
+    spy.mockRestore();
+
+    expect(armed.filter((ms) => ms > 14_000 && ms <= 15_000)).toHaveLength(0);
+    expect(armed).toContain(900);
+    expect(armed.filter((ms) => ms > 300 && ms <= 450)).toHaveLength(1);
+  });
+
+  it('derives the default from a NON-default fatal backstop, so the graceful terminal stays reachable', async () => {
+    // A renderer configured with a 4s fatal backstop must derive 2s, not 15s - observed at the
+    // arming site rather than recomputed here.
+    const spy = vi.spyOn(globalThis, 'setTimeout');
+
+    await drive(
+      () => (
+        <Suspense fallback={<p>loading</p>}>
+          <p>shell</p>
+        </Suspense>
+      ),
+      {
+        deferredData: deferredRegistry({ reviews: Promise.resolve({ count: 3 }) }),
+        streamOptions: { dataTimeoutMs: 4_000 },
+        initialData: pendingRouteData(),
+        wait: 300,
+      },
+    );
+
+    const armed = spy.mock.calls.map((call) => Number(call[1]));
+    spy.mockRestore();
+
+    expect(armed).toContain(4_000);
+    expect(armed.filter((ms) => ms > 1_500 && ms <= 2_000)).toHaveLength(1);
+
     expect(() =>
       createRenderer({ appComponent: () => <p />, headContent: () => '', streamOptions: { dataTimeoutMs: 4_000, deferredTimeoutMs: 2_000 } }),
     ).not.toThrow();

--- a/packages/react/src/test/SSRDeferredData.stream.test.tsx
+++ b/packages/react/src/test/SSRDeferredData.stream.test.tsx
@@ -32,12 +32,18 @@ const drive = async (
     callOptions?: Record<string, unknown>;
     /** Left PENDING when a cell needs the fatal route-data backstop to actually arm. */
     initialData?: Record<string, unknown> | Promise<Record<string, unknown>>;
+    /** Live chunk observer, for cells that must gate an action on an OBSERVED flush. */
+    onChunk?: (text: string) => void;
   } = {},
 ) => {
   const writable = new PassThrough();
   const chunks: { at: number; text: string }[] = [];
   const t0 = Date.now();
-  writable.on('data', (c) => chunks.push({ at: Date.now() - t0, text: c.toString() }));
+  writable.on('data', (c) => {
+    const text = c.toString();
+    chunks.push({ at: Date.now() - t0, text });
+    opts.onChunk?.(text);
+  });
 
   const { renderStream } = createRenderer({ appComponent, headContent: () => '<title>t</title>', streamOptions: opts.streamOptions });
   const errors: unknown[] = [];
@@ -76,11 +82,22 @@ describe('@taujs/react deferred adapter - native projection (renderer contract 1
       </main>
     );
 
-    const driven = drive(App, { deferredData: deferredRegistry({ reviews }) });
-    await settle(80);
-    resolveReviews({ count: 3 });
+    // Settlement is GATED on the flushed shell, never on a timer: a timed release can lose the
+    // race to React's first flush on a slow machine, and the value would then render inline -
+    // the cell would be probing scheduler luck rather than the boundary-isolation claim.
+    let sawFallback = false;
+    const driven = drive(App, {
+      deferredData: deferredRegistry({ reviews }),
+      onChunk: (text) => {
+        if (!sawFallback && text.includes('loading reviews')) {
+          sawFallback = true;
+          resolveReviews({ count: 3 });
+        }
+      },
+    });
     const { chunks, html } = await driven;
 
+    expect(sawFallback).toBe(true);
     // The FIRST chunk carries the independent content and the fallback, and NOT the value - the
     // shell was committed before the promise settled, which is the whole claim.
     expect(chunks[0]!.text).toContain('unrelated shell content');

--- a/packages/server/src/Config.ts
+++ b/packages/server/src/Config.ts
@@ -72,6 +72,11 @@ export type RouteData<C extends TaujsConfig = TaujsConfig, P extends string = st
 // loaders); `ServiceDataHandler` is `serviceData()`'s branded return type.
 export type { HeadAttributes, HeadDataOf, RouteParams, ServiceDataHandler } from './core/config/types';
 
+// RFC 0007 (decision 19): the config-side deferred-data surface, beside `HeadDataOf`.
+// `DeferredDataOf<R>` infers what a renderer's deferred accessor receives for a route;
+// `DeferredDataAttributes` is the streaming arm's `attr.deferred` record type.
+export type { DeferredDataAttributes, DeferredDataOf } from './core/config/types';
+
 // RFC 0005 (VS2): the public, allowlisted Vite surface. Exported here (the `./config` entry,
 // alongside `defineConfig`/`TaujsConfig`) so the `vite.shared.ts satisfies TaujsViteConfig` recipe
 // resolves from the same place users import `defineConfig`.

--- a/packages/server/src/core/config/Setup.ts
+++ b/packages/server/src/core/config/Setup.ts
@@ -1,6 +1,12 @@
+import { RENDERTYPE } from '../constants';
 import { now } from '../telemetry/Telemetry';
 
 import type { RouteParams, Route, CoreAppConfig, CoreSecurityConfig, CoreTaujsConfig } from './types';
+
+/** RFC 0007 (R1 rule 1): route-local identifiers - configuration, never user data. */
+const DEFERRED_KEY_PATTERN = /^[A-Za-z][A-Za-z0-9_]*$/;
+
+const isPlainRecord = (v: unknown): v is Record<string, unknown> => !!v && typeof v === 'object' && Object.getPrototypeOf(v) === Object.prototype;
 
 export type ExtractSecurityResult<S extends CoreSecurityConfig = CoreSecurityConfig> = {
   security: S;
@@ -90,6 +96,28 @@ export const extractRoutes = (taujsConfig: CoreTaujsConfig): ExtractRoutesResult
         }
         if (head.optional !== undefined && typeof head.optional !== 'boolean') {
           throw new Error(`${at}: attr.head.optional must be a boolean (received ${String(head.optional)})`);
+        }
+      }
+
+      // RFC 0007 (R1, authoring-contract rules 3 + 4): validate `attr.deferred` at BOOT, beside the
+      // head checks. Malformed input is a hard error, never a warning - a declaration the host
+      // cannot start is a configuration defect, and every rule here is decidable statically.
+      const attr = route.attr as { render?: unknown; deferred?: unknown } | undefined;
+      if (attr?.deferred !== undefined) {
+        const at = `Route "${route.path}" (app "${app.appId}")`;
+        if (attr.render !== RENDERTYPE.streaming) {
+          throw new Error(`${at}: attr.deferred is only valid on a "${RENDERTYPE.streaming}" route; data a non-streamed response needs belongs in attr.data`);
+        }
+        if (!isPlainRecord(attr.deferred)) throw new Error(`${at}: attr.deferred must be a plain object of named data handlers`);
+        // OWN enumerable keys only - an inherited property is never trusted (rule 1). The
+        // plain-object check above already rejects a foreign prototype.
+        for (const key of Object.keys(attr.deferred)) {
+          if (!DEFERRED_KEY_PATTERN.test(key)) {
+            throw new Error(`${at}: attr.deferred key "${key}" must match ${DEFERRED_KEY_PATTERN.source}`);
+          }
+          if (typeof (attr.deferred as Record<string, unknown>)[key] !== 'function') {
+            throw new Error(`${at}: attr.deferred."${key}" must be a function (a data handler or serviceData(...) sugar)`);
+          }
         }
       }
 

--- a/packages/server/src/core/config/test/DeferredDataOf.test-d.ts
+++ b/packages/server/src/core/config/test/DeferredDataOf.test-d.ts
@@ -1,0 +1,86 @@
+// RFC 0007 - HARD GATE, mirroring `HeadDataOf.test-d.ts`: `DeferredDataOf<R>` must infer each
+// declared key's payload from the route config alone, so a renderer's accessor is typeable from
+// `typeof config` without re-declaring a payload shape.
+//
+// Type-level test: enforced by `pnpm --filter @taujs/server typecheck` (tsc); the `.test-d.ts`
+// suffix is outside vitest's test glob so it never runs as a spec. Invariant-Equal (not mere
+// assignability) so width-subtyping cannot fake a pass.
+import { createServiceData } from '../../services/ServiceData';
+
+import type { DeferredDataOf } from '../types';
+import type { ServiceDescriptor } from '../../services/DataServices';
+
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+type Reviews = { count: number; top: string };
+type Stock = { available: boolean };
+
+type Registry = Readonly<{
+  reviews: Readonly<{
+    forProduct: (params: { id: string }, ctx: any) => Promise<Reviews>;
+  }>;
+  inventory: Readonly<{
+    stock: (params: { id: string }, ctx: any) => Promise<Stock>;
+  }>;
+}>;
+
+const serviceData = createServiceData<Registry>();
+
+// --- Arm 1: serviceData() sugar infers the SELECTED METHOD's resolved result (the brand),
+// per key, including a NON-DEFAULT result type. ---
+const productRoute = {
+  path: '/product/:id',
+  attr: {
+    render: 'streaming',
+    meta: {},
+    data: serviceData('reviews', 'forProduct', (p) => ({ id: String(p.id) })),
+    deferred: {
+      reviews: serviceData('reviews', 'forProduct', (p) => ({ id: String(p.id) })),
+      stock: serviceData('inventory', 'stock', (p) => ({ id: String(p.id) })),
+    },
+  },
+} as const;
+
+type _ServiceArm = Expect<Equal<DeferredDataOf<typeof productRoute>, { readonly reviews: Reviews; readonly stock: Stock }>>;
+
+// And explicitly NOT the descriptor (the callable's honest runtime return):
+// @ts-expect-error - a deferred entry is the dispatched result, never the ServiceDescriptor
+const _neverDescriptor: ServiceDescriptor = {} as DeferredDataOf<typeof productRoute>['reviews'];
+void _neverDescriptor;
+
+// --- Arm 2: a closure handler infers its own resolved return type. ---
+const closureRoute = {
+  path: '/legacy',
+  attr: {
+    render: 'streaming',
+    meta: {},
+    deferred: { notes: async () => ({ note: 'hand-written' }) },
+  },
+} as const;
+
+type _ClosureArm = Expect<Equal<DeferredDataOf<typeof closureRoute>, { readonly notes: { note: string } }>>;
+
+// --- Arm 2b: a MIXED closure return keeps the descriptor branch as Record<string, unknown> -
+// the dispatched branch may resolve to any record and must never be narrowed away. ---
+const mixedRoute = {
+  path: '/mixed',
+  attr: {
+    render: 'streaming',
+    meta: {},
+    deferred: {
+      notes: async (params: { premium?: string }) =>
+        params.premium ? { title: 'direct' } : ({ serviceName: 'reviews', serviceMethod: 'forProduct', args: {} } as ServiceDescriptor),
+    },
+  },
+} as const;
+
+type _MixedArm = Expect<Equal<DeferredDataOf<typeof mixedRoute>, { readonly notes: { title: string } | Record<string, unknown> }>>;
+
+// --- Arm 3: no `attr.deferred` -> undefined. ---
+const plainRoute = { path: '/', attr: { render: 'streaming', meta: {} } } as const;
+
+type _NoDeferredArm = Expect<Equal<DeferredDataOf<typeof plainRoute>, undefined>>;
+
+// Keep tsc's noUnusedLocals honest.
+export type _Proof = [_ServiceArm, _ClosureArm, _MixedArm, _NoDeferredArm];

--- a/packages/server/src/core/config/test/SetupDeferred.test.ts
+++ b/packages/server/src/core/config/test/SetupDeferred.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment node
+// RFC 0007 (R1, authoring-contract rules 1/3/4): `attr.deferred` boot validation lives with the
+// existing extract-routes checks. Malformed input is a HARD ERROR, never a warning.
+import { describe, it, expect } from 'vitest';
+
+import { extractRoutes } from '../Setup';
+
+const withDeferred = (deferred: unknown, render: string = 'streaming') =>
+  ({ apps: [{ appId: 'shop', entryPoint: '', routes: [{ path: '/product/:id', attr: { render, meta: {}, deferred } }] }] }) as any;
+
+describe('extractRoutes attr.deferred validation (RFC 0007 R1)', () => {
+  it('accepts a valid streaming declaration, and leaves routes without deferred untouched', () => {
+    expect(() => extractRoutes(withDeferred({ reviews: async () => ({}), stock_2: async () => ({}) }))).not.toThrow();
+    expect(() => extractRoutes(withDeferred(undefined))).not.toThrow();
+    expect(() => extractRoutes({ apps: [{ appId: 'shop', entryPoint: '', routes: [{ path: '/x', attr: { render: 'ssr' } }] }] } as any)).not.toThrow();
+  });
+
+  it('rejects deferred on an ssr route (rule 3)', () => {
+    expect(() => extractRoutes(withDeferred({ reviews: async () => ({}) }, 'ssr'))).toThrow(/attr\.deferred is only valid on a "streaming" route/);
+  });
+
+  it('rejects a non-plain-object record (rule 4), including a foreign prototype', () => {
+    expect(() => extractRoutes(withDeferred([async () => ({})]))).toThrow(/attr\.deferred must be a plain object/);
+    expect(() => extractRoutes(withDeferred('reviews'))).toThrow(/attr\.deferred must be a plain object/);
+    expect(() => extractRoutes(withDeferred(Object.create({ reviews: async () => ({}) })))).toThrow(/attr\.deferred must be a plain object/);
+  });
+
+  it('rejects a non-function entry value (rule 4)', () => {
+    expect(() => extractRoutes(withDeferred({ reviews: 42 }))).toThrow(/attr\.deferred\."reviews" must be a function/);
+  });
+
+  it('rejects keys failing the charset rule (rule 1)', () => {
+    for (const key of ['9reviews', 'reviews-list', 'reviews.count', '', '__proto__', 'a b']) {
+      expect(() => extractRoutes(withDeferred({ [key]: async () => ({}) }))).toThrow(/must match \^\[A-Za-z\]\[A-Za-z0-9_\]\*\$/);
+    }
+  });
+
+  it('never trusts an inherited key: only OWN enumerable keys are validated', () => {
+    // A polluted Object.prototype must not turn a valid record into a boot failure.
+    (Object.prototype as unknown as Record<string, unknown>)['inheritedNonsense'] = 42;
+    try {
+      expect(() => extractRoutes(withDeferred({ reviews: async () => ({}) }))).not.toThrow();
+    } finally {
+      delete (Object.prototype as unknown as Record<string, unknown>)['inheritedNonsense'];
+    }
+  });
+});

--- a/packages/server/src/core/config/types.ts
+++ b/packages/server/src/core/config/types.ts
@@ -79,6 +79,15 @@ export type HeadAttributes<Params extends RouteParams = RouteParams, L extends L
   optional?: boolean;
 };
 
+/**
+ * RFC 0007 (R1): the flat, STREAMING-ONLY record of route-owned deferred loaders. Values are the
+ * existing `DataHandler` shape (`serviceData()` sugar included) - no new helper, no dependencies
+ * between entries, and no optionality: `deferred` describes timing, not whether a value may be
+ * missing. Keys are stable route-local identifiers matching `^[A-Za-z][A-Za-z0-9_]*$`, validated at
+ * boot beside the other extract-routes checks.
+ */
+export type DeferredDataAttributes<Params extends RouteParams = RouteParams, L extends Logs = Logs> = Readonly<Record<string, DataHandler<Params, L>>>;
+
 export type RouteAttributes<Params extends RouteParams = RouteParams, Middleware = BaseMiddleware, L extends Logs = Logs> =
   | {
       render: 'ssr';
@@ -94,6 +103,10 @@ export type RouteAttributes<Params extends RouteParams = RouteParams, Middleware
       meta: Record<string, unknown>;
       middleware?: Middleware;
       data?: DataHandler<Params, L>;
+      // RFC 0007 (R1): the streaming arm ONLY. `deferred` on an `ssr` route is a type error here
+      // AND a boot hard error for untyped input - data required by a non-streamed response belongs
+      // in `data`.
+      deferred?: DeferredDataAttributes<Params, L>;
       head?: HeadAttributes<Params, L>;
     };
 
@@ -131,6 +144,30 @@ export type HeadDataOf<R> = R extends { attr?: infer A }
       : H extends (...args: any) => infer Ret
         ? DescriptorMemberToRecord<Awaited<Ret>>
         : unknown
+    : undefined
+  : undefined;
+
+/**
+ * RFC 0007: the type a renderer's deferred accessor receives for a route, following `HeadDataOf`'s
+ * three arms exactly:
+ * - `serviceData()` sugar: the SELECTED METHOD's resolved result, read from the phantom brand;
+ * - closure handler: its resolved return type (descriptor returns collapse to
+ *   `Record<string, unknown>` - the dispatch result is untyped for hand-built descriptors);
+ * - no `attr.deferred`: `undefined`.
+ *
+ * Note the inferred type describes the loader's DECLARED result. What arrives is that value's JSON
+ * snapshot (failure semantics item 2) - the same caveat that already applies to `attr.data`
+ * crossing `__INITIAL_DATA__`.
+ */
+export type DeferredDataOf<R> = R extends { attr?: infer A }
+  ? A extends { deferred: infer D }
+    ? {
+        [K in keyof D]: D[K] extends { readonly [SERVICE_RESULT]: infer Res }
+          ? Res
+          : D[K] extends (...args: any) => infer Ret
+            ? DescriptorMemberToRecord<Awaited<Ret>>
+            : unknown;
+      }
     : undefined
   : undefined;
 

--- a/packages/server/src/core/introspection/DevFiles.ts
+++ b/packages/server/src/core/introspection/DevFiles.ts
@@ -20,12 +20,15 @@ export const registerDevFiles = (app: FastifyInstance, introspection: DevIntrosp
   const filePath = (name: string) => path.join(dir, name);
 
   let timer: NodeJS.Timeout | undefined;
-  let last = { traces: -1, logs: -1, observationsUpdatedAt: null as string | null };
+  let last = { traces: -1, tracesRevision: -1, logs: -1, observationsUpdatedAt: null as string | null };
 
   const flush = async (): Promise<void> => {
     const stats = introspection.stats();
 
-    if (stats.traces !== last.traces) {
+    // `tracesRevision` advances for a NEW finalized trace and for an in-place amendment of one
+    // (RFC 0007 R5: a deferred outcome arriving after the terminal), so a late outcome reaches the
+    // on-disk artefact through this same bounded rewrite rather than lagging until the next request.
+    if (stats.tracesRevision !== last.tracesRevision) {
       const lines = introspection.getTraces().map((t) => JSON.stringify(t));
       await writeTaujsArtifact(dir, 'traces.ndjson', lines.length ? `${lines.join('\n')}\n` : '', logger);
     }

--- a/packages/server/src/core/introspection/DevFiles.ts
+++ b/packages/server/src/core/introspection/DevFiles.ts
@@ -25,7 +25,7 @@ export const registerDevFiles = (app: FastifyInstance, introspection: DevIntrosp
   const flush = async (): Promise<void> => {
     const stats = introspection.stats();
 
-    // `tracesRevision` advances for a NEW finalized trace and for an in-place amendment of one
+    // `tracesRevision` advances for a NEW finalised trace and for an in-place amendment of one
     // (RFC 0007 R5: a deferred outcome arriving after the terminal), so a late outcome reaches the
     // on-disk artefact through this same bounded rewrite rather than lagging until the next request.
     if (stats.tracesRevision !== last.tracesRevision) {

--- a/packages/server/src/core/introspection/DevIntrospection.ts
+++ b/packages/server/src/core/introspection/DevIntrospection.ts
@@ -209,11 +209,11 @@ export const createDevIntrospection = (options?: { logger?: Logs; denyKeys?: str
       // the abort reaches the registry, so the per-key outcomes for exactly the case R5 exists to
       // explain would otherwise be dropped. An amendment to a finalised trace bumps
       // `tracesRevision`, which is what carries it into the on-disk NDJSON.
-      const finalized = pending.get(e.traceId) === undefined;
+      const finalised = pending.get(e.traceId) === undefined;
       const trace = pending.get(e.traceId) ?? traces.find((t) => t.traceId === e.traceId);
       if (!trace) return;
       (trace.deferredData ??= []).push({ key: e.key, outcome: e.outcome, ms: e.ms });
-      if (finalized) tracesRevision += 1;
+      if (finalised) tracesRevision += 1;
     },
 
     serviceCall(e) {

--- a/packages/server/src/core/introspection/DevIntrospection.ts
+++ b/packages/server/src/core/introspection/DevIntrospection.ts
@@ -85,7 +85,7 @@ export type DevIntrospection = {
   findTrace: (traceId: string) => TraceRecord | undefined;
   /**
    * Cumulative counters for change detection by the file emitter. `tracesRevision` also advances
-   * when an ALREADY-FINALIZED trace is amended in place (RFC 0007 R5: a deferred outcome arriving
+   * when an ALREADY-FINALISED trace is amended in place (RFC 0007 R5: a deferred outcome arriving
    * after the terminal), which `traces` alone cannot express - without it a late outcome would be
    * visible in memory and absent from the on-disk NDJSON, and therefore from MCP.
    */
@@ -204,10 +204,10 @@ export const createDevIntrospection = (options?: { logger?: Logs; denyKeys?: str
     },
 
     deferredData(e) {
-      // RFC 0007 (R5) retention. FINALIZED traces are looked up too (the `clientHydration` idiom):
-      // on a client disconnect the host records the benign abort - finalizing the trace - BEFORE
+      // RFC 0007 (R5) retention. FINALISED traces are looked up too (the `clientHydration` idiom):
+      // on a client disconnect the host records the benign abort - finalising the trace - BEFORE
       // the abort reaches the registry, so the per-key outcomes for exactly the case R5 exists to
-      // explain would otherwise be dropped. An amendment to a finalized trace bumps
+      // explain would otherwise be dropped. An amendment to a finalised trace bumps
       // `tracesRevision`, which is what carries it into the on-disk NDJSON.
       const finalized = pending.get(e.traceId) === undefined;
       const trace = pending.get(e.traceId) ?? traces.find((t) => t.traceId === e.traceId);

--- a/packages/server/src/core/introspection/DevIntrospection.ts
+++ b/packages/server/src/core/introspection/DevIntrospection.ts
@@ -33,6 +33,13 @@ export type TraceRecord = {
   url: { pathname: string; queryKeys: string[]; queryValuesRedacted: true };
   timeline: TraceTimeline;
   serviceCalls: { service: string; method: string; ms: number; ok: boolean }[];
+  /**
+   * RFC 0007 (R5): per-key deferred outcomes, in arrival order. ADDITIVE-OPTIONAL and ABSENT for
+   * any trace with no deferred events, so existing trace bytes and older readers are unaffected.
+   * Bounded by construction - one entry per DECLARED key per request, and declared keys are static
+   * configuration - so it carries no cap of its own, exactly like `serviceCalls`.
+   */
+  deferredData?: { key: string; outcome: 'complete' | 'failed' | 'aborted'; ms: number }[];
   client: { hydrated: boolean; hydrationMs: number | null; error: string | null } | null;
   error: { kind: string; message: string } | null;
 };
@@ -76,8 +83,13 @@ export type DevIntrospection = {
   getObservations: () => ObservationsDocument;
   /** Finalized-or-pending trace lookup — used by the beacon endpoint's duplicate check. */
   findTrace: (traceId: string) => TraceRecord | undefined;
-  /** Cumulative counters for change detection by the file emitter. */
-  stats: () => { traces: number; logs: number; observationsUpdatedAt: string | null };
+  /**
+   * Cumulative counters for change detection by the file emitter. `tracesRevision` also advances
+   * when an ALREADY-FINALIZED trace is amended in place (RFC 0007 R5: a deferred outcome arriving
+   * after the terminal), which `traces` alone cannot express - without it a late outcome would be
+   * visible in memory and absent from the on-disk NDJSON, and therefore from MCP.
+   */
+  stats: () => { traces: number; tracesRevision: number; logs: number; observationsUpdatedAt: string | null };
 };
 
 type PendingTrace = TraceRecord & { t0: number; done: boolean };
@@ -133,6 +145,7 @@ export const createDevIntrospection = (options?: { logger?: Logs; denyKeys?: str
   const edges = new Map<string, ObservedEdge & { routeIds: Set<string> }>();
   let observationsChangedAt: string | null = null;
   let totalTraces = 0;
+  let tracesRevision = 0;
   let totalLogs = 0;
 
   const finalize = (trace: PendingTrace, outcome: TraceRecord['outcome']): void => {
@@ -144,6 +157,7 @@ export const createDevIntrospection = (options?: { logger?: Logs; denyKeys?: str
     const { t0: _t0, done: _done, ...record } = trace;
     traces.push(record);
     totalTraces += 1;
+    tracesRevision += 1;
     if (traces.length > TRACE_RING_CAP) traces.shift();
   };
 
@@ -187,6 +201,19 @@ export const createDevIntrospection = (options?: { logger?: Logs; denyKeys?: str
       const dataEnd = +(now() - trace.t0).toFixed(1);
       trace.timeline.dataEnd = dataEnd;
       trace.timeline.dataStart = +(dataEnd - e.ms).toFixed(1);
+    },
+
+    deferredData(e) {
+      // RFC 0007 (R5) retention. FINALIZED traces are looked up too (the `clientHydration` idiom):
+      // on a client disconnect the host records the benign abort - finalizing the trace - BEFORE
+      // the abort reaches the registry, so the per-key outcomes for exactly the case R5 exists to
+      // explain would otherwise be dropped. An amendment to a finalized trace bumps
+      // `tracesRevision`, which is what carries it into the on-disk NDJSON.
+      const finalized = pending.get(e.traceId) === undefined;
+      const trace = pending.get(e.traceId) ?? traces.find((t) => t.traceId === e.traceId);
+      if (!trace) return;
+      (trace.deferredData ??= []).push({ key: e.key, outcome: e.outcome, ms: e.ms });
+      if (finalized) tracesRevision += 1;
     },
 
     serviceCall(e) {
@@ -323,6 +350,6 @@ export const createDevIntrospection = (options?: { logger?: Logs; denyKeys?: str
       }
       return traces.find((t) => t.traceId === traceId);
     },
-    stats: () => ({ traces: totalTraces, logs: totalLogs, observationsUpdatedAt: observationsChangedAt }),
+    stats: () => ({ traces: totalTraces, tracesRevision, logs: totalLogs, observationsUpdatedAt: observationsChangedAt }),
   };
 };

--- a/packages/server/src/core/introspection/RequestGraph.ts
+++ b/packages/server/src/core/introspection/RequestGraph.ts
@@ -37,6 +37,13 @@ export type GraphRoute = {
   specificity: number;
   middleware: { auth: { declared: boolean }; csp: GraphRouteCSP };
   data: GraphRouteData;
+  /**
+   * RFC 0007 (R5): declared `attr.deferred` entries, key-sorted. ABSENT when the route declares
+   * none, per spec 02's additive-optional-fields rule - routes without the declaration keep
+   * byte-identical graph emission and older readers are unaffected. `kind: 'none'` is not valid
+   * here: an entry exists only when declared.
+   */
+  deferred?: { key: string; data: GraphRouteData }[];
 };
 
 export type GraphUsedBy = { routeId: string; appId: string; path: string };
@@ -68,6 +75,9 @@ export type CreateRequestGraphOptions = {
 };
 
 const isMatchAllWildcard = (path: string): boolean => path === '/*' || path === '*';
+
+const isServiceEdge = (edge: GraphRouteData, service: string, method: string): boolean =>
+  edge.kind === 'service' && edge.service === service && edge.method === method;
 
 // Pure, deterministic, no I/O. Serialises the resolved config into spec 02 schema v1 —
 // nothing here executes data handlers or touches a server instance; declared route → service
@@ -127,6 +137,25 @@ export function createRequestGraph(config: CoreTaujsConfig, options: CreateReque
         data = meta ? { kind: 'service', service: meta.serviceName, method: meta.serviceMethod } : { kind: 'dynamic' };
       }
 
+      // RFC 0007 (R5): derivation mirrors the data edge exactly. OWN enumerable keys only, and the
+      // same non-function guard the registry applies, so the graph and the runtime agree on which
+      // entries exist.
+      const declaredDeferred = (attr as { deferred?: Record<string, unknown> } | undefined)?.deferred;
+      const deferred =
+        declaredDeferred && typeof declaredDeferred === 'object'
+          ? Object.keys(declaredDeferred)
+              .filter((key) => typeof declaredDeferred[key] === 'function')
+              .sort()
+              .map((key) => {
+                const meta = getServiceDataMetadata(declaredDeferred[key] as (...args: never[]) => unknown);
+
+                return {
+                  key,
+                  data: meta ? ({ kind: 'service', service: meta.serviceName, method: meta.serviceMethod } as const) : ({ kind: 'dynamic' } as const),
+                };
+              })
+          : [];
+
       routes.push({
         id,
         appId: app.appId,
@@ -136,6 +165,7 @@ export function createRequestGraph(config: CoreTaujsConfig, options: CreateReque
         specificity: calculateSpecificity(route.path),
         middleware: { auth: { declared: Boolean(attr?.middleware?.auth) }, csp: cspBlock },
         data,
+        ...(deferred.length > 0 ? { deferred } : {}),
       });
 
       if (renderDefaulted) {
@@ -190,8 +220,15 @@ export function createRequestGraph(config: CoreTaujsConfig, options: CreateReque
               name: methodName,
               params: { ...(meta?.params ?? { declared: false }) },
               result: { ...(meta?.result ?? { declared: false }) },
+              // RFC 0007 (R5): a DECLARED deferred service entry contributes exactly as the `data`
+              // edge does. The predicate is per-route, so a route declaring the same method both
+              // critically and deferred (or under two deferred keys) still appears at most once -
+              // the routeId dedupe, with the existing deterministic route order preserved.
               usedBy: routes
-                .filter((r) => r.data.kind === 'service' && r.data.service === serviceName && r.data.method === methodName)
+                .filter(
+                  (r) =>
+                    isServiceEdge(r.data, serviceName, methodName) || (r.deferred ?? []).some((entry) => isServiceEdge(entry.data, serviceName, methodName)),
+                )
                 .map((r) => ({ routeId: r.id, appId: r.appId, path: r.path })),
             };
           }),

--- a/packages/server/src/core/introspection/TraceRecorder.ts
+++ b/packages/server/src/core/introspection/TraceRecorder.ts
@@ -7,6 +7,12 @@ export interface TraceRecorder {
   requestStart(e: { traceId: string; url: string; method: string }): void;
   routeMatched(e: { traceId: string; path: string; appId: string; render: 'ssr' | 'streaming' }): void;
   dataFetch(e: { traceId: string; ms: number; ok: boolean }): void;
+  /**
+   * RFC 0007 (R5): fired exactly ONCE per declared `attr.deferred` key per request. `ms` measures
+   * from registry creation to settlement or `aborted` classification. No payload, params, URL
+   * values, error message or stack - the graph supplies the declared key -> service relation.
+   */
+  deferredData(e: { traceId: string; key: string; ms: number; outcome: 'complete' | 'failed' | 'aborted' }): void;
   serviceCall(e: { traceId: string; service: string; method: string; ms: number; ok: boolean }): void;
   streamPhase(e: { traceId: string; phase: 'head' | 'shellReady' | 'allReady' }): void;
   sent(e: { traceId: string; status: number; mode: 'ssr' | 'streaming' | 'fallthrough' }): void;
@@ -19,6 +25,7 @@ export const noopTraceRecorder: TraceRecorder = {
   requestStart() {},
   routeMatched() {},
   dataFetch() {},
+  deferredData() {},
   serviceCall() {},
   streamPhase() {},
   sent() {},
@@ -47,6 +54,7 @@ export const createSafeRecorder = (impl: TraceRecorder, onFirstError?: (err: unk
     requestStart: guard(impl.requestStart),
     routeMatched: guard(impl.routeMatched),
     dataFetch: guard(impl.dataFetch),
+    deferredData: guard(impl.deferredData),
     serviceCall: guard(impl.serviceCall),
     streamPhase: guard(impl.streamPhase),
     sent: guard(impl.sent),

--- a/packages/server/src/core/introspection/test/DeferredTrace.test.ts
+++ b/packages/server/src/core/introspection/test/DeferredTrace.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment node
+// RFC 0007 (R5): dev-trace retention of the per-key deferred outcome, and its DURABLE arrival in
+// the on-disk NDJSON through the ordinary bounded persistence mechanism.
+import { mkdtemp, readFile, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import fastify from 'fastify';
+import { describe, it, expect, vi } from 'vitest';
+
+import { createDevIntrospection } from '../DevIntrospection';
+import { registerDevFiles } from '../DevFiles';
+
+const mkLogger = (): any => {
+  const l: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), isDebugEnabled: () => false };
+  l.child = () => l;
+  return l;
+};
+
+describe('dev trace retention of deferred outcomes (RFC 0007 R5)', () => {
+  it('retains { key, outcome, ms } per key and stays ABSENT for a trace with no deferred events', () => {
+    const dev = createDevIntrospection();
+
+    dev.recorder.requestStart({ traceId: 'plain', url: '/plain', method: 'GET' });
+    dev.recorder.sent({ traceId: 'plain', status: 200, mode: 'streaming' });
+
+    dev.recorder.requestStart({ traceId: 'deferred', url: '/product/42', method: 'GET' });
+    dev.recorder.deferredData({ traceId: 'deferred', key: 'reviews', ms: 12.5, outcome: 'complete' });
+    dev.recorder.deferredData({ traceId: 'deferred', key: 'stock', ms: 30, outcome: 'failed' });
+    dev.recorder.sent({ traceId: 'deferred', status: 200, mode: 'streaming' });
+
+    const traces = Object.fromEntries(dev.getTraces().map((t) => [t.traceId, t]));
+    expect('deferredData' in traces['plain']!).toBe(false);
+    expect(traces['deferred']!.deferredData).toEqual([
+      { key: 'reviews', outcome: 'complete', ms: 12.5 },
+      { key: 'stock', outcome: 'failed', ms: 30 },
+    ]);
+    // No payload, params, message or stack ever crosses.
+    expect(JSON.stringify(traces['deferred']!.deferredData)).toBe(
+      '[{"key":"reviews","outcome":"complete","ms":12.5},{"key":"stock","outcome":"failed","ms":30}]',
+    );
+  });
+
+  it('resolves FINALIZED traces too - the client-disconnect ordering R5 exists to explain', () => {
+    const dev = createDevIntrospection();
+
+    dev.recorder.requestStart({ traceId: 'disconnect', url: '/product/42', method: 'GET' });
+    // The host records the benign abort (finalizing the trace) BEFORE the abort reaches the registry.
+    dev.recorder.aborted({ traceId: 'disconnect', phase: 'stream' });
+    dev.recorder.deferredData({ traceId: 'disconnect', key: 'reviews', ms: 4, outcome: 'aborted' });
+
+    expect(dev.findTrace('disconnect')!.deferredData).toEqual([{ key: 'reviews', outcome: 'aborted', ms: 4 }]);
+  });
+
+  it('a late outcome marks the persisted trace DIRTY: tracesRevision advances without a new trace', () => {
+    const dev = createDevIntrospection();
+
+    dev.recorder.requestStart({ traceId: 'late', url: '/product/42', method: 'GET' });
+    dev.recorder.sent({ traceId: 'late', status: 200, mode: 'streaming' });
+    const afterFinalize = dev.stats();
+
+    dev.recorder.deferredData({ traceId: 'late', key: 'reviews', ms: 9, outcome: 'aborted' });
+    const afterLate = dev.stats();
+
+    expect(afterLate.traces).toBe(afterFinalize.traces);
+    expect(afterLate.tracesRevision).toBe(afterFinalize.tracesRevision + 1);
+  });
+
+  it('a late outcome reaches the on-disk traces.ndjson through the ordinary bounded rewrite', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'taujs-deferred-'));
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(dir);
+    try {
+      const dev = createDevIntrospection();
+      const app = fastify();
+      registerDevFiles(app, dev, mkLogger());
+
+      dev.recorder.requestStart({ traceId: 'late-disk', url: '/product/42', method: 'GET' });
+      dev.recorder.sent({ traceId: 'late-disk', status: 200, mode: 'streaming' });
+
+      await app.listen({ port: 0, host: '127.0.0.1' });
+
+      const tracesPath = path.join(dir, 'node_modules', '.taujs', 'traces.ndjson');
+      await vi.waitFor(async () => {
+        await stat(tracesPath);
+        expect(await readFile(tracesPath, 'utf8')).toContain('late-disk');
+      });
+      expect(await readFile(tracesPath, 'utf8')).not.toContain('deferredData');
+
+      // The outcome arrives AFTER the trace was finalized and persisted.
+      dev.recorder.deferredData({ traceId: 'late-disk', key: 'reviews', ms: 7, outcome: 'aborted' });
+
+      await vi.waitFor(async () => {
+        expect(await readFile(tracesPath, 'utf8')).toContain('"deferredData":[{"key":"reviews","outcome":"aborted","ms":7}]');
+      });
+
+      await app.close();
+    } finally {
+      cwdSpy.mockRestore();
+    }
+  });
+});

--- a/packages/server/src/core/introspection/test/DeferredTrace.test.ts
+++ b/packages/server/src/core/introspection/test/DeferredTrace.test.ts
@@ -41,11 +41,11 @@ describe('dev trace retention of deferred outcomes (RFC 0007 R5)', () => {
     );
   });
 
-  it('resolves FINALIZED traces too - the client-disconnect ordering R5 exists to explain', () => {
+  it('resolves FINALISED traces too - the client-disconnect ordering R5 exists to explain', () => {
     const dev = createDevIntrospection();
 
     dev.recorder.requestStart({ traceId: 'disconnect', url: '/product/42', method: 'GET' });
-    // The host records the benign abort (finalizing the trace) BEFORE the abort reaches the registry.
+    // The host records the benign abort (finalising the trace) BEFORE the abort reaches the registry.
     dev.recorder.aborted({ traceId: 'disconnect', phase: 'stream' });
     dev.recorder.deferredData({ traceId: 'disconnect', key: 'reviews', ms: 4, outcome: 'aborted' });
 
@@ -86,7 +86,7 @@ describe('dev trace retention of deferred outcomes (RFC 0007 R5)', () => {
       });
       expect(await readFile(tracesPath, 'utf8')).not.toContain('deferredData');
 
-      // The outcome arrives AFTER the trace was finalized and persisted.
+      // The outcome arrives AFTER the trace was finalised and persisted.
       dev.recorder.deferredData({ traceId: 'late-disk', key: 'reviews', ms: 7, outcome: 'aborted' });
 
       await vi.waitFor(async () => {

--- a/packages/server/src/core/introspection/test/DevIntrospection.test.ts
+++ b/packages/server/src/core/introspection/test/DevIntrospection.test.ts
@@ -241,6 +241,9 @@ describe('recorder isolation (spec 03 invariant 2)', () => {
     dataFetch() {
       throw new Error('hostile');
     },
+    deferredData() {
+      throw new Error('hostile');
+    },
     serviceCall() {
       throw new Error('hostile');
     },

--- a/packages/server/src/core/introspection/test/RequestGraphDeferred.test.ts
+++ b/packages/server/src/core/introspection/test/RequestGraphDeferred.test.ts
@@ -1,0 +1,108 @@
+// @vitest-environment node
+// RFC 0007 (R5): the additive-optional `GraphRoute.deferred` field and its `usedBy` contribution.
+import { describe, it, expect } from 'vitest';
+
+import { createRequestGraph } from '../RequestGraph';
+import { createServiceData } from '../../services/ServiceData';
+import { defineService, defineServiceRegistry } from '../../services/DataServices';
+
+import type { CoreTaujsConfig } from '../../config/types';
+
+const registry = defineServiceRegistry({
+  reviews: defineService({ forProduct: async () => ({ count: 3 }) }),
+  inventory: defineService({ stock: async () => ({ available: true }) }),
+});
+
+const serviceData = createServiceData<typeof registry>();
+
+const emitted = { source: 'boot' as const, emittedAt: '2026-07-28T00:00:00.000Z' };
+
+const configWith = (attr: Record<string, unknown>): CoreTaujsConfig => ({
+  apps: [{ appId: 'shop', entryPoint: '', routes: [{ path: '/product/:id', attr: attr as never }] }],
+});
+
+describe('createRequestGraph deferred entries (RFC 0007 R5)', () => {
+  it('emits nothing for a route declaring no deferred entries (byte-identical emission)', () => {
+    const graph = createRequestGraph(configWith({ render: 'streaming', meta: {} }), emitted);
+
+    expect('deferred' in graph.routes[0]!).toBe(false);
+    expect(JSON.stringify(graph.routes[0])).not.toContain('deferred');
+  });
+
+  it('emits key-SORTED entries, deriving each edge exactly like the data edge', () => {
+    const graph = createRequestGraph(
+      configWith({
+        render: 'streaming',
+        meta: {},
+        deferred: {
+          stock: serviceData('inventory', 'stock', () => ({})),
+          reviews: serviceData('reviews', 'forProduct', () => ({})),
+          notes: async () => ({ note: 'dynamic' }),
+        },
+      }),
+      emitted,
+    );
+
+    expect(graph.routes[0]!.deferred).toEqual([
+      { key: 'notes', data: { kind: 'dynamic' } },
+      { key: 'reviews', data: { kind: 'service', service: 'reviews', method: 'forProduct' } },
+      { key: 'stock', data: { kind: 'service', service: 'inventory', method: 'stock' } },
+    ]);
+  });
+
+  it('is deterministic across runs', () => {
+    const config = configWith({
+      render: 'streaming',
+      meta: {},
+      deferred: { stock: serviceData('inventory', 'stock', () => ({})), reviews: serviceData('reviews', 'forProduct', () => ({})) },
+    });
+
+    expect(JSON.stringify(createRequestGraph(config, emitted))).toBe(JSON.stringify(createRequestGraph(config, emitted)));
+  });
+
+  it('contributes to GraphServiceMethod.usedBy exactly as a data edge does, with routeId dedupe', () => {
+    const graph = createRequestGraph(
+      {
+        apps: [
+          {
+            appId: 'shop',
+            entryPoint: '',
+            routes: [
+              {
+                path: '/product/:id',
+                attr: {
+                  render: 'streaming',
+                  meta: {},
+                  // The SAME method both critically and deferred, plus a second deferred key on it:
+                  // the route must appear at most once.
+                  data: serviceData('reviews', 'forProduct', () => ({})),
+                  deferred: {
+                    reviews: serviceData('reviews', 'forProduct', () => ({})),
+                    alsoReviews: serviceData('reviews', 'forProduct', () => ({})),
+                    stock: serviceData('inventory', 'stock', () => ({})),
+                  },
+                } as never,
+              },
+              { path: '/plain', attr: { render: 'streaming', meta: {} } as never },
+            ],
+          },
+        ],
+      },
+      { ...emitted, serviceRegistry: registry },
+    );
+
+    const byName = Object.fromEntries(graph.services!.map((s) => [s.name, s]));
+    expect(byName['reviews']!.methods[0]!.usedBy).toEqual([{ routeId: 'shop:/product/:id', appId: 'shop', path: '/product/:id' }]);
+    // A method reached ONLY through a deferred declaration is still a declared edge.
+    expect(byName['inventory']!.methods[0]!.usedBy).toEqual([{ routeId: 'shop:/product/:id', appId: 'shop', path: '/product/:id' }]);
+  });
+
+  it('ignores non-function entries and inherited keys', () => {
+    const graph = createRequestGraph(
+      configWith({ render: 'streaming', meta: {}, deferred: Object.assign(Object.create({ inherited: () => ({}) }), { reviews: async () => ({}) }) }),
+      emitted,
+    );
+
+    expect(graph.routes[0]!.deferred).toEqual([{ key: 'reviews', data: { kind: 'dynamic' } }]);
+  });
+});

--- a/packages/server/src/core/routes/DataRoutes.ts
+++ b/packages/server/src/core/routes/DataRoutes.ts
@@ -1,18 +1,12 @@
-import { callServiceMethod, ensureServiceCaller, isServiceDescriptor } from '../services/DataServices';
+import { callServiceMethod } from '../services/DataServices';
 import { AppError } from '../errors/AppError';
+import { prepareDataContext, resolveDataHandler } from './ResolveRouteData';
 
-import type { ServiceContext, ServiceRegistry } from '../services/DataServices';
+import type { ServiceRegistry } from '../services/DataServices';
 import type { Logs } from '../logging/types';
-import type { RouteAttributes, RouteParams, RequestServiceContext } from '../config/types';
+import type { RouteAttributes, RouteParams } from '../config/types';
 import type { RequestContext } from '../telemetry/Telemetry';
-
-type CallServiceOn<R extends ServiceRegistry> = (
-  registry: R,
-  serviceName: string,
-  methodName: string,
-  params: Record<string, unknown>,
-  ctx: ServiceContext,
-) => Promise<Record<string, unknown>>;
+import type { CallServiceOn } from './ResolveRouteData';
 
 export const calculateSpecificity = (path: string): number => {
   let score = 0;
@@ -34,8 +28,6 @@ export const calculateSpecificity = (path: string): number => {
   return score;
 };
 
-const isPlainObject = (v: unknown): v is Record<string, unknown> => !!v && typeof v === 'object' && Object.getPrototypeOf(v) === Object.prototype;
-
 /**
  * RFC 0004 (H1): resolve `attr.head.data` - the same dispatch shape as `fetchInitialData`
  * (handler -> `ServiceDescriptor` ? service call : plain object), returning `undefined` when the
@@ -53,29 +45,20 @@ export const fetchHeadData = async <Params extends RouteParams, R extends Servic
   const headHandler = attr?.head?.data;
   if (!headHandler || typeof headHandler !== 'function') return undefined;
 
-  const ctxForData: RequestServiceContext<L> = {
-    ...ctx,
-    headers: ctx.headers ?? {},
-  } as const;
+  const ctxForData = prepareDataContext(serviceRegistry, ctx);
 
-  ensureServiceCaller(serviceRegistry, ctxForData as ServiceContext & Partial<{ call: typeof ctxForData.call }>);
-
-  const result = await headHandler(
+  const step = await resolveDataHandler(
+    headHandler,
     params,
-    ctxForData as unknown as RequestServiceContext<L> & {
-      call: NonNullable<RequestServiceContext<L>['call']>;
-    } & { [key: string]: unknown },
+    serviceRegistry,
+    ctxForData,
+    callServiceMethodImpl,
+    'attr.head.data must return a plain object or a ServiceDescriptor',
   );
 
-  if (isServiceDescriptor(result)) {
-    const { serviceName, serviceMethod, args } = result;
-
-    return callServiceMethodImpl(serviceRegistry, serviceName, serviceMethod, args ?? {}, ctxForData);
-  }
-
-  if (isPlainObject(result)) return result;
-
-  throw AppError.badRequest('attr.head.data must return a plain object or a ServiceDescriptor');
+  // Awaited here, exactly as before: this path has no classification block for a dispatch
+  // rejection to escape, so the await placement is observably identical.
+  return step.kind === 'dispatch' ? step.dispatch() : step.value;
 };
 
 export const fetchInitialData = async <Params extends RouteParams, R extends ServiceRegistry, L extends Logs = Logs>(
@@ -88,30 +71,21 @@ export const fetchInitialData = async <Params extends RouteParams, R extends Ser
   const dataHandler = attr?.data;
   if (!dataHandler || typeof dataHandler !== 'function') return {};
 
-  const ctxForData: RequestServiceContext<L> = {
-    ...ctx,
-    headers: ctx.headers ?? {},
-  } as const;
-
-  ensureServiceCaller(serviceRegistry, ctxForData as ServiceContext & Partial<{ call: typeof ctxForData.call }>);
+  const ctxForData = prepareDataContext(serviceRegistry, ctx);
 
   try {
-    const result = await dataHandler(
+    const step = await resolveDataHandler(
+      dataHandler,
       params,
-      ctxForData as unknown as RequestServiceContext<L> & {
-        call: NonNullable<RequestServiceContext<L>['call']>;
-      } & { [key: string]: unknown },
+      serviceRegistry,
+      ctxForData,
+      callServiceMethodImpl,
+      'attr.data must return a plain object or a ServiceDescriptor',
     );
 
-    if (isServiceDescriptor(result)) {
-      const { serviceName, serviceMethod, args } = result;
-
-      return callServiceMethodImpl(serviceRegistry, serviceName, serviceMethod, args ?? {}, ctxForData);
-    }
-
-    if (isPlainObject(result)) return result;
-
-    throw AppError.badRequest('attr.data must return a plain object or a ServiceDescriptor');
+    // RETURNED, never `return await`ed: a service-call rejection escapes this classification block
+    // exactly as it always did (only a handler rejection or an invalid result is classified here).
+    return step.kind === 'dispatch' ? step.dispatch() : step.value;
   } catch (err: unknown) {
     let e = AppError.from(err);
 

--- a/packages/server/src/core/routes/DeferredData.ts
+++ b/packages/server/src/core/routes/DeferredData.ts
@@ -1,0 +1,284 @@
+import { callServiceMethod } from '../services/DataServices';
+import { now } from '../telemetry/Telemetry';
+import { snapshotInlineData } from '../../utils/InlineData';
+import { prepareDataContext, runDataHandler } from './ResolveRouteData';
+
+import type { ServiceRegistry } from '../services/DataServices';
+import type { Logs } from '../logging/types';
+import type { DataHandler, RouteAttributes, RouteParams } from '../config/types';
+import type { RequestContext } from '../telemetry/Telemetry';
+import type { TraceRecorder } from '../introspection/TraceRecorder';
+import type { CallServiceOn } from './ResolveRouteData';
+
+/**
+ * RFC 0007 (decision 14): the accepted INTERNAL host -> renderer transport. A BARE named-promise
+ * record - no scheduler, no lifecycle handle, no per-entry policy. Not a public application API.
+ */
+export type DeferredDataRegistry = Readonly<Record<string, Promise<Record<string, unknown>>>>;
+
+/**
+ * The host-internal settlement record - the only three v1 outcomes. `failed` carries NO message,
+ * stack or detail.
+ *
+ * A `complete` entry retains the SNAPSHOT BYTES taken at settlement (`json`), not the loader's
+ * object: the terminal splices that value fragment into the envelope unchanged, while the renderer
+ * consumed `JSON.parse` of the same bytes (failure semantics item 2).
+ */
+export type DeferredSettlement = { status: 'complete'; json: string } | { status: 'failed' } | { status: 'aborted' };
+
+export type DeferredSettlements = Record<string, DeferredSettlement>;
+
+/**
+ * Assemble the envelope's JSON TEXT from the settlements. Each `complete` entry's retained value
+ * fragment is spliced VERBATIM - only the enclosing key/status structure is assembled here, and no
+ * value is ever serialised a second time. The single hardened inline escape is applied once by the
+ * caller to the assembled text, exactly as for the public `__INITIAL_DATA__` snapshot.
+ *
+ * Keys are emitted sorted for deterministic bytes; `JSON.stringify(key)` quotes and escapes the key.
+ */
+export const buildDeferredEnvelopeJson = (settlements: DeferredSettlements): string => {
+  const parts: string[] = [];
+
+  for (const key of Object.keys(settlements).sort()) {
+    const settlement = settlements[key]!;
+
+    parts.push(
+      `${JSON.stringify(key)}:${settlement.status === 'complete' ? `{"status":"complete","value":${settlement.json}}` : `{"status":"${settlement.status}"}`}`,
+    );
+  }
+
+  return `{${parts.join(',')}}`;
+};
+
+export type DeferredDataController = {
+  /** Declared keys, in declaration order. */
+  readonly keys: readonly string[];
+  /**
+   * The internal host -> renderer transport (`RenderOptions.deferredData`). Frozen, so a renderer
+   * holding it after the terminal keeps a stable object; `release()` drops the HOST's reference
+   * rather than mutating the renderer's copy.
+   */
+  readonly registry: DeferredDataRegistry;
+  /**
+   * Response terminal: signal outstanding work, classify anything still pending as `aborted`
+   * (recording its trace event exactly once) and return the outcome envelope. Idempotent.
+   *
+   * AFTER `release()` the controller retains nothing, so this returns the EMPTY envelope rather
+   * than rebuilding one: the outcomes are gone and a rebuild would report every key `aborted`,
+   * contradicting the trace events already recorded.
+   */
+  settleAll: () => DeferredSettlements;
+  /** `settleAll` + drop every retained value and promise reference, for terminals emitting no envelope. */
+  release: () => void;
+};
+
+const EMPTY_REGISTRY: DeferredDataRegistry = Object.freeze({});
+const EMPTY_ENVELOPE: DeferredSettlements = Object.freeze(Object.create(null) as DeferredSettlements);
+
+const isPlainRecord = (v: unknown): v is Record<string, unknown> => !!v && typeof v === 'object' && !Array.isArray(v);
+
+/**
+ * The registry promise's rejection when the settlement snapshot fails. DETAIL-FREE by construction:
+ * the underlying serialiser error may quote application data and the renderer surfaces this to a
+ * boundary, so nothing but the fact of failure crosses.
+ */
+const snapshotFailure = (key: string): Error => new Error(`taujs: deferred entry "${key}" resolved with a value that cannot be delivered`);
+
+export type CreateDeferredDataOptions<Params extends RouteParams, R extends ServiceRegistry, L extends Logs = Logs> = {
+  attr: RouteAttributes<Params> | undefined;
+  params: Params;
+  serviceRegistry: R;
+  /** The SAME request context `attr.data` uses, read AFTER `ctx.signal` was assigned. */
+  ctx: RequestContext<L> & { signal?: AbortSignal };
+  traceId: string;
+  recorder?: TraceRecorder;
+  callServiceMethodImpl?: CallServiceOn<R>;
+};
+
+/**
+ * RFC 0007 (R2): start every declared deferred handler exactly once, eagerly and independently,
+ * with the matched params and the same request service context as `attr.data`.
+ *
+ * Returns `undefined` when the route declares no entries - the caller then behaves byte-identically
+ * to today (no registry, no envelope, no trace events, nothing in the renderer opts bag).
+ *
+ * The deliberate choices:
+ * - every entry promise is PRE-OBSERVED at creation (the R0-01 idiom) so an unconsumed rejection can
+ *   never raise `unhandledRejection`;
+ * - the entries share ONE child `AbortController` derived from the request signal (the head
+ *   resolution's shape), so caller abort AND the response terminal both signal services that honour
+ *   `ctx.signal`;
+ * - CALLER ABORT WINS over application-error classification: once the controller has aborted,
+ *   still-unsettled entries are `aborted`, never `failed`;
+ * - `ms` is measured from REGISTRY CREATION to settlement or `aborted` classification (R5).
+ */
+export const createDeferredData = <Params extends RouteParams, R extends ServiceRegistry, L extends Logs = Logs>(
+  options: CreateDeferredDataOptions<Params, R, L>,
+): DeferredDataController | undefined => {
+  const { attr, params, serviceRegistry, ctx, traceId, recorder } = options;
+  const callServiceMethodImpl = options.callServiceMethodImpl ?? (callServiceMethod as CallServiceOn<R>);
+
+  // Streaming arm only (R1). Untyped input reaching here despite the boot check is ignored rather
+  // than re-validated: `extractRoutes` owns the hard error.
+  const declared = attr?.render === 'streaming' ? (attr as { deferred?: Record<string, unknown> }).deferred : undefined;
+  if (!declared || typeof declared !== 'object') return undefined;
+
+  // OWN enumerable keys only - inherited properties are never trusted (R1 rule 1).
+  const keys = Object.keys(declared).filter((key) => typeof declared[key] === 'function');
+  if (keys.length === 0) return undefined;
+
+  const t0 = now();
+  const outcomes = new Map<string, DeferredSettlement | undefined>();
+
+  // Declared BEFORE any abort wiring: a handler that aborts the request signal synchronously would
+  // otherwise re-enter `releaseAll` while these bindings were still in their temporal dead zone.
+  let frozenRegistry: DeferredDataRegistry | undefined;
+  let envelope: DeferredSettlements | undefined;
+  let released = false;
+  let releasing = false;
+  let terminated = false;
+
+  const deferredAbort = new AbortController();
+  const requestSignal = ctx.signal;
+  // A caller abort is a response terminal: classify, signal AND drop retained state immediately.
+  const onRequestAbort = () => releaseAll();
+
+  const record = (key: string, outcome: DeferredSettlement): void => {
+    if (!outcomes.has(key) || outcomes.get(key) !== undefined) return;
+    outcomes.set(key, outcome);
+    try {
+      recorder?.deferredData({ traceId, key, ms: +(now() - t0).toFixed(1), outcome: outcome.status });
+    } catch {
+      // fire-and-forget telemetry must never affect the response (introspection invariant 2)
+    }
+  };
+
+  const terminate = (): void => {
+    if (terminated) return;
+    terminated = true;
+    try {
+      requestSignal?.removeEventListener('abort', onRequestAbort);
+    } catch {}
+    try {
+      deferredAbort.abort(new Error('taujs: deferred data released at the response terminal'));
+    } catch {}
+    for (const key of keys) record(key, { status: 'aborted' });
+  };
+
+  if (requestSignal?.aborted) {
+    // Already-dead request: the child signal is aborted BEFORE any handler runs, so a loader that
+    // honours `ctx.signal` never starts real work. Entries are still created (stable registry
+    // shape) and classified `aborted` immediately after the start loop.
+    try {
+      deferredAbort.abort(new Error('taujs: request already aborted'));
+    } catch {}
+  } else requestSignal?.addEventListener('abort', onRequestAbort, { once: true });
+
+  // Mirrors `attr.data`'s context exactly, except that `signal` is the child controller's.
+  const ctxForData = prepareDataContext(serviceRegistry, { ...ctx, signal: deferredAbort.signal } as RequestContext<L>);
+
+  // The accumulator is BLOCK-SCOPED and prototype-free, so afterwards the host's only reference to
+  // the started promises is `frozenRegistry`, which `release()` drops outright.
+  {
+    const collected: Record<string, Promise<Record<string, unknown>>> = Object.create(null);
+
+    for (const key of keys) {
+      outcomes.set(key, undefined);
+
+      // Exactly once, here, outside the component tree: the handler is invoked synchronously
+      // inside this loop iteration.
+      const source = runDataHandler(
+        declared[key] as DataHandler<Params, L>,
+        params,
+        serviceRegistry,
+        ctxForData,
+        callServiceMethodImpl,
+        `attr.deferred."${key}" must return a plain object or a ServiceDescriptor`,
+      );
+      source.catch(() => {}); // R0-01: pre-observed at creation
+
+      // ONE handler takes the ONE snapshot, records the trace outcome AND produces the renderer's
+      // value, so trace, envelope and renderer cannot disagree by construction. The registry
+      // promise is this DERIVED promise, never the loader's.
+      const entry = source.then(
+        (value): Record<string, unknown> => {
+          const snapshot = snapshotInlineData(value);
+          // Decision 16: the parsed ROOT must be a plain record. A root `toJSON` yielding a number,
+          // null or an array classifies the entry `failed` exactly as a non-serialisable value
+          // does - the registry promises a record and so does the envelope schema.
+          if (!snapshot.ok || !isPlainRecord(snapshot.value)) {
+            // Operator visibility: payload-free, key only. The trace explains the outcome; this
+            // explains why a RESOLVED loader became `failed`.
+            try {
+              ctx.logger?.warn({ key, traceId }, 'Deferred data could not cross the hydration boundary');
+            } catch {}
+            record(key, terminated ? { status: 'aborted' } : { status: 'failed' });
+
+            throw snapshotFailure(key);
+          }
+
+          record(key, terminated ? { status: 'aborted' } : { status: 'complete', json: snapshot.json });
+
+          // The parsed form of the retained bytes - plain data sharing NO identity with the
+          // loader's object (the envelope splices the very bytes it was parsed from).
+          return snapshot.value as Record<string, unknown>;
+        },
+        (err): never => {
+          // A rejection stays a rejection (failure semantics 3).
+          record(key, terminated ? { status: 'aborted' } : { status: 'failed' });
+
+          throw err;
+        },
+      );
+      entry.catch(() => {}); // R0-01: the derived promise is the one a renderer may leave unconsumed
+
+      collected[key] = entry;
+    }
+
+    // Object spread DEFINES own properties, so even a `__proto__` own key copies across as data -
+    // while the record handed to the renderer keeps the ordinary prototype its contract assumes. If
+    // a handler aborted the request WHILE the loop ran, the terminal has already passed: publishing
+    // now would resurrect a reference `release()` just dropped.
+    frozenRegistry = released ? undefined : Object.freeze({ ...collected });
+  }
+
+  // An already-aborted request settles every entry now (caller abort wins).
+  if (deferredAbort.signal.aborted) terminate();
+
+  // Hoisted declarations: an abort arriving while this scope is still being evaluated must never
+  // hit a temporal dead zone inside the abort listener.
+  function settleAll(): DeferredSettlements {
+    if (released) return EMPTY_ENVELOPE;
+
+    terminate();
+
+    if (!envelope) {
+      const built: DeferredSettlements = Object.create(null);
+      for (const key of [...keys].sort()) built[key] = outcomes.get(key) ?? { status: 'aborted' };
+      envelope = built;
+    }
+
+    return envelope;
+  }
+
+  function releaseAll(): void {
+    if (released || releasing) return;
+    releasing = true;
+    // Settle BEFORE flagging released: terminal classification and its one-per-key trace events
+    // must still fire, and `settleAll` short-circuits once `released` is set.
+    settleAll();
+    released = true;
+    envelope = undefined;
+    outcomes.clear();
+    frozenRegistry = undefined;
+  }
+
+  return {
+    keys,
+    get registry(): DeferredDataRegistry {
+      return frozenRegistry ?? EMPTY_REGISTRY;
+    },
+    settleAll,
+    release: releaseAll,
+  };
+};

--- a/packages/server/src/core/routes/ResolveRouteData.ts
+++ b/packages/server/src/core/routes/ResolveRouteData.ts
@@ -1,0 +1,96 @@
+import { ensureServiceCaller, isServiceDescriptor } from '../services/DataServices';
+import { AppError } from '../errors/AppError';
+
+import type { ServiceContext, ServiceRegistry } from '../services/DataServices';
+import type { Logs } from '../logging/types';
+import type { DataHandler, RouteParams, RequestServiceContext } from '../config/types';
+import type { RequestContext } from '../telemetry/Telemetry';
+
+/**
+ * RFC 0007: the dispatch core shared by the body (`fetchInitialData`), head (`fetchHeadData`) and
+ * deferred (`createDeferredData`) paths.
+ *
+ * The extraction is DELIBERATELY narrow. `fetchInitialData` owns error classification + logging and
+ * `fetchHeadData` deliberately owns none (its caller owns the head taxonomy), so only the steps both
+ * already performed identically move here:
+ *
+ *   1. `prepareDataContext` - build the request service context and install the registry caller.
+ *      This ran OUTSIDE `fetchInitialData`'s try/catch and must keep running outside it: an
+ *      `ensureServiceCaller` throw was never classified/logged and must stay unclassified.
+ *   2. `resolveDataHandler` - handler -> `ServiceDescriptor` ? service call : plain-object
+ *      validation, throwing `AppError.badRequest(<caller-supplied message>)` on an invalid result.
+ *
+ * `resolveDataHandler` returns the service dispatch as an UNINVOKED thunk rather than awaiting it,
+ * because `fetchInitialData` deliberately `return`ed (never `return await`ed) the dispatch promise
+ * from inside its try/catch: a service-call rejection therefore ESCAPED its classification/logging
+ * block, while a handler rejection or an invalid-result throw did not. Awaiting inside the shared
+ * helper would silently start classifying service-call failures under
+ * `component: 'fetch-initial-data'`. The thunk keeps that split exactly where it was, so both
+ * existing call sites keep byte-identical observable behaviour.
+ */
+export type CallServiceOn<R extends ServiceRegistry> = (
+  registry: R,
+  serviceName: string,
+  methodName: string,
+  params: Record<string, unknown>,
+  ctx: ServiceContext,
+) => Promise<Record<string, unknown>>;
+
+export const isPlainObject = (v: unknown): v is Record<string, unknown> => !!v && typeof v === 'object' && Object.getPrototypeOf(v) === Object.prototype;
+
+export const prepareDataContext = <R extends ServiceRegistry, L extends Logs = Logs>(serviceRegistry: R, ctx: RequestContext<L>): RequestServiceContext<L> => {
+  const ctxForData: RequestServiceContext<L> = {
+    ...ctx,
+    headers: ctx.headers ?? {},
+  } as const;
+
+  ensureServiceCaller(serviceRegistry, ctxForData as ServiceContext & Partial<{ call: typeof ctxForData.call }>);
+
+  return ctxForData;
+};
+
+export type ResolvedDataStep = { kind: 'value'; value: Record<string, unknown> } | { kind: 'dispatch'; dispatch: () => Promise<Record<string, unknown>> };
+
+export const resolveDataHandler = async <Params extends RouteParams, R extends ServiceRegistry, L extends Logs = Logs>(
+  handler: DataHandler<Params, L>,
+  params: Params,
+  serviceRegistry: R,
+  ctxForData: RequestServiceContext<L>,
+  callServiceMethodImpl: CallServiceOn<R>,
+  invalidResultMessage: string,
+): Promise<ResolvedDataStep> => {
+  const result = await handler(
+    params,
+    ctxForData as unknown as RequestServiceContext<L> & {
+      call: NonNullable<RequestServiceContext<L>['call']>;
+    } & { [key: string]: unknown },
+  );
+
+  if (isServiceDescriptor(result)) {
+    const { serviceName, serviceMethod, args } = result;
+
+    return { kind: 'dispatch', dispatch: () => callServiceMethodImpl(serviceRegistry, serviceName, serviceMethod, args ?? {}, ctxForData) };
+  }
+
+  if (isPlainObject(result)) return { kind: 'value', value: result };
+
+  throw AppError.badRequest(invalidResultMessage);
+};
+
+/**
+ * Await-everything convenience over {@link resolveDataHandler}, for callers with no
+ * classification-boundary subtlety to preserve: RFC 0007's deferred registry settles its entry the
+ * same way whichever step failed.
+ */
+export const runDataHandler = async <Params extends RouteParams, R extends ServiceRegistry, L extends Logs = Logs>(
+  handler: DataHandler<Params, L>,
+  params: Params,
+  serviceRegistry: R,
+  ctxForData: RequestServiceContext<L>,
+  callServiceMethodImpl: CallServiceOn<R>,
+  invalidResultMessage: string,
+): Promise<Record<string, unknown>> => {
+  const step = await resolveDataHandler(handler, params, serviceRegistry, ctxForData, callServiceMethodImpl, invalidResultMessage);
+
+  return step.kind === 'dispatch' ? step.dispatch() : step.value;
+};

--- a/packages/server/src/core/routes/test/DeferredData.test.ts
+++ b/packages/server/src/core/routes/test/DeferredData.test.ts
@@ -1,0 +1,247 @@
+// @vitest-environment node
+// RFC 0007 (R2 + failure semantics): the request-local registry.
+import { describe, it, expect, vi } from 'vitest';
+
+import { buildDeferredEnvelopeJson, createDeferredData } from '../DeferredData';
+
+import type { TraceRecorder } from '../../introspection/TraceRecorder';
+
+const mkLogger = (): any => {
+  const l: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), isDebugEnabled: () => false };
+  l.child = () => l;
+  return l;
+};
+
+type Event = { key: string; outcome: string };
+
+const mkRecorder = (events: Event[]): TraceRecorder =>
+  ({
+    deferredData: (e: any) => events.push({ key: e.key, outcome: e.outcome }),
+  }) as unknown as TraceRecorder;
+
+const mk = (deferred: Record<string, unknown>, opts: { signal?: AbortSignal; events?: Event[]; logger?: any } = {}) => {
+  const logger = opts.logger ?? mkLogger();
+  const controller = createDeferredData({
+    attr: { render: 'streaming', meta: {}, deferred } as any,
+    params: { id: '42' },
+    serviceRegistry: {} as any,
+    ctx: { traceId: 't1', logger, headers: {}, signal: opts.signal },
+    traceId: 't1',
+    ...(opts.events ? { recorder: mkRecorder(opts.events) } : {}),
+  });
+
+  return { controller, logger };
+};
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe('createDeferredData - declaration and start (R2)', () => {
+  it('returns undefined for a route declaring nothing (byte-identical no-deferred path)', () => {
+    expect(
+      createDeferredData({
+        attr: { render: 'streaming', meta: {} } as any,
+        params: {},
+        serviceRegistry: {} as any,
+        ctx: { traceId: 't', logger: mkLogger() },
+        traceId: 't',
+      }),
+    ).toBeUndefined();
+    expect(
+      createDeferredData({ attr: { render: 'ssr' } as any, params: {}, serviceRegistry: {} as any, ctx: { traceId: 't', logger: mkLogger() }, traceId: 't' }),
+    ).toBeUndefined();
+    expect(mk({}).controller).toBeUndefined();
+  });
+
+  it('invokes each handler EXACTLY ONCE, synchronously, with the matched params', () => {
+    const calls: unknown[] = [];
+    const handler = vi.fn(async (params: unknown) => {
+      calls.push(params);
+      return { ok: true };
+    });
+    const { controller } = mk({ reviews: handler });
+
+    expect(handler).toHaveBeenCalledTimes(1); // synchronous at creation - before any component runs
+    expect(calls[0]).toEqual({ id: '42' });
+    expect(controller!.keys).toEqual(['reviews']);
+    expect(Object.keys(controller!.registry)).toEqual(['reviews']);
+  });
+
+  it('a resolved entry delivers the PARSED SNAPSHOT, not the loader object (failure semantics 2)', async () => {
+    const source = { count: 3, nested: { a: 1 }, dropped: () => {}, gone: undefined };
+    const { controller } = mk({ reviews: async () => source });
+
+    const delivered = await controller!.registry['reviews']!;
+    expect(delivered).toEqual({ count: 3, nested: { a: 1 } });
+    expect(delivered).not.toBe(source);
+    expect(delivered['nested']).not.toBe(source.nested);
+
+    // Post-settlement mutation of the loader's object reaches NEITHER surface.
+    source.count = 999;
+    (source.nested as { a: number }).a = 999;
+    expect(delivered).toEqual({ count: 3, nested: { a: 1 } });
+    expect(buildDeferredEnvelopeJson(controller!.settleAll())).toBe('{"reviews":{"status":"complete","value":{"count":3,"nested":{"a":1}}}}');
+  });
+
+  it('takes EXACTLY ONE snapshot attempt, whatever the application toJSON does', async () => {
+    let calls = 0;
+    const unstable = {
+      toJSON() {
+        calls += 1;
+        return { call: calls };
+      },
+    };
+    const { controller } = mk({ reviews: async () => unstable });
+
+    const delivered = await controller!.registry['reviews']!;
+    expect(delivered).toEqual({ call: 1 });
+    expect(buildDeferredEnvelopeJson(controller!.settleAll())).toContain('{"call":1}');
+    expect(calls).toBe(1);
+  });
+
+  it('a non-serialisable resolution is detail-free `failed` on EVERY surface, with one payload-free warn', async () => {
+    const circular: Record<string, unknown> = { secret: 'PLAYGROUND_SECRET' };
+    circular['self'] = circular;
+    const events: Event[] = [];
+    const { controller, logger } = mk({ reviews: async () => circular }, { events });
+
+    await expect(controller!.registry['reviews']).rejects.toThrow(/deferred entry "reviews" resolved with a value that cannot be delivered/);
+    const err = await controller!.registry['reviews']!.catch((e) => e);
+    expect(String(err.message)).not.toContain('PLAYGROUND_SECRET');
+    expect(String(err.message)).not.toContain('circular');
+    expect((err as { cause?: unknown }).cause).toBeUndefined();
+
+    expect(events).toEqual([{ key: 'reviews', outcome: 'failed' }]);
+    expect(buildDeferredEnvelopeJson(controller!.settleAll())).toBe('{"reviews":{"status":"failed"}}');
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const [meta, message] = logger.warn.mock.calls[0];
+    expect(message).toBe('Deferred data could not cross the hydration boundary');
+    expect(meta).toEqual({ key: 'reviews', traceId: 't1' });
+    expect(JSON.stringify(meta)).not.toContain('PLAYGROUND_SECRET');
+  });
+
+  it('decision 16: a non-record snapshot ROOT is `failed`, not a false record', async () => {
+    const events: Event[] = [];
+    const { controller } = mk({ reviews: async () => ({ toJSON: () => 5 }), listy: async () => ({ toJSON: () => [1, 2] }) }, { events });
+
+    await expect(controller!.registry['reviews']).rejects.toThrow();
+    await expect(controller!.registry['listy']).rejects.toThrow();
+    expect(buildDeferredEnvelopeJson(controller!.settleAll())).toBe('{"listy":{"status":"failed"},"reviews":{"status":"failed"}}');
+    expect(events.map((e) => e.outcome).sort()).toEqual(['failed', 'failed']);
+  });
+
+  it('a rejection stays a rejection, recorded once against its key (failure semantics 3)', async () => {
+    const events: Event[] = [];
+    const boom = new Error('service exploded');
+    const { controller } = mk({ reviews: async () => Promise.reject(boom) }, { events });
+
+    await expect(controller!.registry['reviews']).rejects.toBe(boom);
+    expect(events).toEqual([{ key: 'reviews', outcome: 'failed' }]);
+    controller!.settleAll();
+    controller!.settleAll();
+    expect(events).toEqual([{ key: 'reviews', outcome: 'failed' }]);
+  });
+
+  it('rejects a handler returning a non-plain-object through the shared resolver message', async () => {
+    const { controller } = mk({ reviews: async () => 42 as unknown as Record<string, unknown> });
+
+    await expect(controller!.registry['reviews']).rejects.toThrow(/attr\.deferred\."reviews" must return a plain object or a ServiceDescriptor/);
+  });
+});
+
+describe('createDeferredData - terminals (R2 item 8, failure semantics 7/8)', () => {
+  it('an entry pending at the terminal is `aborted`, recorded once', async () => {
+    const events: Event[] = [];
+    const { controller } = mk({ reviews: () => new Promise<Record<string, unknown>>(() => {}) }, { events });
+
+    expect(buildDeferredEnvelopeJson(controller!.settleAll())).toBe('{"reviews":{"status":"aborted"}}');
+    expect(events).toEqual([{ key: 'reviews', outcome: 'aborted' }]);
+  });
+
+  it('signals outstanding work through a child signal derived from the request signal', async () => {
+    let seen: AbortSignal | undefined;
+    const { controller } = mk({
+      reviews: async (_p: unknown, ctx: any) => {
+        seen = ctx.signal;
+        return new Promise<Record<string, unknown>>(() => {});
+      },
+    });
+
+    await flush();
+    expect(seen!.aborted).toBe(false);
+    controller!.settleAll();
+    expect(seen!.aborted).toBe(true);
+  });
+
+  it('caller abort WINS over application-error classification (failure semantics 7)', async () => {
+    const events: Event[] = [];
+    const ac = new AbortController();
+    let rejectEntry!: (e: unknown) => void;
+    const { controller } = mk({ reviews: () => new Promise<Record<string, unknown>>((_r, reject) => (rejectEntry = reject)) }, { signal: ac.signal, events });
+
+    ac.abort();
+    rejectEntry(new Error('late failure'));
+    await flush();
+
+    expect(events).toEqual([{ key: 'reviews', outcome: 'aborted' }]);
+    // The registry reference is dropped: τjs retains no response-owned state.
+    expect(Object.keys(controller!.registry)).toEqual([]);
+    expect(buildDeferredEnvelopeJson(controller!.settleAll())).toBe('{}');
+  });
+
+  it('an ALREADY-aborted request still starts each handler once, with an aborted signal, then classifies `aborted`', async () => {
+    const events: Event[] = [];
+    const ac = new AbortController();
+    ac.abort();
+    const handler = vi.fn(async (_p: unknown, ctx: any) => ({ aborted: ctx.signal.aborted }));
+    const { controller } = mk({ reviews: handler }, { signal: ac.signal, events });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(events).toEqual([{ key: 'reviews', outcome: 'aborted' }]);
+    expect(controller!.keys).toEqual(['reviews']);
+    await flush();
+  });
+
+  it('release drops every retained reference and post-release settleAll fabricates nothing', async () => {
+    const events: Event[] = [];
+    const { controller } = mk({ reviews: async () => ({ count: 1 }) }, { events });
+
+    await controller!.registry['reviews'];
+    controller!.release();
+
+    expect(Object.keys(controller!.registry)).toEqual([]);
+    expect(buildDeferredEnvelopeJson(controller!.settleAll())).toBe('{}');
+    expect(events).toEqual([{ key: 'reviews', outcome: 'complete' }]);
+  });
+
+  it('an unconsumed rejection never raises unhandledRejection (R0-01)', async () => {
+    const seen: unknown[] = [];
+    const onUnhandled = (e: unknown) => seen.push(e);
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      const { controller } = mk({ reviews: async () => Promise.reject(new Error('nobody reads me')) });
+      void controller;
+      await flush();
+      await flush();
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+    expect(seen).toEqual([]);
+  });
+});
+
+describe('buildDeferredEnvelopeJson', () => {
+  it('emits key-sorted, detail-free entries and splices the retained fragment verbatim', () => {
+    expect(
+      buildDeferredEnvelopeJson({
+        stock: { status: 'aborted' },
+        reviews: { status: 'complete', json: '{"count":3}' },
+        blurb: { status: 'failed' },
+      }),
+    ).toBe('{"blurb":{"status":"failed"},"reviews":{"status":"complete","value":{"count":3}},"stock":{"status":"aborted"}}');
+  });
+
+  it('quotes and escapes keys', () => {
+    expect(buildDeferredEnvelopeJson({ 'a"b': { status: 'aborted' } })).toBe('{"a\\"b":{"status":"aborted"}}');
+  });
+});

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -3,6 +3,7 @@ import type { Writable } from 'node:stream';
 import type { FastifyInstance, FastifyPluginAsync, FastifyPluginCallback } from 'fastify';
 
 import type { CoreTaujsConfig, Route, RouteParams } from './core/config/types';
+import type { DeferredDataRegistry } from './core/routes/DeferredData';
 import type { DebugConfig, Logs } from './core/logging/types';
 import type { ServiceRegistry } from './core/services/DataServices';
 
@@ -144,6 +145,17 @@ export type RenderOptions = {
   headData?: Record<string, unknown>;
   cspNonce?: string;
   shouldHydrate?: boolean;
+  /**
+   * RFC 0007 (decision 14): the request-local registry of declared `attr.deferred` entries -
+   * present ONLY when a streaming route declares them, and conditionally spread exactly like
+   * `headData`. This is the accepted INTERNAL host-to-renderer transport, NOT a public application
+   * API: every promise is already started and already pre-observed by the host, a resolved entry
+   * is the host's settlement snapshot (parsed JSON, no identity relationship to the loader's
+   * object), and a value that could not be snapshotted arrives as a detail-free rejection. The
+   * renderer projects each named promise onto its native Suspense/resource primitive and starts
+   * nothing.
+   */
+  deferredData?: DeferredDataRegistry;
 };
 
 export type RenderSSR = (

--- a/packages/server/src/utils/HandleRender.ts
+++ b/packages/server/src/utils/HandleRender.ts
@@ -4,6 +4,7 @@ import { PassThrough } from 'node:stream';
 import { RENDERTYPE } from '../core/constants';
 import { AppError, normaliseError, toReason } from '../core/errors/AppError';
 import { fetchHeadData, fetchInitialData } from '../core/routes/DataRoutes';
+import { buildDeferredEnvelopeJson, createDeferredData } from '../core/routes/DeferredData';
 import { now } from '../core/telemetry/Telemetry';
 import { resolveEntryFile } from '../Build';
 import { createLogger } from '../logging/Logger';
@@ -21,7 +22,7 @@ import {
   stripDevClientAndStyles,
   applyViteTransform,
 } from './Templates';
-import { serializeInlineData } from './InlineData';
+import { inlineJsFromJson, serializeInlineData } from './InlineData';
 import { assertRenderContract, declaredContractOf, requireRendererContribution } from './RendererContract';
 
 import type { FastifyRequest, FastifyReply } from 'fastify';
@@ -29,7 +30,15 @@ import type { ViteDevServer } from 'vite';
 import type { DebugConfig, Logs } from '../core/logging/types';
 import type { SelectedPageRoute } from '../core/routes/FastifyRoutes';
 import type { ServiceRegistry } from '../core/services/DataServices';
+import type { DeferredDataController } from '../core/routes/DeferredData';
 import type { Manifest, ProcessedConfig, RenderModule, SSRManifest } from '../types';
+
+/**
+ * RFC 0007 (R4, decision 15): the PRIVATE deferred-outcome envelope carrier. Undocumented and
+ * unsupported for applications - assigned inside the SAME nonced end-of-stream script as the public
+ * snapshot, only under the host-resolved hydration policy.
+ */
+const DEFERRED_STATE_CARRIER = '__TAUJS_DEFERRED_STATE__';
 
 // R0-02: origin-aware benign classification, textually parallel to `isBenignStreamErr` in
 // packages/react/src/utils/Streaming.ts (the server does not import renderer utils). A
@@ -130,6 +139,13 @@ export const handleRender = async (
   const requestContext = getRequestContext(req) ?? createRequestContext(req, reply, baseLogger);
   const { traceId, logger, headers, recorder } = requestContext;
   const reqLogger = logger;
+
+  // RFC 0007 (R2 item 8): FUNCTION-SCOPED, not block-scoped inside the streaming branch. A
+  // synchronous throw out of `renderStream` - or anything else escaping that branch into the outer
+  // catch - is a response terminal that reaches it with entries already started; without this
+  // binding nothing would classify them, no R5 trace event would fire and their child abort signal
+  // would outlive the response.
+  let deferred: DeferredDataController | undefined;
 
   try {
     const url = req.url ? new URL(req.url, `http://${req.headers.host}`).pathname : '/';
@@ -493,6 +509,13 @@ export const handleRender = async (
 
       ctx.signal = ac.signal; // R1-01: propagate into the data context before renderStream fetches it
 
+      // RFC 0007 (R2, decision 2): the declared deferred entries start HERE - immediately after
+      // `ctx.signal` is assigned and BEFORE head resolution, the earliest point at which the
+      // request context is complete. Each handler is invoked exactly once, eagerly, outside the
+      // component tree, with the matched params and the same request service context `attr.data`
+      // uses. The host never awaits an entry and never inspects one mid-stream.
+      deferred = createDeferredData({ attr, params, serviceRegistry, ctx, traceId, recorder });
+
       const writable = new PassThrough();
       writable.on('error', (err) => {
         if (!isBenignSocketError(err)) logger.error({ error: err }, 'PassThrough error:');
@@ -519,6 +542,12 @@ export const handleRender = async (
         // Telemetry is BELTED INDEPENDENTLY of the teardown (gate-review finding 1, same rule as
         // the fatal-stream path): a throwing host logger/recorder must never skip the raw-socket
         // settlement - the outer catch rethrows into Fastify, which no longer owns this response.
+        // RFC 0007 (failure semantics 6): a critical head failure is a response terminal, and
+        // outstanding deferred work is classified and detached on it - BEFORE any telemetry, so a
+        // throwing logger/recorder cannot strand the registry.
+        try {
+          deferred?.release();
+        } catch {}
         try {
           logger.error({ error: safeNormaliseError(err), url: req.url }, 'Head data failed; terminating streaming request');
           recorder?.failed({ traceId, error: { kind: safeErrorKind(err), message: safeErrorMessage(err) } });
@@ -534,6 +563,9 @@ export const handleRender = async (
         return;
       }
       if (headResolution.aborted) {
+        try {
+          deferred?.release();
+        } catch {}
         try {
           if (!reply.raw.writableEnded && !reply.raw.destroyed) reply.raw.destroy();
         } catch {}
@@ -590,6 +622,11 @@ export const handleRender = async (
             reqLogger.warn({ error: safeNormaliseError(info.error), phase: info.phase, recoverable: info.recoverable, clientRoot, url: req.url }, message);
           },
           onError: (err: unknown) => {
+            // RFC 0007 (R2 item 8): the fatal renderer terminal releases the registry FIRST, before
+            // any telemetry or teardown, on both arms below.
+            try {
+              deferred?.release();
+            } catch {}
             // Gate finding 1: `onError` is the renderer's FATAL channel — the renderer already
             // established origin (benign socket disconnects are handled by the writable guards via
             // `benignAbort`, never routed here). Trust it: the only benign condition is ACTUAL
@@ -660,6 +697,10 @@ export const handleRender = async (
           ...(headResolution.headData !== undefined ? { headData: headResolution.headData } : {}),
           ...(cspNonce ? { cspNonce } : {}),
           shouldHydrate,
+          // RFC 0007 (decision 14): conditionally spread exactly like `headData` - a route
+          // declaring no deferred entries has no `deferredData` property at all, so its opts bag
+          // and its rendered bytes are unchanged.
+          ...(deferred ? { deferredData: deferred.registry } : {}),
         },
       );
 
@@ -682,6 +723,9 @@ export const handleRender = async (
 
           if (!serialized.ok) {
             abortedState.aborted = true;
+            try {
+              deferred?.release();
+            } catch {}
             logger.error({ error: safeNormaliseError(serialized.error), clientRoot, url: req.url }, 'Failed to serialize streaming initial data');
             recorder?.failed({ traceId, error: { kind: 'serialize', message: String(serialized.error.message) } });
 
@@ -704,9 +748,24 @@ export const handleRender = async (
             return;
           }
 
+          // RFC 0007 (R4): this write site IS the response terminal for deferred work. Classify
+          // everything (anything still pending is `aborted`), then release - the envelope text is
+          // already assembled from the retained settlement bytes, so nothing is serialised here.
+          //
+          // Decision 8: the carrier is emitted ONLY under the host-resolved hydration policy. Under
+          // `hydrate: false` there is no client runtime to seed, so the rest of this script is
+          // byte-for-byte what it has always been while the registry is still settled, classified
+          // and released - R5 outcomes are unaffected either way.
+          let deferredAssignment = '';
+          if (deferred) {
+            const settlements = deferred.settleAll();
+            if (shouldHydrate) deferredAssignment = ` window.${DEFERRED_STATE_CARRIER} = ${inlineJsFromJson(buildDeferredEnvelopeJson(settlements))};`;
+            deferred.release();
+          }
+
           const initialDataScript = `<script${
             cspNonce ? ` nonce="${cspNonce}"` : ''
-          }>window.__INITIAL_DATA__ = ${serialized.js}; window.dispatchEvent(new Event('taujs:data-ready'));</script>`;
+          }>window.__INITIAL_DATA__ = ${serialized.js};${deferredAssignment} window.dispatchEvent(new Event('taujs:data-ready'));</script>`;
 
           commitHead();
           reply.raw.write(initialDataScript);
@@ -715,6 +774,9 @@ export const handleRender = async (
           recorder?.sent({ traceId, status: 200, mode: 'streaming' });
         } catch (e) {
           // Belt: never let this listener throw — an uncaughtException here would exit the process.
+          try {
+            deferred?.release();
+          } catch {}
           logger.error({ error: safeNormaliseError(e), clientRoot, url: req.url }, 'Streaming finish listener failed');
           try {
             if (!reply.raw.writableEnded && !reply.raw.destroyed) reply.raw.destroy();
@@ -723,6 +785,12 @@ export const handleRender = async (
       });
     }
   } catch (err) {
+    // RFC 0007: release FIRST, before any telemetry - a throwing recorder or logger must never
+    // strand a started registry (this is the terminal a synchronous `renderStream` throw reaches).
+    try {
+      deferred?.release();
+    } catch {}
+
     recorder?.failed({
       traceId,
       error: { kind: AppError.isAppError(err) ? (err as any).kind : 'internal', message: String((err as any)?.message ?? err ?? '') },

--- a/packages/server/src/utils/HandleRender.ts
+++ b/packages/server/src/utils/HandleRender.ts
@@ -716,7 +716,16 @@ export const handleRender = async (
         // uncaught throw here becomes an `uncaughtException` → process exit. `serializeInlineData`
         // never throws; the outer try/catch is a belt so nothing else in the listener can either.
         try {
-          if (abortedState.aborted || reply.raw.writableEnded) return;
+          // RFC 0007 (R4): this early return IS a response terminal - the bytes are already gone,
+          // so no envelope can be emitted, but outstanding deferred work must still be signalled
+          // and classified `aborted` here. Releasing is idempotent, so the paths that already
+          // released (the fatal channel, the head terminals) are unaffected.
+          if (abortedState.aborted || reply.raw.writableEnded) {
+            try {
+              deferred?.release();
+            } catch {}
+            return;
+          }
 
           const data = finalData ?? {};
           const serialized = serializeInlineData(data);

--- a/packages/server/src/utils/InlineData.ts
+++ b/packages/server/src/utils/InlineData.ts
@@ -81,7 +81,7 @@ const PROTO_KEY_MARKER = '"__proto__"';
  * with `JSON.parse`, `eval` or `new Function`.
  */
 export const inlineJsFromJson = (json: string): string =>
-  // ESC-3: a `__proto__` KEY at any depth (or the exact string value `"__proto__"`) — emit via
+  // ESC-3: a `__proto__` KEY at any depth (or the exact string value `"__proto__"`) - emit via
   // `JSON.parse` so it round-trips as an own data property instead of setting the created
   // object's prototype.
   json.includes(PROTO_KEY_MARKER) ? `JSON.parse(${JSON.stringify(json).replace(/</g, '\\u003c')})` : json.replace(/</g, '\\u003c');
@@ -102,20 +102,20 @@ export const serializeInlineData = (value: unknown): SerializedInlineData => {
 };
 
 /**
- * RFC 0007 (failure semantics item 2) — the STABLE SNAPSHOT taken when a deferred loader settles.
+ * RFC 0007 (failure semantics item 2) - the STABLE SNAPSHOT taken when a deferred loader settles.
  *
  * EXACTLY ONE serialisation attempt is made here, and everything downstream is derived from its
  * bytes:
- *   - `json` — the retained bytes. The end-of-stream envelope splices this VALUE FRAGMENT verbatim
+ *   - `json` - the retained bytes. The end-of-stream envelope splices this VALUE FRAGMENT verbatim
  *     (the enclosing key/status structure is assembled at the terminal, then the whole assembled
  *     text goes through `inlineJsFromJson` once, exactly like the public snapshot).
- *   - `value` — `JSON.parse` of those same bytes, so the renderer consumes a fresh graph sharing no
+ *   - `value` - `JSON.parse` of those same bytes, so the renderer consumes a fresh graph sharing no
  *     identity with the loader's object. Server render, trace and hydration therefore cannot
  *     disagree: members JSON drops are absent from BOTH surfaces, a later mutation of the loader's
  *     object affects NEITHER, and an unstable `toJSON`/getter is invoked by this one attempt only.
  *
  * A failure is a DELIVERY failure for that key: detail-free `failed` on every surface. The error is
- * for host-side logging only — `JSON.stringify` names the offending property in its
+ * for host-side logging only - `JSON.stringify` names the offending property in its
  * circular-reference message, so it must never cross to the client.
  */
 export type InlineSnapshot = { ok: true; json: string; value: unknown } | { ok: false; error: Error };
@@ -127,7 +127,7 @@ export const snapshotInlineData = (value: unknown): InlineSnapshot => {
       return { ok: false, error: new Error('Value is not JSON-serializable (JSON.stringify returned undefined)') };
     }
 
-    // Parsing the bytes τjs itself just produced — never caller text, never `eval`/`new Function`.
+    // Parsing the bytes τjs itself just produced - never caller text, never `eval`/`new Function`.
     return { ok: true, json, value: JSON.parse(json) };
   } catch (err) {
     return { ok: false, error: toError(err) };

--- a/packages/server/src/utils/InlineData.ts
+++ b/packages/server/src/utils/InlineData.ts
@@ -70,6 +70,22 @@ const toError = (err: unknown): Error => {
  */
 const PROTO_KEY_MARKER = '"__proto__"';
 
+/**
+ * The representational half of the boundary: JSON TEXT -> the EXECUTABLE JAVASCRIPT expression that
+ * evaluates to the same value inside an inline script. Byte-identical to what `serializeInlineData`
+ * always emitted (it now calls this); the split exists so a caller holding ALREADY-SERIALISED bytes
+ * (RFC 0007's stable settlement snapshot) can derive the safe inline form from THOSE bytes instead
+ * of serialising a second time.
+ *
+ * The result is JAVASCRIPT SOURCE, not JSON: it must be written into a script, and NEVER parsed back
+ * with `JSON.parse`, `eval` or `new Function`.
+ */
+export const inlineJsFromJson = (json: string): string =>
+  // ESC-3: a `__proto__` KEY at any depth (or the exact string value `"__proto__"`) — emit via
+  // `JSON.parse` so it round-trips as an own data property instead of setting the created
+  // object's prototype.
+  json.includes(PROTO_KEY_MARKER) ? `JSON.parse(${JSON.stringify(json).replace(/</g, '\\u003c')})` : json.replace(/</g, '\\u003c');
+
 export const serializeInlineData = (value: unknown): SerializedInlineData => {
   try {
     const json = JSON.stringify(value);
@@ -79,14 +95,40 @@ export const serializeInlineData = (value: unknown): SerializedInlineData => {
       return { ok: false, error: new Error('Value is not JSON-serializable (JSON.stringify returned undefined)') };
     }
 
-    // ESC-3: a `__proto__` KEY at any depth (or the exact string value `"__proto__"`) — emit via
-    // `JSON.parse` so it round-trips as an own data property instead of setting the created
-    // object's prototype.
-    if (json.includes(PROTO_KEY_MARKER)) {
-      return { ok: true, js: `JSON.parse(${JSON.stringify(json).replace(/</g, '\\u003c')})` };
+    return { ok: true, js: inlineJsFromJson(json) };
+  } catch (err) {
+    return { ok: false, error: toError(err) };
+  }
+};
+
+/**
+ * RFC 0007 (failure semantics item 2) — the STABLE SNAPSHOT taken when a deferred loader settles.
+ *
+ * EXACTLY ONE serialisation attempt is made here, and everything downstream is derived from its
+ * bytes:
+ *   - `json` — the retained bytes. The end-of-stream envelope splices this VALUE FRAGMENT verbatim
+ *     (the enclosing key/status structure is assembled at the terminal, then the whole assembled
+ *     text goes through `inlineJsFromJson` once, exactly like the public snapshot).
+ *   - `value` — `JSON.parse` of those same bytes, so the renderer consumes a fresh graph sharing no
+ *     identity with the loader's object. Server render, trace and hydration therefore cannot
+ *     disagree: members JSON drops are absent from BOTH surfaces, a later mutation of the loader's
+ *     object affects NEITHER, and an unstable `toJSON`/getter is invoked by this one attempt only.
+ *
+ * A failure is a DELIVERY failure for that key: detail-free `failed` on every surface. The error is
+ * for host-side logging only — `JSON.stringify` names the offending property in its
+ * circular-reference message, so it must never cross to the client.
+ */
+export type InlineSnapshot = { ok: true; json: string; value: unknown } | { ok: false; error: Error };
+
+export const snapshotInlineData = (value: unknown): InlineSnapshot => {
+  try {
+    const json = JSON.stringify(value);
+    if (json === undefined) {
+      return { ok: false, error: new Error('Value is not JSON-serializable (JSON.stringify returned undefined)') };
     }
 
-    return { ok: true, js: json.replace(/</g, '\\u003c') };
+    // Parsing the bytes τjs itself just produced — never caller text, never `eval`/`new Function`.
+    return { ok: true, json, value: JSON.parse(json) };
   } catch (err) {
     return { ok: false, error: toError(err) };
   }

--- a/packages/server/src/utils/test/HandleRenderDeferred.test.ts
+++ b/packages/server/src/utils/test/HandleRenderDeferred.test.ts
@@ -1,0 +1,365 @@
+// @vitest-environment node
+// RFC 0007: the host wiring - start point, transport, envelope write site and every terminal,
+// exercised through the REAL `handleRender` path.
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+
+import { describe, it, expect, vi } from 'vitest';
+
+import { handleRender } from '../HandleRender';
+
+import type { TraceRecorder } from '../../core/introspection/TraceRecorder';
+
+const T = 'trace-deferred-1';
+
+const mkLogger = (): any => {
+  const l: any = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), isDebugEnabled: () => false };
+  l.child = () => l;
+  return l;
+};
+
+const mkReq = (url: string, recorder?: TraceRecorder, logger?: any): any => {
+  const raw = new EventEmitter() as any;
+  raw.url = url;
+  return { url, method: 'GET', headers: { host: 'localhost' }, raw, taujsRequestContext: { traceId: T, logger: logger ?? mkLogger(), headers: {}, recorder } };
+};
+
+const mkReply = () => {
+  const chunks: string[] = [];
+  const raw = new PassThrough() as any;
+  raw.writeHead = vi.fn(() => {
+    raw.headersSent = true;
+  });
+  raw.headersSent = false;
+  const write = raw.write.bind(raw);
+  raw.write = (chunk: any, ...rest: any[]) => {
+    chunks.push(String(chunk));
+    return write(chunk, ...rest);
+  };
+  const reply: any = {
+    raw,
+    chunks,
+    header: vi.fn(() => reply),
+    status: vi.fn(() => reply),
+    getHeaders: vi.fn(() => ({})),
+    getHeader: vi.fn(() => undefined),
+    hijack: vi.fn(),
+    send: vi.fn(() => reply),
+  };
+  return reply;
+};
+
+const maps = (renderModule: any): any => ({
+  bootstrapModules: new Map([['/root', '/bootstrap.js']]),
+  cssLinks: new Map(),
+  manifests: new Map(),
+  preloadLinks: new Map(),
+  renderModules: new Map([['/root', renderModule]]),
+  ssrManifests: new Map(),
+  templates: new Map([['/root', '<html><head><!--ssr-head--></head><body><main><!--ssr-html--></main></body></html>']]),
+});
+
+const configs = [{ appId: 'storefront', clientRoot: '/root', entryServer: 'entry-server' }] as any;
+
+const route = (attr: Record<string, unknown>) => ({ route: { path: '/product/:id', appId: 'storefront', attr }, params: { id: '42' } });
+
+type Captured = { opts?: any; callbacks?: any };
+
+/** A renderer that commits the head, optionally reads entries, then finishes the stream. */
+const mkRenderer = (captured: Captured, read?: (registry: any) => Promise<unknown>) => ({
+  renderStream: vi.fn((writable: PassThrough, cb: any, initialDataInput: any, _loc: string, _boot: any, _meta: any, _signal: any, opts: any) => {
+    captured.opts = opts;
+    captured.callbacks = cb;
+    const done = (async () => {
+      cb.onHead('<title>p</title>');
+      cb.onShellReady();
+      const consumed = read ? await read(opts?.deferredData).catch(() => undefined) : undefined;
+      writable.write(`<div>app${consumed ? JSON.stringify(consumed) : ''}</div>`);
+      const data = await (typeof initialDataInput === 'function' ? initialDataInput() : initialDataInput);
+      cb.onAllReady(data);
+      writable.end();
+    })();
+    return { abort: () => {}, done };
+  }),
+});
+
+const run = async (attr: Record<string, unknown>, renderModule: any, opts: { recorder?: TraceRecorder; logger?: any } = {}) => {
+  const logger = opts.logger ?? mkLogger();
+  const req = mkReq('/product/42', opts.recorder, logger);
+  const reply = mkReply();
+  await handleRender(req, reply, route(attr) as any, configs, {} as any, maps(renderModule), { logger });
+  await new Promise((r) => setTimeout(r, 20));
+  return { reply, html: reply.chunks.join(''), logger, req };
+};
+
+const events = () => {
+  const seen: { key: string; outcome: string }[] = [];
+  const noop = () => {};
+  const recorder = {
+    requestStart: noop,
+    routeMatched: noop,
+    dataFetch: noop,
+    serviceCall: noop,
+    streamPhase: noop,
+    sent: noop,
+    aborted: noop,
+    failed: noop,
+    clientHydration: noop,
+    deferredData: (e: any) => seen.push({ key: e.key, outcome: e.outcome }),
+  } as unknown as TraceRecorder;
+  return { seen, recorder };
+};
+
+describe('handleRender deferred transport + envelope (RFC 0007)', () => {
+  it('emits the private envelope inside the SAME nonced script, after __INITIAL_DATA__ and before taujs:data-ready', async () => {
+    const captured: Captured = {};
+    const { html } = await run(
+      { render: 'streaming', meta: {}, deferred: { reviews: async () => ({ count: 3 }), blurb: async () => ({ text: 'hi' }) } },
+      mkRenderer(captured, (r) => Promise.all([r['reviews'], r['blurb']])),
+    );
+
+    expect(html).toContain(
+      'window.__INITIAL_DATA__ = {}; window.__TAUJS_DEFERRED_STATE__ = {"blurb":{"status":"complete","value":{"text":"hi"}},"reviews":{"status":"complete","value":{"count":3}}}; window.dispatchEvent(new Event(\'taujs:data-ready\'));',
+    );
+  });
+
+  it('a route declaring nothing has no deferredData in the opts bag and no carrier in the bytes', async () => {
+    const captured: Captured = {};
+    const { html } = await run({ render: 'streaming', meta: {} }, mkRenderer(captured));
+
+    expect('deferredData' in (captured.opts ?? {})).toBe(false);
+    expect(html).not.toContain('__TAUJS_DEFERRED_STATE__');
+    expect(html).toContain("window.__INITIAL_DATA__ = {}; window.dispatchEvent(new Event('taujs:data-ready'));");
+  });
+
+  it('decision 8: under hydrate:false no envelope is emitted, the rest of the script is unchanged, and outcomes are still recorded', async () => {
+    const { seen, recorder } = events();
+    const captured: Captured = {};
+    const { html } = await run(
+      { render: 'streaming', meta: {}, hydrate: false, deferred: { reviews: async () => ({ count: 3 }) } },
+      mkRenderer(captured, (r) => r['reviews']),
+      { recorder },
+    );
+
+    expect(html).not.toContain('__TAUJS_DEFERRED_STATE__');
+    expect(html).toContain("window.__INITIAL_DATA__ = {}; window.dispatchEvent(new Event('taujs:data-ready'));");
+    // The registry is still handed over, settled, classified and released.
+    expect(Object.keys(captured.opts.deferredData)).toEqual(['reviews']);
+    expect(seen).toEqual([{ key: 'reviews', outcome: 'complete' }]);
+  });
+
+  it('starts entries BEFORE head resolution and hands the renderer a started, pre-observed registry', async () => {
+    const order: string[] = [];
+    const captured: Captured = {};
+    await run(
+      {
+        render: 'streaming',
+        meta: {},
+        head: {
+          data: async () => {
+            order.push('head');
+            return { title: 't' };
+          },
+        },
+        deferred: {
+          reviews: async () => {
+            order.push('deferred');
+            return { count: 3 };
+          },
+        },
+      },
+      mkRenderer(captured),
+    );
+
+    expect(order).toEqual(['deferred', 'head']);
+    expect(captured.opts.deferredData).toBeDefined();
+    expect(Object.isFrozen(captured.opts.deferredData)).toBe(true);
+  });
+
+  it('an entry still pending at the write site is `aborted` in the envelope and the trace', async () => {
+    const { seen, recorder } = events();
+    const captured: Captured = {};
+    const { html } = await run({ render: 'streaming', meta: {}, deferred: { reviews: () => new Promise<any>(() => {}) } }, mkRenderer(captured), { recorder });
+
+    expect(html).toContain('window.__TAUJS_DEFERRED_STATE__ = {"reviews":{"status":"aborted"}}');
+    expect(seen).toEqual([{ key: 'reviews', outcome: 'aborted' }]);
+  });
+
+  it('a consumed rejection is `failed` and detail-free in the envelope', async () => {
+    const captured: Captured = {};
+    const { html } = await run(
+      { render: 'streaming', meta: {}, deferred: { reviews: async () => Promise.reject(new Error('BACKEND_SECRET leaked')) } },
+      mkRenderer(captured, (r) => r['reviews']),
+    );
+
+    expect(html).toContain('window.__TAUJS_DEFERRED_STATE__ = {"reviews":{"status":"failed"}}');
+    expect(html).not.toContain('BACKEND_SECRET');
+  });
+
+  it('post-settlement mutation of the loader object reaches neither the renderer value nor the envelope', async () => {
+    const source: Record<string, unknown> = { count: 3 };
+    const captured: Captured = {};
+    let deliveredAtRead: unknown;
+    const { html } = await run(
+      { render: 'streaming', meta: {}, deferred: { reviews: async () => source } },
+      mkRenderer(captured, async (r) => {
+        deliveredAtRead = await r['reviews'];
+        source['count'] = 'MUTATED-AFTER-SETTLEMENT';
+        return deliveredAtRead;
+      }),
+    );
+
+    expect(deliveredAtRead).toEqual({ count: 3 });
+    expect(html).toContain('window.__TAUJS_DEFERRED_STATE__ = {"reviews":{"status":"complete","value":{"count":3}}}');
+    expect(html).not.toContain('MUTATED-AFTER-SETTLEMENT');
+  });
+});
+
+describe('handleRender deferred terminals (R2 item 8)', () => {
+  it('a non-optional HEAD failure aborts and detaches already-started deferred work', async () => {
+    const { seen, recorder } = events();
+    let entrySignal: AbortSignal | undefined;
+    const captured: Captured = {};
+    await run(
+      {
+        render: 'streaming',
+        meta: {},
+        head: { data: async () => Promise.reject(new Error('head exploded')) },
+        deferred: {
+          reviews: async (_p: unknown, ctx: any) => {
+            entrySignal = ctx.signal;
+            return new Promise<any>(() => {});
+          },
+        },
+      },
+      mkRenderer(captured),
+      { recorder },
+    );
+
+    expect(seen).toEqual([{ key: 'reviews', outcome: 'aborted' }]);
+    expect(entrySignal!.aborted).toBe(true);
+    expect(captured.opts).toBeUndefined(); // the renderer was never reached
+  });
+
+  it('a SYNCHRONOUS renderStream throw is a response terminal: classified once, signalled, detached', async () => {
+    const { seen, recorder } = events();
+    let entrySignal: AbortSignal | undefined;
+    const throwing = {
+      renderStream: vi.fn(() => {
+        throw new Error('renderStream exploded synchronously');
+      }),
+    };
+    const req = mkReq('/product/42', recorder);
+    const reply = mkReply();
+
+    await expect(
+      handleRender(
+        req,
+        reply,
+        route({
+          render: 'streaming',
+          meta: {},
+          deferred: {
+            reviews: async (_p: unknown, ctx: any) => {
+              entrySignal = ctx.signal;
+              return new Promise<any>(() => {});
+            },
+          },
+        }) as any,
+        configs,
+        {} as any,
+        maps(throwing),
+        { logger: mkLogger() },
+      ),
+    ).rejects.toThrow(/handleRender failed/);
+
+    expect(seen).toEqual([{ key: 'reviews', outcome: 'aborted' }]);
+    expect(entrySignal!.aborted).toBe(true);
+  });
+
+  it('a FATAL renderer error releases the registry', async () => {
+    const { seen, recorder } = events();
+    let entrySignal: AbortSignal | undefined;
+    const fatal = {
+      renderStream: vi.fn((_w: PassThrough, cb: any) => {
+        cb.onError(new Error('boom'));
+        return { abort: () => {}, done: Promise.resolve() };
+      }),
+    };
+    await run(
+      {
+        render: 'streaming',
+        meta: {},
+        deferred: {
+          reviews: async (_p: unknown, ctx: any) => {
+            entrySignal = ctx.signal;
+            return new Promise<any>(() => {});
+          },
+        },
+      },
+      fatal,
+      { recorder },
+    );
+
+    expect(seen).toEqual([{ key: 'reviews', outcome: 'aborted' }]);
+    expect(entrySignal!.aborted).toBe(true);
+  });
+
+  it('a client disconnect classifies and detaches through the request signal', async () => {
+    const { seen, recorder } = events();
+    let entrySignal: AbortSignal | undefined;
+    const stalled = {
+      renderStream: vi.fn((_w: PassThrough, cb: any) => {
+        cb.onHead('<title>p</title>');
+        return { abort: () => {}, done: Promise.resolve() };
+      }),
+    };
+    const req = mkReq('/product/42', recorder);
+    const reply = mkReply();
+    await handleRender(
+      req,
+      reply,
+      route({
+        render: 'streaming',
+        meta: {},
+        deferred: {
+          reviews: async (_p: unknown, ctx: any) => {
+            entrySignal = ctx.signal;
+            return new Promise<any>(() => {});
+          },
+        },
+      }) as any,
+      configs,
+      {} as any,
+      maps(stalled),
+      { logger: mkLogger() },
+    );
+
+    req.raw.emit('aborted');
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(seen).toEqual([{ key: 'reviews', outcome: 'aborted' }]);
+    expect(entrySignal!.aborted).toBe(true);
+  });
+
+  it('an UNCONSUMED rejection never raises unhandledRejection and never reverses the completed document', async () => {
+    const seenUnhandled: unknown[] = [];
+    const onUnhandled = (e: unknown) => seenUnhandled.push(e);
+    process.on('unhandledRejection', onUnhandled);
+    let html = '';
+    try {
+      const captured: Captured = {};
+      ({ html } = await run(
+        { render: 'streaming', meta: {}, deferred: { reviews: async () => Promise.reject(new Error('nobody reads me')) } },
+        mkRenderer(captured),
+      ));
+      await new Promise((r) => setTimeout(r, 10));
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+
+    expect(seenUnhandled).toEqual([]);
+    expect(html).toContain('window.__INITIAL_DATA__ = {}');
+    expect(html).toContain('__TAUJS_DEFERRED_STATE__');
+  });
+});

--- a/packages/server/src/utils/test/HandleRenderDeferred.test.ts
+++ b/packages/server/src/utils/test/HandleRenderDeferred.test.ts
@@ -342,6 +342,83 @@ describe('handleRender deferred terminals (R2 item 8)', () => {
     expect(entrySignal!.aborted).toBe(true);
   });
 
+  it('a response ALREADY ENDED at the finish tick is still a terminal: signalled, classified exactly once, retaining nothing', async () => {
+    const { seen, recorder } = events();
+    const signals: Record<string, AbortSignal | undefined> = {};
+    const req = mkReq('/product/42', recorder);
+    const reply = mkReply();
+
+    // `writableEnded` is a prototype getter on the real stream; an own accessor lets this test
+    // stage the two ticks the listener sees - ended (the early return) and not ended (the write
+    // site) - without destroying the pipe the head commit established.
+    let ended = false;
+    Object.defineProperty(reply.raw, 'writableEnded', { configurable: true, get: () => ended });
+
+    // The host attaches its 'finish' listener AFTER `renderStream` returns, so capturing `on`
+    // here hands the test the real listener to fire on a later tick, exactly as the emitter would.
+    let finish: (() => void) | undefined;
+    const stalled = {
+      renderStream: vi.fn((writable: PassThrough, cb: any) => {
+        cb.onHead('<title>p</title>');
+        cb.onShellReady();
+        const on = writable.on.bind(writable);
+        (writable as any).on = (event: string, handler: any) => {
+          if (event === 'finish') {
+            finish = handler;
+            return writable;
+          }
+          return on(event, handler);
+        };
+        return { abort: () => {}, done: Promise.resolve() };
+      }),
+    };
+
+    const pending = (key: string) => async (_p: unknown, ctx: any) => {
+      signals[key] = ctx.signal;
+      return new Promise<any>(() => {});
+    };
+
+    await handleRender(
+      req,
+      reply,
+      route({ render: 'streaming', meta: {}, deferred: { reviews: pending('reviews'), blurb: pending('blurb') } }) as any,
+      configs,
+      {} as any,
+      maps(stalled),
+      { logger: mkLogger() },
+    );
+
+    // Nothing has terminated yet: the release must come from the finish listener itself.
+    expect(seen).toEqual([]);
+    expect(signals['reviews']!.aborted).toBe(false);
+
+    ended = true;
+    expect(() => finish!()).not.toThrow();
+    await new Promise((r) => setTimeout(r, 0));
+
+    // The bytes are gone, so no envelope can be emitted - but the work is signalled and each
+    // pending key is classified `aborted` EXACTLY ONCE.
+    expect(signals['reviews']!.aborted).toBe(true);
+    expect(signals['blurb']!.aborted).toBe(true);
+    expect(seen).toEqual([
+      { key: 'reviews', outcome: 'aborted' },
+      { key: 'blurb', outcome: 'aborted' },
+    ]);
+    expect(reply.chunks.join('')).not.toContain('__TAUJS_DEFERRED_STATE__');
+
+    // Envelope state: the controller retains nothing afterwards. A later write site emits the
+    // EMPTY envelope rather than re-classifying keys already accounted for in the trace.
+    ended = false;
+    expect(() => finish!()).not.toThrow();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(reply.chunks.join('')).toContain('window.__TAUJS_DEFERRED_STATE__ = {};');
+    expect(seen).toEqual([
+      { key: 'reviews', outcome: 'aborted' },
+      { key: 'blurb', outcome: 'aborted' },
+    ]);
+  });
+
   it('an UNCONSUMED rejection never raises unhandledRejection and never reverses the completed document', async () => {
     const seenUnhandled: unknown[] = [];
     const onUnhandled = (e: unknown) => seenUnhandled.push(e);

--- a/packages/server/src/utils/test/HandleRenderRecorder.test.ts
+++ b/packages/server/src/utils/test/HandleRenderRecorder.test.ts
@@ -284,6 +284,9 @@ describe('throwing-recorder isolation through the real render path', () => {
       dataFetch() {
         throw new Error('hostile');
       },
+      deferredData() {
+        throw new Error('hostile');
+      },
       serviceCall() {
         throw new Error('hostile');
       },

--- a/packages/solid/src/SSRDeferredData.ts
+++ b/packages/solid/src/SSRDeferredData.ts
@@ -1,0 +1,309 @@
+import { createResource, sharedConfig } from 'solid-js';
+
+import { useSSRStore } from './SSRDataStore.js';
+import { getDeferredData } from './internal.js';
+
+import type { Accessor } from 'solid-js';
+
+/**
+ * RFC 0007 - the @taujs/solid deferred-data adapter. The point of this module is how LITTLE it
+ * does: Solid already owns every mechanism the RFC asks a renderer for.
+ *
+ *  - `createResource` maps a promise onto a `<Suspense>` boundary and suspends THAT boundary only;
+ *  - `renderToStream` emits its own `<template>` + `$df(...)` patch scripts for the late fragment,
+ *    and its own serialised payload for hydration - τjs writes none of those bytes;
+ *  - the client `createResource` reads that payload through Solid's own hydration context and never
+ *    calls the fetcher, so hydration re-executes no loader by construction;
+ *  - a rejected resource reaches the application's `<ErrorBoundary>` on the SERVER (decision 13:
+ *    Solid's engine has real server-side error boundaries, so the throwing read is Solid's
+ *    server-completing consumed-rejection path and no result accessor is needed) and crosses the
+ *    wire through the package's non-disableable error sanitiser, so no server detail travels.
+ *
+ * So the adapter is a store-carried holder that turns a host promise into a Solid resource, plus
+ * the ONE case Solid cannot express on its own: an entry still pending when the response terminated
+ * (`aborted`). Solid's serialised slot for such a key is a promise that will never settle, so a
+ * hydrating client would sit in its fallback forever; the envelope is what makes that deterministic.
+ *
+ * NO MEMOISATION, deliberately. A Solid `<Suspense>` re-runs its children when a resource settles,
+ * with the hydration id counter reset, so a τjs-side per-key cache would consume a context id on
+ * the FIRST pass and none on the second - shifting every id allocated after it and breaking
+ * hydration for unrelated application resources. Calling `createResource` on every read keeps id
+ * consumption identical in every pass and on the client; Solid itself dedupes by context id and
+ * skips the fetcher once data is present, so "start once" is Solid's guarantee, not a cache of ours.
+ *
+ * EXPORT HYGIENE (renderer contract item 9 / decision 10): only `createDeferredAccessor`,
+ * `useDeferredData`, `DeferredDataError` and the `DeferredAccessor` type reach `index.ts`.
+ */
+
+/** @internal The host's internal transport (`RenderOptions.deferredData`), structurally re-stated. */
+export type DeferredDataRegistry = Readonly<Record<string, Promise<Record<string, unknown>>>>;
+
+/** @internal RFC 0007 (R4): the only three v1 outcomes. `failed` carries NO message, stack or detail. */
+export type DeferredOutcome = { status: 'complete'; value: Record<string, unknown> } | { status: 'failed' } | { status: 'aborted' };
+
+/** @internal */
+export type DeferredHydrationState = Readonly<Record<string, DeferredOutcome>>;
+
+/** @internal The private, UNDOCUMENTED envelope carrier the host attaches at end of stream. */
+export const DEFERRED_STATE_CARRIER = '__TAUJS_DEFERRED_STATE__';
+
+/**
+ * The terminal for a `failed` or `aborted` entry. It names the KEY and the OUTCOME and nothing
+ * else - the key is route configuration already visible in the application's own source, so no
+ * server value, message, stack or cause is constructible from it.
+ */
+export class DeferredDataError extends Error {
+  readonly key: string;
+  readonly outcome: 'failed' | 'aborted';
+
+  constructor(key: string, outcome: 'failed' | 'aborted') {
+    super(
+      outcome === 'aborted' ? `taujs: deferred data "${key}" was abandoned when the response terminated` : `taujs: deferred data "${key}" failed on the server`,
+    );
+    this.name = 'DeferredDataError';
+    this.key = key;
+    this.outcome = outcome;
+  }
+}
+
+/**
+ * `T | undefined`, matching Solid's own `Resource<T>` exactly.
+ *
+ * Solid does NOT skip a suspended boundary's body: it runs once with the accessor returning
+ * `undefined` (that is how the resource registers with the enclosing `<Suspense>`) and again when
+ * the resource settles. Only the second pass reaches the wire, so the DELIVERED html always carries
+ * the value - but the application must still write `reviews()?.count` or `<Show when={reviews()}>`,
+ * exactly as for any other Solid resource. Typing this `Accessor<T>` would be a lie about the first
+ * pass.
+ */
+export type DeferredAccessor<T> = Accessor<T | undefined>;
+
+/** @internal */
+export type DeferredDataHolder = {
+  /** The declared key set for THIS request. Authoritative; an unknown read is a developer error. */
+  readonly keys: readonly string[];
+  /** Map a declared key onto a Solid accessor. Suspends the reading boundary only. */
+  read<T>(key: string): DeferredAccessor<T>;
+  /**
+   * The response-level deferred deadline (decision 18). A LATCH, not a one-shot sweep:
+   *
+   *  1. every consumed entry that has not settled is abandoned NOW, by rejecting the ADAPTER'S OWN
+   *     wrapper, so Solid errors those boundaries through its native channel and finishes the
+   *     document itself;
+   *  2. the holder stays expired, so a boundary whose FIRST read happens after the deadline is born
+   *     abandoned rather than starting a fresh, unbounded wait.
+   *
+   * Without (2) the deadline would be a hint: a late-registering consumer is invisible to the timer.
+   * The host's response-owned promise is NOT touched in either case - it stays pending, the host
+   * classifies it `aborted` at its write site, and the service still observes the request signal.
+   * Returns how many were abandoned by (1).
+   */
+  expire(): number;
+  /** Release every reference this holder owns. Idempotent; runs on every terminal. */
+  release(): void;
+};
+
+const hasOwn = (o: object, k: string): boolean => Object.prototype.hasOwnProperty.call(o, k);
+
+const unknownKey = (key: string, keys: readonly string[]): Error =>
+  new Error(`taujs: unknown deferred data key ${JSON.stringify(key)}. This route declares [${keys.map((k) => JSON.stringify(k)).join(', ')}].`);
+
+const releasedError = (key: string): Error =>
+  new Error(`taujs: deferred data ${JSON.stringify(key)} was read after the response terminal; the holder has been released.`);
+
+/**
+ * @internal SERVER holder. The registry is RESPONSE-OWNED: the promises are already started and
+ * already pre-observed by the host, so nothing here starts, restarts, memoises or decorates them.
+ */
+export function createDeferredHolder(source: DeferredDataRegistry, onAbandon?: (keys: readonly string[]) => void): DeferredDataHolder {
+  const keys = Object.freeze(Object.keys(source));
+  const pending = new Set<string>();
+  const wrappers = new Map<string, { promise: Promise<Record<string, unknown>>; abandon: (reason: unknown) => void }>();
+  // The ONLY reference this adapter keeps to the response-owned registry, dropped at the terminal.
+  let registry: DeferredDataRegistry | undefined = source;
+  let released = false;
+  let expired = false;
+
+  /**
+   * The adapter's own promise per key, created lazily on first read. It DELEGATES to the
+   * response-owned promise and never mutates or replaces it - but because the adapter owns this
+   * one, the deadline can settle it, which is the whole mechanism behind `expire()`. Memoising the
+   * WRAPPER is safe (it consumes no hydration context id); memoising the RESOURCE would not be.
+   */
+  const wrapper = (key: string): Promise<Record<string, unknown>> => {
+    const existing = wrappers.get(key);
+    if (existing) return existing.promise;
+
+    if (expired) {
+      // The deadline already passed: abandon immediately and tell the renderer, rather than
+      // starting a fresh unbounded wait on a document it is still holding open.
+      const promise = Promise.reject(new DeferredDataError(key, 'aborted')) as Promise<Record<string, unknown>>;
+      promise.catch(() => {}); // pre-observed: Solid may never consume this rejection
+      wrappers.set(key, { promise, abandon: () => {} });
+      onAbandon?.([key]);
+
+      return promise;
+    }
+
+    let abandon!: (reason: unknown) => void;
+    const promise = new Promise<Record<string, unknown>>((resolve, reject) => {
+      abandon = reject;
+      registry![key]!.then(
+        (value) => {
+          pending.delete(key);
+          resolve(value);
+        },
+        (reason) => {
+          pending.delete(key);
+          reject(reason);
+        },
+      );
+    });
+    promise.catch(() => {}); // pre-observed: an abandoned wrapper must never be an unhandledRejection
+
+    pending.add(key);
+    wrappers.set(key, { promise, abandon });
+
+    return promise;
+  };
+
+  return {
+    keys,
+
+    read<T>(key: string): DeferredAccessor<T> {
+      if (released) throw releasedError(key);
+      if (!registry || !hasOwn(registry, key)) throw unknownKey(key, keys);
+
+      const [read] = createResource(() => wrapper(key));
+
+      return read as unknown as DeferredAccessor<T>;
+    },
+
+    expire() {
+      expired = true;
+
+      const abandoned = [...pending];
+      for (const key of abandoned) {
+        pending.delete(key);
+        wrappers.get(key)?.abandon(new DeferredDataError(key, 'aborted'));
+      }
+      if (abandoned.length > 0) onAbandon?.(abandoned);
+
+      return abandoned.length;
+    },
+
+    release() {
+      released = true;
+      registry = undefined;
+      pending.clear();
+      wrappers.clear();
+    },
+  };
+}
+
+/**
+ * @internal CLIENT holder, built from the envelope read synchronously at bootstrap.
+ *
+ * `complete` and `failed` are deliberately routed back through `createResource` rather than
+ * short-circuited: during hydration Solid finds its own serialised slot and uses it WITHOUT calling
+ * the fetcher, which is the native zero-refetch path. The fetcher below is the fallback for a
+ * boundary Solid never serialised, and it too is refetch-free - it resolves from the envelope value
+ * already in memory.
+ *
+ * `aborted` is the one case that must NOT reach Solid's slot: the server terminated with that
+ * promise still pending, so the slot holds a promise nothing will ever settle and the boundary
+ * would stay in its fallback forever. The context id is consumed anyway (so every later hydration
+ * id still lines up with the server's walk) and the read throws into the app's `<ErrorBoundary>`.
+ */
+export function createHydrationHolder(source: DeferredHydrationState): DeferredDataHolder {
+  const keys = Object.freeze(Object.keys(source));
+  let envelope: DeferredHydrationState | undefined = source;
+  let released = false;
+
+  return {
+    keys,
+
+    read<T>(key: string): DeferredAccessor<T> {
+      // The released check comes FIRST: `keys` is frozen at construction while `envelope` is
+      // dropped by `release()`, so falling through to `unknownKey` would contradict itself.
+      if (released) throw releasedError(key);
+      if (!envelope || !hasOwn(envelope, key)) throw unknownKey(key, keys);
+
+      const outcome = envelope[key]!;
+
+      if (outcome.status === 'aborted') {
+        // Burn the context id the SERVER's `createResource` consumed at this position; skipping it
+        // would shift every subsequent id and break hydration for unrelated application resources.
+        if (sharedConfig.context) sharedConfig.getNextContextId();
+
+        return (() => {
+          throw new DeferredDataError(key, 'aborted');
+        }) as DeferredAccessor<T>;
+      }
+
+      const [read] = createResource<Record<string, unknown>>(() =>
+        outcome.status === 'complete' ? Promise.resolve(outcome.value) : Promise.reject(new DeferredDataError(key, 'failed')),
+      );
+
+      return read as unknown as DeferredAccessor<T>;
+    },
+
+    // No request lifecycle to bound on the client: the outcomes are already terminal.
+    expire: () => 0,
+
+    release() {
+      released = true;
+      envelope = undefined;
+    },
+  };
+}
+
+/**
+ * Read a declared deferred entry. ONE component, both sides - it never learns which side it is on.
+ *
+ * Reading a pending entry suspends the nearest `<Suspense>` and nothing else; a rejected entry
+ * throws into the nearest `<ErrorBoundary>`, on the SERVER and on the client alike. PLACEMENT
+ * MATTERS: the `<ErrorBoundary>` must sit INSIDE the `<Suspense>`; outside it the response still
+ * completes and the rejection is still redacted, but the fallback renders on the client.
+ */
+export function useDeferredData<T>(key: string): DeferredAccessor<T> {
+  const holder = getDeferredData(useSSRStore()) as DeferredDataHolder | undefined;
+
+  if (!holder) {
+    throw new Error(`taujs: useDeferredData(${JSON.stringify(key)}) requires a route declaring \`attr.deferred\`, rendered by the τjs Solid renderer`);
+  }
+
+  return holder.read<T>(key);
+}
+
+/**
+ * The TYPED façade: `createDeferredAccessor<DeferredDataOf<typeof route>>()`.
+ *
+ * A factory rather than `useDeferredData<D>('reviews')` because TypeScript cannot infer one type
+ * argument while another is supplied explicitly - a two-parameter hook collapses the return type to
+ * a union over every declared key. The factory fixes `D` once and infers `K` from the argument.
+ */
+export function createDeferredAccessor<D>() {
+  return <K extends keyof D & string>(key: K): DeferredAccessor<D[K]> => useDeferredData<D[K]>(key);
+}
+
+/**
+ * @internal Read the private envelope ONCE and drop the carrier.
+ *
+ * An ABSENT carrier is the ordinary case - a route that declared nothing, and (decision 8)
+ * `hydrate: false` - never an error and never a reason to fetch.
+ */
+export const takeDeferredHydrationState = (): DeferredHydrationState | undefined => {
+  try {
+    const w = window as unknown as Record<string, unknown>;
+    const raw = w[DEFERRED_STATE_CARRIER];
+    delete w[DEFERRED_STATE_CARRIER];
+
+    if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+
+    return raw as DeferredHydrationState;
+  } catch {
+    // A hostile or absent global must never break bootstrap.
+    return undefined;
+  }
+};

--- a/packages/solid/src/SSRHydration.ts
+++ b/packages/solid/src/SSRHydration.ts
@@ -1,6 +1,8 @@
 import { hydrate, render } from 'solid-js/web';
 
 import { createSSRStore, provideSSRStore } from './SSRDataStore.js';
+import { createHydrationHolder, takeDeferredHydrationState } from './SSRDeferredData.js';
+import { attachDeferredData } from './internal.js';
 import { createUILogger } from './utils/Logger.js';
 
 import type { JSX } from 'solid-js';
@@ -128,6 +130,13 @@ export function hydrateApp({
     }
 
     const initialData = (window as { __INITIAL_DATA__?: Record<string, unknown> }).__INITIAL_DATA__;
+    // RFC 0007 (R4): read the private envelope synchronously, in DOCUMENT ORDER, and drop the
+    // carrier - on EVERY path (CSR fallback included), so it can never survive bootstrap on a page
+    // that took a different branch. No event and no listener: `bootstrap()` runs after
+    // `DOMContentLoaded` or with `readyState !== 'loading'`, i.e. strictly after the host's
+    // end-of-stream script. `taujs:data-ready` is deliberately NOT used - it dispatches first.
+    const deferredState = takeDeferredHydrationState();
+    const deferredHolder = deferredState ? createHydrationHolder(deferredState) : undefined;
     const location = window.location.pathname + window.location.search;
 
     // Missing initial data falls back to CSR (design 4): a CSR mount is NOT a hydration, so it emits
@@ -139,6 +148,7 @@ export function hydrateApp({
       try {
         rootElement.innerHTML = '';
         const store = createSSRStore<Record<string, unknown>>({});
+        if (deferredHolder) attachDeferredData(store, deferredHolder);
         render(() => provideSSRStore(store, () => app({ location })), rootElement);
         reportSuccess('CSR mount succeeded');
       } catch (err) {
@@ -156,6 +166,9 @@ export function hydrateApp({
 
     try {
       const store = createSSRStore(initialData);
+      // Mirrors the server exactly: carried on the store, so the hydrated tree has the SAME shape
+      // and the SAME context-id walk as the rendered one, envelope or no envelope.
+      if (deferredHolder) attachDeferredData(store, deferredHolder);
       hydrate(() => provideSSRStore(store, () => app({ location })), rootElement, renderId ? { renderId } : undefined);
       reportSuccess('Hydration succeeded');
     } catch (err) {

--- a/packages/solid/src/SSRRender.ts
+++ b/packages/solid/src/SSRRender.ts
@@ -2,7 +2,7 @@ import { generateHydrationScript, renderToStream, renderToStringAsync } from 'so
 
 import { createSSRStore, provideSSRStore } from './SSRDataStore.js';
 import { createDeferredHolder } from './SSRDeferredData.js';
-import { attachDeferredData, detachStore, getStoreReadiness, getStoreState } from './internal.js';
+import { attachDeferredData, detachDeferredData, detachStore, getStoreReadiness, getStoreState } from './internal.js';
 import { brandRenderFunctions, SOLID_RENDERER_KEY } from './renderContract.js';
 import { escapeHtml } from './utils/Html.js';
 import { SanitisedErrorPlugin } from './utils/SanitiseError.js';
@@ -486,7 +486,14 @@ export function createRenderer<
     // holder is released on the SAME terminal, under the same retention standard as the store.
     controller.setDetach(() => {
       detachStore(store);
-      deferredHolder?.release();
+
+      if (deferredHolder) {
+        deferredHolder.release();
+        // Releasing empties the holder; this drops the STORE -> holder edge too, which is what
+        // `attachDeferredData`'s `configurable: true` exists for. The response's retained graph is a
+        // no-deferred route's again.
+        detachDeferredData(store);
+      }
     });
 
     const readiness = getStoreReadiness(store) ?? Promise.resolve();

--- a/packages/solid/src/SSRRender.ts
+++ b/packages/solid/src/SSRRender.ts
@@ -1,7 +1,8 @@
 import { generateHydrationScript, renderToStream, renderToStringAsync } from 'solid-js/web';
 
 import { createSSRStore, provideSSRStore } from './SSRDataStore.js';
-import { detachStore, getStoreReadiness, getStoreState } from './internal.js';
+import { createDeferredHolder } from './SSRDeferredData.js';
+import { attachDeferredData, detachStore, getStoreReadiness, getStoreState } from './internal.js';
 import { brandRenderFunctions, SOLID_RENDERER_KEY } from './renderContract.js';
 import { escapeHtml } from './utils/Html.js';
 import { SanitisedErrorPlugin } from './utils/SanitiseError.js';
@@ -10,6 +11,7 @@ import { createStreamController, startTimer, wireWritableGuards } from './utils/
 
 import type { JSX } from 'solid-js';
 import type { Writable } from 'node:stream';
+import type { DeferredDataRegistry } from './SSRDeferredData.js';
 import type { SolidLogger } from './utils/Logger.js';
 
 /**
@@ -61,6 +63,12 @@ export type RenderOptions = {
   headData?: Record<string, unknown>;
   cspNonce?: string;
   shouldHydrate?: boolean;
+  /**
+   * RFC 0007 (decision 14): the host's request-local registry of declared deferred entries. Present
+   * ONLY when the route declares `attr.deferred`; every promise is already started and already
+   * pre-observed by the host. Streaming-only - `renderSSR` deliberately ignores it (R1).
+   */
+  deferredData?: DeferredDataRegistry;
 };
 
 export type InitialDataInput = Record<string, unknown> | Promise<Record<string, unknown>> | (() => Promise<Record<string, unknown>>);
@@ -98,6 +106,29 @@ export type StreamOptions = {
   shellTimeoutMs?: number;
   /** Bound on the WHOLE renderStream lifecycle (default 30_000). Every terminal clears it. */
   completionTimeoutMs?: number;
+  /**
+   * RFC 0007 (decision 18): the ONE response-level deferred completion deadline.
+   *
+   * A separate number from `completionTimeoutMs` on purpose. That one is FATAL (destroy the sink,
+   * reject `done`) because a stalled render is a delivery failure; abandoning a deferred boundary
+   * is a normal, COMPLETE document with the application's own fallback UI in it.
+   *
+   * Measured from `renderStream` entry - the same origin as `completionTimeoutMs`, so their
+   * ordering is a property of the CONFIGURATION rather than of how fast the shell committed - and
+   * armed at shell commit with whatever remains of the budget (a budget already spent arms at 1ms).
+   * It LATCHES: a boundary whose first read arrives after expiry is born abandoned. Abandonment is
+   * NATIVE - the adapter rejects its OWN wrapper, so Solid errors those boundaries through its
+   * ordinary channel, renders the application's `<ErrorBoundary>` fallback INTO the response and
+   * ends the stream itself. τjs writes no framework-patch bytes and never touches the host's
+   * response-owned promise.
+   *
+   * POSITIVE FINITE only, validated at the factory - there is no disable sentinel, because this
+   * deadline is what keeps "bounded total response time" true. Default
+   * `min(15_000, completionTimeoutMs / 2)`, and a finite value must be STRICTLY LESS than a finite
+   * `completionTimeoutMs`: at or above it the fatal watchdog always wins the race and graceful
+   * abandonment is unreachable.
+   */
+  deferredTimeoutMs?: number;
 };
 
 export type SSROptions = {
@@ -106,6 +137,13 @@ export type SSROptions = {
 };
 
 const NOOP = () => {};
+
+/**
+ * RFC 0007 (decision 18): the cap on the DERIVED default `deferredTimeoutMs`. The default is
+ * `min(this, completionTimeoutMs / 2)` so the ordering is derived rather than asserted by
+ * coincidence.
+ */
+const DEFERRED_TIMEOUT_DEFAULT_CAP_MS = 15_000;
 
 /**
  * Design 4 (R1). `shouldHydrate` is the host-RESOLVED policy (`attr.hydrate !== false`), delivered
@@ -170,6 +208,14 @@ export function createRenderer<
   logger?: SolidLogger;
 }) {
   const { shellTimeoutMs = 10_000, completionTimeoutMs = 30_000 } = streamOptions;
+  // RFC 0007 (decision 18): DERIVED, not a literal - half the fatal backstop's budget, capped at
+  // 15s, so the graceful deferred terminal is reachable for whatever `completionTimeoutMs` an
+  // application configures rather than only for the stock one.
+  const deferredTimeoutMs =
+    streamOptions.deferredTimeoutMs ??
+    (Number.isFinite(completionTimeoutMs) && completionTimeoutMs > 0
+      ? Math.min(DEFERRED_TIMEOUT_DEFAULT_CAP_MS, completionTimeoutMs / 2)
+      : DEFERRED_TIMEOUT_DEFAULT_CAP_MS);
   const { prerenderTimeoutMs = 10_000 } = ssrOptions;
 
   // Validate ONCE, at the factory. `startTimer` arms only for finite positive values, so without
@@ -185,6 +231,26 @@ export function createRenderer<
   assertTimeout(shellTimeoutMs, 'streamOptions.shellTimeoutMs');
   assertTimeout(completionTimeoutMs, 'streamOptions.completionTimeoutMs');
   assertTimeout(prerenderTimeoutMs, 'ssrOptions.prerenderTimeoutMs');
+
+  // RFC 0007 (decision 18): POSITIVE FINITE only - unlike the watchdogs above there is no
+  // 0/Infinity sentinel, because this deadline is what keeps "bounded total response time" true.
+  if (!(typeof deferredTimeoutMs === 'number' && Number.isFinite(deferredTimeoutMs) && deferredTimeoutMs > 0)) {
+    throw new TypeError(
+      `createRenderer: streamOptions.deferredTimeoutMs must be a positive finite number of milliseconds (received ${String(deferredTimeoutMs)})`,
+    );
+  }
+
+  // The ORDERING rule. Both are measured from `renderStream` entry, so at or above the fatal
+  // watchdog the deferred one can never abandon a boundary: the document would be destroyed and
+  // `done` rejected instead. That is a DEAD option, not a marginal configuration, so it is a
+  // factory error rather than a silent surprise at request time. Either sentinel on
+  // `completionTimeoutMs` ("no bound") switches the race off, so no ordering is required there.
+  if (Number.isFinite(completionTimeoutMs) && completionTimeoutMs > 0 && deferredTimeoutMs >= completionTimeoutMs) {
+    throw new TypeError(
+      `createRenderer: streamOptions.deferredTimeoutMs (${deferredTimeoutMs}) must be strictly less than streamOptions.completionTimeoutMs (${completionTimeoutMs}); ` +
+        'both are measured from renderStream entry, so at or above it the fatal completion watchdog always fires first and the deferred deadline can never abandon a boundary',
+    );
+  }
 
   // ---------------------------------------------------------------------------------------------
   // renderSSR - the `ssr` strategy. A SINGLE promise; deliberately no stream vocabulary (INDEX
@@ -326,6 +392,12 @@ export function createRenderer<
 
     const controller = createStreamController(sink, { log, warn, error });
 
+    // RFC 0007 (decision 18): the SHARED time origin for the two whole-response watchdogs. The
+    // deferred deadline is armed later (at shell commit) but measured from HERE, so the
+    // factory-enforced `deferredTimeoutMs < completionTimeoutMs` is sufficient for it to land first
+    // on every request, whatever the shell cost.
+    const renderStartedAt = Date.now();
+
     /**
      * The single fatal site. Claims the terminal FIRST, then runs the host's isolated `onError`:
      * the host callback may synchronously abort the very AbortSignal wired to `benignAbort`, and a
@@ -395,9 +467,27 @@ export function createRenderer<
 
       return { abort: NOOP, done: controller.done };
     }
+    // RFC 0007: the holder exists ONLY when the host declared entries, so a no-deferred route
+    // renders the identical tree and emits identical bytes. It starts nothing - the registry's
+    // promises are already running and already pre-observed. `onAbandon` fires for BOTH abandonment
+    // routes: the deadline sweep, and a boundary whose first read arrives after it.
+    const deferredHolder = opts?.deferredData
+      ? createDeferredHolder(opts.deferredData, (abandoned) =>
+          warn(`Deferred data not ready after ${deferredTimeoutMs}ms; abandoning [${abandoned.join(', ')}]`),
+        )
+      : undefined;
+    // Carried ON THE STORE, not in a provider of its own: an extra `createComponent` would open a
+    // nested hydration context and shift every context id in the subtree (see internal.ts
+    // STORE_DEFERRED). The tree, and therefore the emitted bytes, are unchanged.
+    if (deferredHolder) attachDeferredData(store, deferredHolder);
+
     // M1: every terminal releases τjs-owned request state, exactly once (the controller enforces
-    // the once-ness across all terminal kinds).
-    controller.setDetach(() => detachStore(store));
+    // the once-ness across all terminal kinds). RFC 0007 renderer contract item 8: the deferred
+    // holder is released on the SAME terminal, under the same retention standard as the store.
+    controller.setDetach(() => {
+      detachStore(store);
+      deferredHolder?.release();
+    });
 
     const readiness = getStoreReadiness(store) ?? Promise.resolve();
 
@@ -574,6 +664,22 @@ export function createRenderer<
             }
 
             controller.markShellCommitted();
+
+            // RFC 0007 (decision 18): arm the deferred deadline at shell commit - before the shell
+            // there is no document to complete, and a pre-shell stall is the shell timer's fault to
+            // report - with what REMAINS of a budget measured from `renderStartedAt`.
+            if (deferredHolder) {
+              const stopDeferredTimer = startTimer(Math.max(deferredTimeoutMs - (Date.now() - renderStartedAt), 1), () => {
+                if (controller.terminated) return;
+                // LATCH FIRST, unconditionally: a read registering later must be born abandoned
+                // rather than start a fresh unbounded wait. Abandonment is NATIVE - rejecting the
+                // adapter's own wrapper makes Solid error those boundaries through its ordinary
+                // channel, render the app's `<ErrorBoundary>` fallback into the RESPONSE and end
+                // the stream itself. A deadline that abandons nothing is silent and costs nothing.
+                deferredHolder.expire();
+              });
+              controller.addCleanup(stopDeferredTimer);
+            }
 
             try {
               cb.onShellReady();

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -17,6 +17,14 @@ export { createSSRStore, useSSRStore } from './SSRDataStore.js';
 export { hydrateApp } from './SSRHydration.js';
 export { escapeHtml } from './utils/Html.js';
 
+// RFC 0007 (decision 19, renderer contract item 9): the package's PUBLIC surface for this feature
+// is the COMPONENT-FACING ACCESSORS and their result/error types, and nothing else. The carrier
+// name, both holders, the store seam and the envelope/registry transport shapes are private
+// transport and stay unexported - `PublicSurface.test.ts` asserts both halves against the BUILT
+// dist. Solid's engine HAS server-side error boundaries, so under the need-based ruling
+// (decision 13) it carries no result accessor: the throwing read already completes the response.
+export { createDeferredAccessor, DeferredDataError, useDeferredData } from './SSRDeferredData.js';
+
 export type {
   HeadContext,
   InitialDataInput,
@@ -30,5 +38,6 @@ export type {
   StreamOptions,
 } from './SSRRender.js';
 export type { SSRStore } from './SSRDataStore.js';
+export type { DeferredAccessor } from './SSRDeferredData.js';
 export type { HydrateAppOptions } from './SSRHydration.js';
 export type { ServerLogger, SolidLogger, UILogger } from './utils/Logger.js';

--- a/packages/solid/src/internal.ts
+++ b/packages/solid/src/internal.ts
@@ -28,6 +28,19 @@ export const STORE_DETACH: unique symbol = Symbol('taujs.solid.storeDetach');
 /** Internal read of the store's settled state, so the adapter never guesses from `data()`. */
 export const STORE_STATE: unique symbol = Symbol('taujs.solid.storeState');
 
+/**
+ * RFC 0007: the request's deferred-data holder, carried on the STORE rather than in a provider of
+ * its own.
+ *
+ * This is not a stylistic choice. Solid's `createComponent` opens a NESTED hydration context and
+ * consumes a context id, so an extra provider component shifts every `createUniqueId`, resource id
+ * and Suspense-fragment key in the whole subtree - a conditional one would make a `deferred`
+ * route's bytes differ from a non-deferred route's for reasons unrelated to the deferred content,
+ * and would make hydration depend on the client inserting exactly the same conditional wrapper.
+ * Riding on the store the adapter ALREADY provides costs zero components and zero ids on both sides.
+ */
+export const STORE_DEFERRED: unique symbol = Symbol('taujs.solid.storeDeferred');
+
 export type StoreState = {
   /** `pending` until the seed settles or `setData` commits. */
   status: 'pending' | 'success' | 'error';
@@ -45,6 +58,16 @@ export const getStoreState = (store: unknown): StoreState | undefined => {
 
   return typeof read === 'function' ? read() : undefined;
 };
+
+/**
+ * Attach the request's deferred holder to the store. `configurable` so the terminal can drop it.
+ * `unknown` rather than the holder type: `internal.ts` must stay free of module cycles.
+ */
+export const attachDeferredData = (store: unknown, holder: unknown): void => {
+  Object.defineProperty(store as object, STORE_DEFERRED, { value: holder, enumerable: false, configurable: true });
+};
+
+export const getDeferredData = (store: unknown): unknown => (store as Record<symbol, unknown> | null | undefined)?.[STORE_DEFERRED];
 
 /** Release the store's τjs-owned payload. Safe to call repeatedly and on a non-store value. */
 export const detachStore = (store: unknown): void => {

--- a/packages/solid/src/internal.ts
+++ b/packages/solid/src/internal.ts
@@ -69,6 +69,16 @@ export const attachDeferredData = (store: unknown, holder: unknown): void => {
 
 export const getDeferredData = (store: unknown): unknown => (store as Record<symbol, unknown> | null | undefined)?.[STORE_DEFERRED];
 
+/**
+ * Drop the store -> holder edge at the terminal - which is what `configurable: true` above is for.
+ * Releasing the holder empties it; deleting the property also removes the store's reference to it,
+ * so a deferred response's retained graph returns to a no-deferred route's. Idempotent, and safe on
+ * a non-store value.
+ */
+export const detachDeferredData = (store: unknown): void => {
+  if (store && typeof store === 'object') delete (store as Record<symbol, unknown>)[STORE_DEFERRED];
+};
+
 /** Release the store's τjs-owned payload. Safe to call repeatedly and on a non-store value. */
 export const detachStore = (store: unknown): void => {
   const detach = (store as Record<symbol, unknown> | null | undefined)?.[STORE_DETACH] as (() => void) | undefined;

--- a/packages/solid/src/test/PublicSurface.test.ts
+++ b/packages/solid/src/test/PublicSurface.test.ts
@@ -59,7 +59,19 @@ describe('slice 6 - the runtime author surface (`@taujs/solid`)', () => {
   it('exports exactly the frozen runtime API', async () => {
     const rootModule = await import('../index.js');
 
-    expect(Object.keys(rootModule).sort()).toEqual(['createRenderer', 'createSSRStore', 'escapeHtml', 'hydrateApp', 'useSSRStore']);
+    // RFC 0007 (decision 19) adds exactly three runtime symbols to this frozen enumeration. The
+    // gate exists so growth is a conscious act - the deferred transport's carrier, holders, store
+    // seam and hydration reader are asserted ABSENT by the leak test below.
+    expect(Object.keys(rootModule).sort()).toEqual([
+      'DeferredDataError',
+      'createDeferredAccessor',
+      'createRenderer',
+      'createSSRStore',
+      'escapeHtml',
+      'hydrateApp',
+      'useDeferredData',
+      'useSSRStore',
+    ]);
   });
 
   it('does NOT export solidRenderer - the root-vs-subpath split is frozen', async () => {
@@ -82,6 +94,13 @@ describe('slice 6 - the runtime author surface (`@taujs/solid`)', () => {
       'provideSSRStore',
       'detachStore',
       'brandRenderFunctions',
+      // RFC 0007 private transport (decision 10).
+      'DEFERRED_STATE_CARRIER',
+      'createDeferredHolder',
+      'createHydrationHolder',
+      'takeDeferredHydrationState',
+      'attachDeferredData',
+      'getDeferredData',
     ]) {
       expect(rootModule[leaked], `${leaked} leaked from the root entry`).toBeUndefined();
     }

--- a/packages/solid/src/test/RendererRetention.test.ts
+++ b/packages/solid/src/test/RendererRetention.test.ts
@@ -5,6 +5,7 @@ import { ssr } from 'solid-js/web';
 import { describe, it, expect } from 'vitest';
 
 import { createRenderer } from '../SSRRender.js';
+import { createDeferredHolder } from '../SSRDeferredData.js';
 
 import type { JSX } from 'solid-js';
 
@@ -135,6 +136,55 @@ describe('7.3 forced-GC: a renderer terminal releases the route payload', () => 
     await collect();
 
     expect(started.ref.deref(), 'the route payload survived a completed stream - the adapter is still holding it').toBeUndefined();
+  });
+
+  gcIt('DEFERRED (RFC 0007) introduces no new retention class: it behaves exactly as `opts.headData` does', async () => {
+    // What this measures, stated precisely, because a weaker claim would be dishonest.
+    //
+    // The deferred registry arrives on the SAME `opts` bag as `headData`, and an `opts` field
+    // outlives the stream terminal in this renderer's closure graph TODAY - that is pre-existing
+    // behaviour, not something RFC 0007 introduced. A probe that watched a deferred value through
+    // `opts` would therefore be measuring the opts bag, not the deferred holder, and would report
+    // "leak" for a holder that had already dropped every reference it owns.
+    //
+    // So the assertion is a COMPARISON: the deferred value and a `headData` value delivered through
+    // the identical path must reach the identical state after a completed stream. The holder's own
+    // release is asserted behaviourally beside it (a later read throws, and `expire()` reports
+    // nothing outstanding), which is the same standard the store's accessor is held to.
+    const start = () => {
+      const deferredValue = { big: 'x'.repeat(4096) };
+      const headValue = { big: 'h'.repeat(4096) };
+      const { renderStream } = createRenderer({ appComponent, headContent: () => '' });
+
+      return {
+        deferredRef: new WeakRef(deferredValue),
+        headRef: new WeakRef(headValue),
+        done: renderStream(makeSink(), makeCallbacks(), {}, '/', undefined, {}, undefined, {
+          headData: headValue,
+          deferredData: Object.freeze({ reviews: Promise.resolve(deferredValue as unknown as Record<string, unknown>) }),
+        }).done,
+      };
+    };
+    const started = start();
+
+    await started.done;
+    started.done = undefined as never;
+
+    await collect();
+
+    expect(
+      started.deferredRef.deref() === undefined,
+      'the deferred registry retains differently from the pre-existing headData field - RFC 0007 would then own a NEW retention class',
+    ).toBe(started.headRef.deref() === undefined);
+  });
+
+  gcIt('DEFERRED (RFC 0007): the holder drops its own references at the terminal', async () => {
+    const holder = createDeferredHolder(Object.freeze({ reviews: Promise.resolve({ count: 1 }) }));
+
+    holder.release();
+
+    expect(() => holder.read('reviews')).toThrow(/read after the response terminal/);
+    expect(holder.expire(), 'a released holder still had entries to abandon').toBe(0);
   });
 
   gcIt('SSR TIMEOUT: the payload is collectable after prerenderTimeoutMs rejects', async () => {

--- a/packages/solid/src/test/SSRDeferredData.test.ts
+++ b/packages/solid/src/test/SSRDeferredData.test.ts
@@ -8,6 +8,8 @@ import { renderToStringAsync, ssr } from 'solid-js/web';
 import { describe, it, expect } from 'vitest';
 
 import { createRenderer } from '../SSRRender.js';
+import { useSSRStore } from '../SSRDataStore.js';
+import { getDeferredData } from '../internal.js';
 import {
   createDeferredAccessor,
   createDeferredHolder,
@@ -17,6 +19,7 @@ import {
   useDeferredData,
 } from '../SSRDeferredData.js';
 
+import type { DeferredDataHolder } from '../SSRDeferredData.js';
 import type { JSX } from 'solid-js';
 
 const html = (markup: string): JSX.Element => ssr(markup) as never;
@@ -282,6 +285,74 @@ describe('@taujs/solid deferred adapter - retention (renderer contract 8)', () =
     // A read after the terminal is a deterministic developer error, not a silent fresh wait.
     expect(() => holder.read('reviews')).toThrow(/read after the response terminal/);
     expect(holder.expire()).toBe(0);
+  });
+
+  it('leg 3 - a CALLER ABORT releases the holder through the controller’s single detach path', async () => {
+    // The store is captured from inside the render, so the assertions read the SAME holder the
+    // production path attached - not one the test constructed.
+    let captured: unknown;
+    const probe = (): JSX.Element =>
+      createComponent(Suspense, {
+        fallback: html('<p id="pending">loading reviews</p>'),
+        get children() {
+          captured = useSSRStore();
+          useDeferredData<{ count: number }>('reviews');
+
+          return html('<p id="reviews">never</p>');
+        },
+      }) as never;
+
+    const sink = new PassThrough();
+    const chunks: string[] = [];
+    sink.on('data', (c: Buffer) => chunks.push(String(c)));
+    sink.on('error', () => {});
+
+    let resolveReviews!: (value: Record<string, unknown>) => void;
+    const registry = deferredRegistry({ reviews: new Promise<Record<string, unknown>>((r) => (resolveReviews = r)) });
+    const errors: unknown[] = [];
+    const { renderStream } = createRenderer({
+      appComponent: probe,
+      headContent: () => '<title>t</title>',
+      streamOptions: { deferredTimeoutMs: 2_000, completionTimeoutMs: 5_000 },
+    });
+    const handle = renderStream(
+      sink,
+      { onHead: () => {}, onAllReady: () => {}, onError: (e) => errors.push(e) },
+      { critical: 1 },
+      '/product/42',
+      undefined,
+      {},
+      undefined,
+      {
+        deferredData: registry,
+        shouldHydrate: true,
+      },
+    );
+
+    await settle(80);
+    expect(getDeferredData(captured)).toBeDefined();
+    const holder = getDeferredData(captured) as DeferredDataHolder;
+
+    handle.abort();
+
+    // A caller abort is a BENIGN terminal, never a fatal one.
+    await expect(handle.done).resolves.toBeUndefined();
+    await settle(20);
+
+    // The terminal released the holder AND dropped the store's edge to it.
+    expect(() => holder.read('reviews')).toThrow(/read after the response terminal/);
+    expect(getDeferredData(captured)).toBeUndefined();
+
+    // A host promise that settles after the terminal writes nothing more: no late patch, no
+    // envelope, no fatal error.
+    const before = chunks.join('');
+    resolveReviews({ count: 3 });
+    await settle(60);
+
+    expect(chunks.join('')).toBe(before);
+    expect(before).not.toContain('reviews: 3');
+    expect(before).not.toContain('__TAUJS_DEFERRED_STATE__');
+    expect(errors).toEqual([]);
   });
 });
 

--- a/packages/solid/src/test/SSRDeferredData.test.ts
+++ b/packages/solid/src/test/SSRDeferredData.test.ts
@@ -5,7 +5,7 @@ import { PassThrough } from 'node:stream';
 
 import { createComponent, ErrorBoundary, Suspense } from 'solid-js';
 import { renderToStringAsync, ssr } from 'solid-js/web';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 import { createRenderer } from '../SSRRender.js';
 import { useSSRStore } from '../SSRDataStore.js';
@@ -179,20 +179,47 @@ describe('@taujs/solid deferred deadline (decision 18)', () => {
     }
   });
 
-  it('DEFAULT CONFIGURATION: the derived deadline is 15_000 and strictly precedes the fatal backstop', () => {
-    const DEFAULT_COMPLETION = 30_000;
-    const derived = Math.min(15_000, DEFAULT_COMPLETION / 2);
+  it('DEFAULT CONFIGURATION: the SHIPPED deadlines arm at 15_000 and 30_000, in that order', async () => {
+    // Deterministic (no 30-second run) and it OBSERVES THE MODULE rather than restating its
+    // derivation: the delays handed to `setTimeout` ARE the shipped relationship, so the cell fails
+    // the moment either default - the 15_000 cap or the 30_000 fatal backstop - moves.
+    const spy = vi.spyOn(globalThis, 'setTimeout');
 
-    expect(derived).toBe(15_000);
-    expect(derived).toBeLessThan(DEFAULT_COMPLETION);
+    await drive(page, { deferredData: deferredRegistry({ reviews: Promise.resolve({ count: 3 }) }), wait: 300 });
+
+    const armed = spy.mock.calls.map((call) => Number(call[1]));
+    spy.mockRestore();
+
+    // Armed at shell commit with what REMAINS of a 15_000 budget measured from renderStream entry.
+    const deferred = armed.filter((ms) => ms > 14_000 && ms <= 15_000);
+    expect(deferred).toHaveLength(1);
+    // The fatal completion backstop, armed at renderStream entry, is strictly LATER - so the
+    // graceful terminal is structurally reachable.
+    expect(armed).toContain(30_000);
+    expect(deferred[0]!).toBeLessThan(30_000);
+
     expect(() => createRenderer({ appComponent: page, headContent: () => '', streamOptions: { deferredTimeoutMs: 30_000 } })).toThrow(
       /must be strictly less than streamOptions.completionTimeoutMs/,
     );
   });
 
-  it('derives from a NON-default fatal backstop, so the graceful terminal stays reachable', () => {
-    expect(Math.min(15_000, 5_000 / 2)).toBe(2_500);
-    expect(() => createRenderer({ appComponent: page, headContent: () => '', streamOptions: { completionTimeoutMs: 5_000 } })).not.toThrow();
+  it('derives from a NON-default fatal backstop, so the graceful terminal stays reachable', async () => {
+    // A renderer configured with a 5s fatal backstop must derive 2.5s, not 15s - observed at the
+    // arming site rather than recomputed here.
+    const spy = vi.spyOn(globalThis, 'setTimeout');
+
+    await drive(page, {
+      deferredData: deferredRegistry({ reviews: Promise.resolve({ count: 3 }) }),
+      streamOptions: { completionTimeoutMs: 5_000 },
+      wait: 300,
+    });
+
+    const armed = spy.mock.calls.map((call) => Number(call[1]));
+    spy.mockRestore();
+
+    expect(armed).toContain(5_000);
+    expect(armed.filter((ms) => ms > 2_000 && ms <= 2_500)).toHaveLength(1);
+
     expect(() =>
       createRenderer({ appComponent: page, headContent: () => '', streamOptions: { completionTimeoutMs: 5_000, deferredTimeoutMs: 5_000 } }),
     ).toThrow();

--- a/packages/solid/src/test/SSRDeferredData.test.ts
+++ b/packages/solid/src/test/SSRDeferredData.test.ts
@@ -1,0 +1,285 @@
+// @vitest-environment node
+// RFC 0007 - @taujs/solid adapter: renderer contract items 1-9 against a REAL Solid stream render
+// and a REAL PassThrough.
+import { PassThrough } from 'node:stream';
+
+import { createComponent, ErrorBoundary, Suspense } from 'solid-js';
+import { ssr } from 'solid-js/web';
+import { describe, it, expect } from 'vitest';
+
+import { createRenderer } from '../SSRRender.js';
+import {
+  createDeferredAccessor,
+  createDeferredHolder,
+  createHydrationHolder,
+  DeferredDataError,
+  takeDeferredHydrationState,
+  useDeferredData,
+} from '../SSRDeferredData.js';
+
+import type { JSX } from 'solid-js';
+
+const html = (markup: string): JSX.Element => ssr(markup) as never;
+
+const settle = (ms = 60) => new Promise<void>((r) => setTimeout(r, ms));
+
+type Registry = Record<string, Promise<Record<string, unknown>>>;
+
+const deferredRegistry = (entries: Record<string, Promise<Record<string, unknown>>>): Registry => {
+  for (const promise of Object.values(entries)) promise.catch(() => {}); // the host pre-observes
+  return Object.freeze({ ...entries });
+};
+
+/** Shell content, then a Suspense boundary reading `reviews`, then tail content. */
+const page = (): JSX.Element =>
+  [
+    html('<div id="shell">shell</div>'),
+    createComponent(Suspense, {
+      fallback: html('<p id="pending">loading reviews</p>'),
+      get children() {
+        const inner = () => {
+          const reviews = useDeferredData<{ count: number }>('reviews');
+          return html(`<p id="reviews">reviews: ${String(reviews()?.count ?? '')}</p>`);
+        };
+
+        // PLACEMENT MATTERS (documented on `useDeferredData`): the ErrorBoundary sits INSIDE the
+        // Suspense, which is what makes the fallback reach the RESPONSE rather than the client.
+        return createComponent(ErrorBoundary, {
+          fallback: () => html('<p id="reviews-error">reviews unavailable</p>'),
+          get children() {
+            return inner();
+          },
+        });
+      },
+    }),
+    html('<p id="tail">tail content, after the boundary</p>'),
+  ] as never;
+
+const drive = async (appComponent: () => JSX.Element, opts: { deferredData?: Registry; streamOptions?: Record<string, number>; wait?: number } = {}) => {
+  const sink = new PassThrough();
+  const chunks: { at: number; text: string }[] = [];
+  const t0 = Date.now();
+  sink.on('data', (c: Buffer) => chunks.push({ at: Date.now() - t0, text: String(c) }));
+  sink.on('error', () => {});
+
+  const { renderStream } = createRenderer({ appComponent, headContent: () => '<title>t</title>', streamOptions: opts.streamOptions });
+  const errors: unknown[] = [];
+  const handle = renderStream(
+    sink,
+    { onHead: () => {}, onAllReady: () => {}, onError: (e) => errors.push(e) },
+    { critical: 1 },
+    '/product/42',
+    undefined,
+    {},
+    undefined,
+    { ...(opts.deferredData ? { deferredData: opts.deferredData } : {}), shouldHydrate: true },
+  );
+
+  await Promise.race([handle.done.catch(() => {}), settle(opts.wait ?? 600)]);
+  await settle(20);
+
+  return { chunks, html: chunks.map((c) => c.text).join(''), errors, handle };
+};
+
+describe('@taujs/solid deferred adapter - native projection (renderer contract 1-3)', () => {
+  it('OUT-OF-ORDER class: shell and tail precede the value, which Solid patches in itself', async () => {
+    let resolveReviews!: (v: Record<string, unknown>) => void;
+    const reviews = new Promise<Record<string, unknown>>((r) => (resolveReviews = r));
+
+    const driven = drive(page, { deferredData: deferredRegistry({ reviews }) });
+    await settle(120);
+    resolveReviews({ count: 3 });
+    const { chunks, html: out } = await driven;
+
+    expect(chunks[0]!.text).toContain('shell');
+    expect(chunks[0]!.text).toContain('loading reviews');
+    expect(chunks[0]!.text).toContain('tail content, after the boundary');
+    expect(chunks[0]!.text).not.toContain('reviews: 3');
+    expect(out).toContain('reviews: 3');
+    // Solid's OWN patch mechanism delivers the fragment - τjs writes none of those bytes.
+    expect(out).toContain('$df');
+    expect(out).not.toContain('__TAUJS_DEFERRED_STATE__');
+    expect(out).not.toContain('__INITIAL_DATA__');
+  });
+
+  it('a route with NO registry renders byte-identical output (no provider, no context id)', async () => {
+    const plain = (): JSX.Element =>
+      [
+        html('<div id="shell">shell</div>'),
+        createComponent(Suspense, {
+          fallback: html('<p>f</p>'),
+          get children() {
+            return html('<p id="content">content</p>');
+          },
+        }),
+      ] as never;
+
+    const a = await drive(plain);
+    const b = await drive(plain, { deferredData: deferredRegistry({ reviews: Promise.resolve({ count: 3 }) }) });
+
+    // A declared-but-UNCONSUMED registry must not shift a single hydration id or byte.
+    expect(b.html).toBe(a.html);
+  });
+});
+
+describe('@taujs/solid deferred adapter - failure legs (renderer contract 6, 7)', () => {
+  it('leg 1 - a consumed rejection reaches Solid’s SERVER-SIDE ErrorBoundary and the fallback completes the response', async () => {
+    const { html: out, handle } = await drive(page, {
+      deferredData: deferredRegistry({ reviews: Promise.reject(new Error('REVIEWS_BACKEND_SECRET')) }),
+    });
+
+    await expect(handle.done).resolves.toBeUndefined();
+    expect(out).toContain('reviews unavailable'); // the app's own fallback, IN the response
+    expect(out).not.toContain('REVIEWS_BACKEND_SECRET'); // the package's non-disableable sanitiser
+  });
+
+  it('leg 2 - an UNCONSUMED rejection raises no unhandledRejection and does not reverse the document', async () => {
+    const seen: unknown[] = [];
+    const onUnhandled = (e: unknown) => seen.push(e);
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      const shellOnly = (): JSX.Element => html('<div id="shell">shell only</div>');
+      const { html: out, errors } = await drive(shellOnly, { deferredData: deferredRegistry({ reviews: Promise.reject(new Error('nobody reads me')) }) });
+      await settle(30);
+      expect(out).toContain('shell only');
+      expect(errors).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+    expect(seen).toEqual([]);
+  });
+
+  it('an unknown key is a deterministic DEVELOPER error naming the declared set', () => {
+    const holder = createDeferredHolder(deferredRegistry({ reviews: Promise.resolve({ count: 1 }) }));
+
+    expect(() => holder.read('nope')).toThrow(/unknown deferred data key "nope"/);
+    expect(() => holder.read('nope')).toThrow(/"reviews"/);
+  });
+
+  it('reading without a registry is a deterministic developer error', async () => {
+    const orphan = (): JSX.Element => {
+      useDeferredData('reviews');
+      return html('<p/>');
+    };
+    const { errors } = await drive(orphan);
+
+    expect(String((errors[0] as Error)?.message)).toContain('requires a route declaring `attr.deferred`');
+  });
+});
+
+describe('@taujs/solid deferred deadline (decision 18)', () => {
+  it('rejects a non positive-finite value at the factory - there is no disable sentinel', () => {
+    for (const bad of [0, Infinity, -1, NaN, '5' as unknown as number]) {
+      expect(() => createRenderer({ appComponent: page, headContent: () => '', streamOptions: { deferredTimeoutMs: bad } })).toThrow(
+        /deferredTimeoutMs must be a positive finite number/,
+      );
+    }
+  });
+
+  it('DEFAULT CONFIGURATION: the derived deadline is 15_000 and strictly precedes the fatal backstop', () => {
+    const DEFAULT_COMPLETION = 30_000;
+    const derived = Math.min(15_000, DEFAULT_COMPLETION / 2);
+
+    expect(derived).toBe(15_000);
+    expect(derived).toBeLessThan(DEFAULT_COMPLETION);
+    expect(() => createRenderer({ appComponent: page, headContent: () => '', streamOptions: { deferredTimeoutMs: 30_000 } })).toThrow(
+      /must be strictly less than streamOptions.completionTimeoutMs/,
+    );
+  });
+
+  it('derives from a NON-default fatal backstop, so the graceful terminal stays reachable', () => {
+    expect(Math.min(15_000, 5_000 / 2)).toBe(2_500);
+    expect(() => createRenderer({ appComponent: page, headContent: () => '', streamOptions: { completionTimeoutMs: 5_000 } })).not.toThrow();
+    expect(() =>
+      createRenderer({ appComponent: page, headContent: () => '', streamOptions: { completionTimeoutMs: 5_000, deferredTimeoutMs: 5_000 } }),
+    ).toThrow();
+  });
+
+  it('leg 4 - on expiry the boundary errors NATIVELY, the app fallback reaches the response and the document terminates', async () => {
+    const { html: out, handle } = await drive(page, {
+      deferredData: deferredRegistry({ reviews: new Promise<Record<string, unknown>>(() => {}) }),
+      streamOptions: { deferredTimeoutMs: 80, completionTimeoutMs: 5_000 },
+      wait: 2_000,
+    });
+
+    await expect(handle.done).resolves.toBeUndefined();
+    expect(out).toContain('reviews unavailable');
+  });
+
+  it('the deadline LATCHES: a read whose first access arrives after expiry is born `aborted`', async () => {
+    const abandoned: string[][] = [];
+    const holder = createDeferredHolder(deferredRegistry({ reviews: new Promise<Record<string, unknown>>(() => {}) }), (keys) => abandoned.push([...keys]));
+
+    expect(holder.expire()).toBe(0); // nothing consumed yet
+    // A later read must not start a fresh unbounded wait: it is born abandoned and reported.
+    holder.read('reviews');
+    expect(abandoned).toEqual([['reviews']]);
+  });
+
+  it('the deadline is ONE per response, never per key', async () => {
+    const holder = createDeferredHolder(
+      deferredRegistry({ reviews: new Promise<Record<string, unknown>>(() => {}), stock: new Promise<Record<string, unknown>>(() => {}) }),
+    );
+
+    holder.read('reviews');
+    holder.read('stock');
+    expect(holder.expire()).toBe(2);
+  });
+});
+
+describe('@taujs/solid deferred adapter - retention (renderer contract 8)', () => {
+  it('release drops every reference and refuses later reads', () => {
+    const holder = createDeferredHolder(deferredRegistry({ reviews: Promise.resolve({ count: 1 }) }));
+
+    holder.read('reviews');
+    holder.release();
+
+    expect(() => holder.read('reviews')).toThrow(/read after the response terminal/);
+  });
+});
+
+describe('@taujs/solid deferred adapter - hydration (R4)', () => {
+  it('takeDeferredHydrationState reads the carrier once and deletes it; absent is normal', () => {
+    const w = globalThis as unknown as { window?: unknown };
+    const original = w.window;
+    w.window = { __TAUJS_DEFERRED_STATE__: { reviews: { status: 'complete', value: { count: 3 } } } };
+    try {
+      expect(takeDeferredHydrationState()).toEqual({ reviews: { status: 'complete', value: { count: 3 } } });
+      expect(takeDeferredHydrationState()).toBeUndefined();
+    } finally {
+      w.window = original;
+    }
+  });
+
+  it('the client holder seeds from the envelope and never fetches', () => {
+    const holder = createHydrationHolder({ reviews: { status: 'complete', value: { count: 3 } }, stock: { status: 'aborted' } });
+
+    expect(typeof holder.read('reviews')).toBe('function');
+    // `aborted` must NOT reach Solid's slot - the server terminated with that promise pending, so
+    // the read throws deterministically into the app's ErrorBoundary instead of hanging forever.
+    expect(() => (holder.read('stock') as () => unknown)()).toThrow(DeferredDataError);
+    expect(() => holder.read('nope')).toThrow(/unknown deferred data key/);
+  });
+});
+
+describe('@taujs/solid deferred adapter - typed facade', () => {
+  it('createDeferredAccessor derives the payload type from the route config', async () => {
+    type Deferred = { reviews: { count: number } };
+    const useDeferred = createDeferredAccessor<Deferred>();
+    const typed = (): JSX.Element =>
+      [
+        html('<div id="shell">shell</div>'),
+        createComponent(Suspense, {
+          fallback: html('<p>f</p>'),
+          get children() {
+            const reviews = useDeferred('reviews');
+            return html(`<p id="typed">count: ${String(reviews()?.count ?? '')}</p>`);
+          },
+        }),
+      ] as never;
+
+    const { html: out } = await drive(typed, { deferredData: deferredRegistry({ reviews: Promise.resolve({ count: 3 }) }) });
+
+    expect(out).toContain('count: 3');
+  });
+});

--- a/packages/solid/src/test/SSRDeferredData.test.ts
+++ b/packages/solid/src/test/SSRDeferredData.test.ts
@@ -58,11 +58,18 @@ const page = (): JSX.Element =>
     html('<p id="tail">tail content, after the boundary</p>'),
   ] as never;
 
-const drive = async (appComponent: () => JSX.Element, opts: { deferredData?: Registry; streamOptions?: Record<string, number>; wait?: number } = {}) => {
+const drive = async (
+  appComponent: () => JSX.Element,
+  opts: { deferredData?: Registry; streamOptions?: Record<string, number>; wait?: number; onChunk?: (text: string) => void } = {},
+) => {
   const sink = new PassThrough();
   const chunks: { at: number; text: string }[] = [];
   const t0 = Date.now();
-  sink.on('data', (c: Buffer) => chunks.push({ at: Date.now() - t0, text: String(c) }));
+  sink.on('data', (c: Buffer) => {
+    const text = String(c);
+    chunks.push({ at: Date.now() - t0, text });
+    opts.onChunk?.(text);
+  });
   sink.on('error', () => {});
 
   const { renderStream } = createRenderer({ appComponent, headContent: () => '<title>t</title>', streamOptions: opts.streamOptions });
@@ -89,11 +96,22 @@ describe('@taujs/solid deferred adapter - native projection (renderer contract 1
     let resolveReviews!: (v: Record<string, unknown>) => void;
     const reviews = new Promise<Record<string, unknown>>((r) => (resolveReviews = r));
 
-    const driven = drive(page, { deferredData: deferredRegistry({ reviews }) });
-    await settle(120);
-    resolveReviews({ count: 3 });
+    // Settlement is GATED on the flushed shell, never on a timer: a timed release can lose the
+    // race to Solid's first flush on a slow machine, and Solid then legitimately renders the
+    // value IN order - the cell would be probing scheduler luck rather than the ordering class.
+    let sawFallback = false;
+    const driven = drive(page, {
+      deferredData: deferredRegistry({ reviews }),
+      onChunk: (text) => {
+        if (!sawFallback && text.includes('loading reviews')) {
+          sawFallback = true;
+          resolveReviews({ count: 3 });
+        }
+      },
+    });
     const { chunks, html: out } = await driven;
 
+    expect(sawFallback).toBe(true);
     expect(chunks[0]!.text).toContain('shell');
     expect(chunks[0]!.text).toContain('loading reviews');
     expect(chunks[0]!.text).toContain('tail content, after the boundary');
@@ -396,7 +414,10 @@ describe('@taujs/solid deferred adapter - retention (renderer contract 8)', () =
       },
     );
 
-    await settle(80);
+    // Bounded poll rather than a fixed wait: the assertion needs the renderer to have reached
+    // the provider, which a slow machine may take longer than any single guessed delay.
+    const captureDeadline = Date.now() + 5_000;
+    while (getDeferredData(captured) === undefined && Date.now() < captureDeadline) await settle(10);
     expect(getDeferredData(captured)).toBeDefined();
     const holder = getDeferredData(captured) as DeferredDataHolder;
 

--- a/packages/solid/src/test/SSRDeferredData.test.ts
+++ b/packages/solid/src/test/SSRDeferredData.test.ts
@@ -203,6 +203,46 @@ describe('@taujs/solid deferred deadline (decision 18)', () => {
     );
   });
 
+  it('TIME ORIGIN: a costly shell arms what REMAINS of the budget, measured from renderStream ENTRY', async () => {
+    // The magnitude cell above cannot see decision 18's time-ORIGIN clause: with a ~0ms shell the
+    // remaining budget and the full budget are the same number. A CONTROLLED clock (no real waiting)
+    // charges the pre-shell phase exactly 6_000ms of the 15_000 budget, so the arming site must hand
+    // `startTimer` 9_000. Arming the FULL budget instead breaks the SHARED origin the two watchdogs
+    // rely on: the graceful deadline would land at entry+21s while the fatal completion backstop -
+    // armed AT entry - still fires at entry+30s, so the configured margin survives here only because
+    // the shell happened to be cheap.
+    const base = Date.now();
+    let elapsed = 0;
+    const clock = vi.spyOn(Date, 'now').mockImplementation(() => base + elapsed);
+    const spy = vi.spyOn(globalThis, 'setTimeout');
+    let armed: number[] = [];
+
+    try {
+      // The component body runs DURING the shell render - after renderStream entry, before
+      // `onCompleteShell`.
+      await drive(
+        () => {
+          elapsed = 6_000;
+
+          return page();
+        },
+        { deferredData: deferredRegistry({ reviews: Promise.resolve({ count: 3 }) }), wait: 300 },
+      );
+      armed = spy.mock.calls.map((call) => Number(call[1]));
+    } finally {
+      spy.mockRestore();
+      clock.mockRestore();
+    }
+
+    expect(armed).toContain(9_000); // 15_000 budget, 6_000 of it already spent before the shell
+    expect(armed.filter((ms) => ms > 14_000 && ms <= 15_000)).toHaveLength(0); // never the full budget
+    // Neither the shell timer nor the fatal completion backstop is re-based - both are armed AT
+    // entry - so the moved value is attributable to the deferred arming site rather than to a global
+    // clock shift.
+    expect(armed).toContain(10_000);
+    expect(armed).toContain(30_000);
+  });
+
   it('derives from a NON-default fatal backstop, so the graceful terminal stays reachable', async () => {
     // A renderer configured with a 5s fatal backstop must derive 2.5s, not 15s - observed at the
     // arming site rather than recomputed here.

--- a/packages/solid/src/test/SSRDeferredData.test.ts
+++ b/packages/solid/src/test/SSRDeferredData.test.ts
@@ -4,7 +4,7 @@
 import { PassThrough } from 'node:stream';
 
 import { createComponent, ErrorBoundary, Suspense } from 'solid-js';
-import { ssr } from 'solid-js/web';
+import { renderToStringAsync, ssr } from 'solid-js/web';
 import { describe, it, expect } from 'vitest';
 
 import { createRenderer } from '../SSRRender.js';
@@ -206,24 +206,70 @@ describe('@taujs/solid deferred deadline (decision 18)', () => {
     expect(out).toContain('reviews unavailable');
   });
 
-  it('the deadline LATCHES: a read whose first access arrives after expiry is born `aborted`', async () => {
+  it('the deadline LATCHES: a read whose FIRST access arrives after expiry is born `aborted`', async () => {
+    // The hole the latch closes: a boundary whose first read arrives after the deadline (an
+    // app-owned resource gated it) must NOT start a fresh unbounded wait - it is born abandoned and
+    // reported, so the document τjs is still holding open stays bounded.
     const abandoned: string[][] = [];
     const holder = createDeferredHolder(deferredRegistry({ reviews: new Promise<Record<string, unknown>>(() => {}) }), (keys) => abandoned.push([...keys]));
 
-    expect(holder.expire()).toBe(0); // nothing consumed yet
-    // A later read must not start a fresh unbounded wait: it is born abandoned and reported.
-    holder.read('reviews');
-    expect(abandoned).toEqual([['reviews']]);
-  });
+    expect(holder.expire()).toBe(0); // nothing consumed yet - the latch is set all the same
 
-  it('the deadline is ONE per response, never per key', async () => {
-    const holder = createDeferredHolder(
-      deferredRegistry({ reviews: new Promise<Record<string, unknown>>(() => {}), stock: new Promise<Record<string, unknown>>(() => {}) }),
+    // Read inside a REAL render: `createResource` requires a render context, which is the only
+    // context an application ever reads from.
+    const out = await renderToStringAsync(() =>
+      createComponent(Suspense, {
+        fallback: html('<p id="reviews-pending">loading</p>'),
+        get children() {
+          return createComponent(ErrorBoundary, {
+            fallback: () => html('<p id="reviews-error">reviews unavailable</p>'),
+            get children() {
+              const reviews = holder.read<{ count: number }>('reviews');
+
+              return html(`<p id="reviews">reviews: ${String(reviews()?.count ?? '')}</p>`);
+            },
+          });
+        },
+      }),
     );
 
-    holder.read('reviews');
-    holder.read('stock');
-    expect(holder.expire()).toBe(2);
+    expect(abandoned).toEqual([['reviews']]);
+    expect(out).toContain('reviews unavailable');
+  });
+
+  it('the deadline is ONE per response, never per key: two pending boundaries are abandoned together', async () => {
+    const twoKeys = (): JSX.Element =>
+      [
+        html('<div id="shell">shell</div>'),
+        ...(['reviews', 'stock'] as const).map((key) =>
+          createComponent(Suspense, {
+            fallback: html(`<p id="${key}-pending">loading</p>`),
+            get children() {
+              return createComponent(ErrorBoundary, {
+                fallback: () => html(`<p id="${key}-error">${key} unavailable</p>`),
+                get children() {
+                  const value = useDeferredData<{ count: number }>(key);
+
+                  return html(`<p id="${key}">${key}: ${String(value()?.count ?? '')}</p>`);
+                },
+              });
+            },
+          }),
+        ),
+      ] as never;
+
+    const { html: out, handle } = await drive(twoKeys, {
+      deferredData: deferredRegistry({
+        reviews: new Promise<Record<string, unknown>>(() => {}),
+        stock: new Promise<Record<string, unknown>>(() => {}),
+      }),
+      streamOptions: { deferredTimeoutMs: 80, completionTimeoutMs: 5_000 },
+      wait: 3_000,
+    });
+
+    await expect(handle.done).resolves.toBeUndefined();
+    expect(out).toContain('reviews unavailable');
+    expect(out).toContain('stock unavailable');
   });
 });
 
@@ -231,10 +277,11 @@ describe('@taujs/solid deferred adapter - retention (renderer contract 8)', () =
   it('release drops every reference and refuses later reads', () => {
     const holder = createDeferredHolder(deferredRegistry({ reviews: Promise.resolve({ count: 1 }) }));
 
-    holder.read('reviews');
     holder.release();
 
+    // A read after the terminal is a deterministic developer error, not a silent fresh wait.
     expect(() => holder.read('reviews')).toThrow(/read after the response terminal/);
+    expect(holder.expire()).toBe(0);
   });
 });
 
@@ -254,11 +301,13 @@ describe('@taujs/solid deferred adapter - hydration (R4)', () => {
   it('the client holder seeds from the envelope and never fetches', () => {
     const holder = createHydrationHolder({ reviews: { status: 'complete', value: { count: 3 } }, stock: { status: 'aborted' } });
 
-    expect(typeof holder.read('reviews')).toBe('function');
     // `aborted` must NOT reach Solid's slot - the server terminated with that promise pending, so
     // the read throws deterministically into the app's ErrorBoundary instead of hanging forever.
+    // (The `complete` path goes through Solid's own resource machinery and is proved end to end by
+    // the playground-solid browser suite, which runs it inside a real hydration context.)
     expect(() => (holder.read('stock') as () => unknown)()).toThrow(DeferredDataError);
     expect(() => holder.read('nope')).toThrow(/unknown deferred data key/);
+    expect(holder.keys).toEqual(['reviews', 'stock']);
   });
 });
 

--- a/packages/vue/src/SSRDeferredData.ts
+++ b/packages/vue/src/SSRDeferredData.ts
@@ -1,0 +1,346 @@
+import { inject, type InjectionKey } from 'vue';
+
+/**
+ * RFC 0007 - the @taujs/vue deferred-data adapter: the smallest projection of a named host promise
+ * into Vue's own async-`setup()` model.
+ *
+ *  - SERVER: `opts.deferredData` (the host's request-local registry) becomes one awaitable entry
+ *    per CONSUMED key. `@vue/server-renderer` does the suspending and delivers the resolved HTML
+ *    through its OWN streaming mechanism - τjs writes no bytes of its own for it.
+ *  - CLIENT: each consumed boundary is seeded from the private end-of-stream envelope, read at the
+ *    same rendezvous `hydrateApp` already uses for `window.__INITIAL_DATA__`, so hydration
+ *    re-executes no loader and issues no refetch.
+ *
+ * VUE GROUND TRUTH the design rests on:
+ *
+ *  1. `@vue/server-renderer` streams STRICTLY IN ORDER - an awaiting boundary holds every byte that
+ *     follows it in document order, and Vue SSR has no patch or instruction protocol at all. Under
+ *     decision 12 that is Vue's ordering class, not a contract shortfall. AUTHORING CONSEQUENCE:
+ *     place a deferred boundary AFTER the independent content that should stream immediately.
+ *  2. Vue SSR renders each subtree exactly once, so a boundary that catches an error has already
+ *     emitted its markup and only an empty node reaches the client. A caught error therefore cannot
+ *     substitute fallback UI into the response - which is why the detail-free RESULT read is Vue's
+ *     server-completing consumed-rejection path (decision 13) and the throwing read is a
+ *     renderer-native secondary.
+ *
+ * EXPORT HYGIENE (renderer contract item 9 / decision 10): only `createDeferredAccessor`,
+ * `useDeferredData`, `useDeferredDataResult`, `DeferredDataError` and the `DeferredResult` type
+ * reach `index.ts`. The carrier constant, both holders, the injection key, the provider and the
+ * hydration reader are private transport and stay unexported from the package root.
+ */
+
+/** @internal The host's internal transport (`RenderOptions.deferredData`), structurally re-stated. */
+export type DeferredDataRegistry = Readonly<Record<string, Promise<Record<string, unknown>>>>;
+
+/** @internal RFC 0007 (R4): the only three v1 outcomes. `failed` carries NO message, stack or detail. */
+export type DeferredOutcome = { status: 'complete'; value: Record<string, unknown> } | { status: 'failed' } | { status: 'aborted' };
+
+/** @internal */
+export type DeferredHydrationState = Readonly<Record<string, DeferredOutcome>>;
+
+/** The typed, per-key result an application branches on - structurally the envelope's own shape. */
+export type DeferredResult<T = Record<string, unknown>> = { status: 'complete'; value: T } | { status: 'failed' } | { status: 'aborted' };
+
+/**
+ * @internal The private, UNDOCUMENTED envelope carrier the host attaches at its existing
+ * end-of-stream write site, and only when the host-resolved hydration policy is on (decision 8).
+ */
+export const DEFERRED_STATE_CARRIER = '__TAUJS_DEFERRED_STATE__';
+
+/**
+ * The terminal error for a boundary whose value never arrived, rejected by the THROWING accessor.
+ * `key` is route CONFIGURATION, already visible in the application's own source; nothing here
+ * carries a server message, stack or cause.
+ */
+export class DeferredDataError extends Error {
+  readonly key: string;
+  readonly outcome: 'failed' | 'aborted';
+
+  constructor(key: string, outcome: 'failed' | 'aborted') {
+    super(`taujs: deferred data "${key}" did not arrive (${outcome})`);
+    this.name = 'DeferredDataError';
+    this.key = key;
+    this.outcome = outcome;
+  }
+}
+
+const unknownKeyError = (key: string, keys: readonly string[]): Error =>
+  new Error(
+    `taujs: unknown deferred data key "${key}". This route declares [${keys.map((k) => `"${k}"`).join(', ')}]. ` +
+      "Declared keys come from the route's `attr.deferred` record; the host does not validate reads.",
+  );
+
+const releasedError = (key: string): Error => new Error(`taujs: deferred data "${key}" was read after the response terminal; the holder has been released.`);
+
+const ownKey = (source: object, key: string): boolean => Object.prototype.hasOwnProperty.call(source, key);
+
+/**
+ * One consumed entry. Its promise NEVER rejects - it always settles with an outcome, which is what
+ * lets the deadline and the terminal settle a still-pending read WITHOUT touching the host's
+ * response-owned promise, and what makes an unobserved read incapable of raising
+ * `unhandledRejection`.
+ *
+ * `reason` is retained on the SERVER only, for the throwing read: it is whatever the host's
+ * registry promise rejected with, so a server-side `onErrorCaptured` / `app.config.errorHandler`
+ * observer sees what any other server error would give it. It never crosses to the client - the
+ * client holder is built from the detail-free envelope.
+ */
+type Settled = { result: DeferredResult; reason?: unknown };
+
+type Entry = { settled: Promise<Settled>; settle: (s: Settled) => void; pending: () => boolean };
+
+const createEntry = (): Entry => {
+  let pending = true;
+  let resolve!: (s: Settled) => void;
+  const settled = new Promise<Settled>((r) => (resolve = r));
+
+  return {
+    settled,
+    settle(s: Settled) {
+      if (!pending) return;
+      pending = false;
+      resolve(s);
+    },
+    pending: () => pending,
+  };
+};
+
+/**
+ * @internal The per-request (server) / per-root (client) holder. `resource()` and `result()` are
+ * SETUP-PHASE reads returning promises: an async `setup()` awaits one and Vue's own renderer does
+ * the suspending. The holder never renders, never writes bytes and never starts work.
+ */
+export type DeferredHolder = {
+  readonly keys: readonly string[];
+  /** Throwing read: rejects with the loader error (server) / `DeferredDataError` (client). */
+  resource: (key: string) => Promise<Record<string, unknown>>;
+  /** Result read: never rejects for a declared key; yields the detail-free outcome. */
+  result: (key: string) => Promise<DeferredResult>;
+  /**
+   * The response-level deferred deadline (decision 18). Settles every still-pending CONSUMED read
+   * as `aborted` so the in-order stream can finish with the application's own `aborted` branch
+   * rendered INTO the response, and LATCHES - a read registering afterwards is born `aborted`
+   * rather than starting a fresh unbounded wait. Returns how many were abandoned.
+   */
+  expire: () => number;
+  /** Terminal: abandon anything pending, then drop every retained value and source reference. */
+  release: () => void;
+};
+
+const createHolder = (keys: readonly string[], make: (key: string) => Entry, guard: (key: string) => void, onRelease: () => void): DeferredHolder => {
+  const entries = new Map<string, Entry>();
+  let released = false;
+  let expired = false;
+
+  const entryFor = (key: string): Entry => {
+    const existing = entries.get(key);
+    if (existing) return existing;
+    if (released) throw releasedError(key);
+    guard(key);
+
+    const entry = expired ? createEntry() : make(key);
+    if (expired) entry.settle({ result: { status: 'aborted' } });
+    entries.set(key, entry);
+
+    return entry;
+  };
+
+  const abandonPending = (): number => {
+    let abandoned = 0;
+    for (const entry of entries.values()) {
+      if (!entry.pending()) continue;
+      entry.settle({ result: { status: 'aborted' } });
+      abandoned += 1;
+    }
+
+    return abandoned;
+  };
+
+  return {
+    keys,
+
+    resource(key: string) {
+      return entryFor(key).settled.then((s) => {
+        if (s.result.status === 'complete') return s.result.value as Record<string, unknown>;
+        throw s.reason !== undefined ? s.reason : new DeferredDataError(key, s.result.status);
+      });
+    },
+
+    result: (key: string) => entryFor(key).settled.then((s) => s.result),
+
+    expire() {
+      expired = true;
+
+      return abandonPending();
+    },
+
+    release() {
+      if (released) return;
+      // Settle FIRST: a still-awaiting `unrollBuffer` must be released before references are
+      // dropped, or the render pipeline waits on a promise nothing will ever settle.
+      abandonPending();
+      released = true;
+      entries.clear();
+      onRelease();
+    },
+  };
+};
+
+/**
+ * @internal SERVER holder over the host's registry (renderer contract items 1, 7, 8).
+ *
+ * Entries are tracked LAZILY, on first read, so an UNCONSUMED key is never observed here and never
+ * counts towards the deadline - the host has already pre-observed every promise, so an unconsumed
+ * rejection stays harmless. The host's promises are never mutated or decorated.
+ */
+export const createDeferredHolder = (registry: DeferredDataRegistry): DeferredHolder => {
+  let source: DeferredDataRegistry | undefined = registry;
+  const keys = Object.freeze(Object.keys(registry));
+
+  return createHolder(
+    keys,
+    (key) => {
+      const entry = createEntry();
+      void source![key]!.then(
+        (value) => entry.settle({ result: { status: 'complete', value } }),
+        (reason) => entry.settle({ result: { status: 'failed' }, reason }),
+      );
+
+      return entry;
+    },
+    (key) => {
+      if (!source) throw releasedError(key);
+      if (!ownKey(source, key)) throw unknownKeyError(key, keys);
+    },
+    () => {
+      source = undefined;
+    },
+  );
+};
+
+/** @internal CLIENT holder over the private envelope. Every entry is already settled at creation. */
+export const createHydrationHolder = (state: DeferredHydrationState): DeferredHolder => {
+  const keys = Object.freeze(Object.keys(state));
+
+  return createHolder(
+    keys,
+    (key) => {
+      const entry = createEntry();
+      // No `reason`: server error detail never crosses the envelope.
+      entry.settle({ result: state[key] as DeferredResult });
+
+      return entry;
+    },
+    (key) => {
+      if (!ownKey(state, key)) throw unknownKeyError(key, keys);
+    },
+    () => {},
+  );
+};
+
+/** @internal */
+export const DEFERRED_DATA_KEY: InjectionKey<DeferredHolder> = Symbol('taujs:deferred-data');
+
+/**
+ * @internal APP-LEVEL provide, not a wrapper component, and applied ONLY when a registry (server)
+ * or an envelope (client) exists.
+ *
+ * This is not a style choice: a Vue provider component renders `slots.default?.()` as an ARRAY,
+ * which `@vue/server-renderer` renders as a Fragment bracketed by `<!--[-->`/`<!--]-->` anchors, so
+ * wrapping the tree would measurably change the bytes of a route that merely DECLARES deferred
+ * entries. `app.provide()` adds no node and no markup at all.
+ */
+export const provideDeferredHolder = (
+  app: { provide: (key: InjectionKey<DeferredHolder>, value: DeferredHolder) => unknown },
+  holder: DeferredHolder,
+): void => {
+  app.provide(DEFERRED_DATA_KEY, holder);
+};
+
+const holderOrThrow = (accessor: string, key: string): DeferredHolder => {
+  const holder = inject(DEFERRED_DATA_KEY, undefined);
+  if (!holder) {
+    throw new Error(
+      `taujs: ${accessor}("${key}") was called outside a deferred-data provider. ` +
+        "Only a `render: 'streaming'` route that declares `attr.deferred` provides one.",
+    );
+  }
+
+  return holder;
+};
+
+/**
+ * THROWING read - a renderer-native SECONDARY API. Returns a promise an async `setup()` awaits;
+ * a rejection reaches Vue's native error channel (`onErrorCaptured`, then
+ * `app.config.errorHandler`).
+ *
+ * SERVER CAVEAT, recorded and not worked around: Vue SSR renders each subtree exactly once, so a
+ * boundary that catches the error has already emitted its markup and emits an EMPTY node - it
+ * cannot substitute fallback UI into the response, and the same component re-renders its caught
+ * fallback on the client, which is a hydration mismatch by construction. Prefer
+ * {@link useDeferredDataResult} for any entry that can fail.
+ *
+ * Must be called SYNCHRONOUSLY in `setup()` (before the first `await`): it injects.
+ */
+export function useDeferredData<T extends Record<string, unknown> = Record<string, unknown>>(key: string): Promise<T> {
+  return holderOrThrow('useDeferredData', key).resource(key) as Promise<T>;
+}
+
+/**
+ * RESULT read - the PRIMARY Vue accessor and its server-completing consumed-rejection path
+ * (decision 13).
+ *
+ * The returned promise never rejects for a declared key: the application branches on
+ * `complete` / `failed` / `aborted` and renders the branch it wants, so a handled failure fallback
+ * COMPLETES THE RESPONSE and server and client render the identical branch from the identical
+ * detail-free outcome. `failed` and `aborted` carry no value, message, stack or cause.
+ *
+ * Must be called SYNCHRONOUSLY in `setup()` (before the first `await`): it injects.
+ */
+export function useDeferredDataResult<T extends Record<string, unknown> = Record<string, unknown>>(key: string): Promise<DeferredResult<T>> {
+  return holderOrThrow('useDeferredDataResult', key).result(key) as Promise<DeferredResult<T>>;
+}
+
+/**
+ * The typed component-facing façade. `D` comes from the route config
+ * (`DeferredDataOf<typeof route>`), so the key is checked and the payload type DERIVED:
+ *
+ * ```ts
+ * const deferred = createDeferredAccessor<DeferredDataOf<typeof productRoute>>();
+ * const outcome = await deferred.result('reviews'); // DeferredResult<{ count: number }>
+ * const value = await deferred.data('reviews'); // { count: number }, rejects on failure
+ * ```
+ *
+ * A factory rather than a two-type-parameter function on purpose: TypeScript cannot infer one type
+ * argument while another is supplied explicitly, so a two-parameter read would collapse the return
+ * type to a union over every declared key. It returns an OBJECT with two methods because Vue needs
+ * both reads to be first-class - the result read for anything that can fail, the throwing read for
+ * the native error channel.
+ */
+export function createDeferredAccessor<D>() {
+  return {
+    data: <K extends keyof D & string>(key: K): Promise<D[K]> => useDeferredData(key) as unknown as Promise<D[K]>,
+    result: <K extends keyof D & string>(key: K): Promise<DeferredResult<D[K]>> => useDeferredDataResult(key) as unknown as Promise<DeferredResult<D[K]>>,
+  };
+}
+
+/**
+ * @internal Read the private envelope ONCE and drop the carrier.
+ *
+ * An ABSENT carrier is the ordinary case - a route that declared nothing, and (decision 8)
+ * `hydrate: false` - never an error and never a reason to fetch.
+ */
+export const takeDeferredHydrationState = (): DeferredHydrationState | undefined => {
+  try {
+    const w = window as unknown as Record<string, unknown>;
+    const raw = w[DEFERRED_STATE_CARRIER];
+    delete w[DEFERRED_STATE_CARRIER];
+
+    if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+
+    return raw as DeferredHydrationState;
+  } catch {
+    // A hostile or absent global must never break bootstrap.
+    return undefined;
+  }
+};

--- a/packages/vue/src/SSRHydration.ts
+++ b/packages/vue/src/SSRHydration.ts
@@ -1,8 +1,10 @@
 import { createApp, createSSRApp, h, nextTick, type App, type Component, type VNode } from 'vue';
 
 import { createSSRStore, SSRStoreProvider } from './SSRDataStore.js';
+import { createHydrationHolder, provideDeferredHolder, takeDeferredHydrationState } from './SSRDeferredData.js';
 import { createUILogger, createVueErrorHandler } from './utils/Logger.js';
 
+import type { DeferredHolder } from './SSRDeferredData.js';
 import type { LoggerLike } from './utils/Logger.js';
 
 // Dev-only introspection hook, set by the server-injected dev script (never by users).
@@ -100,7 +102,12 @@ export function hydrateApp<T>({
     return appComponent as Component;
   };
 
-  const mountCSR = (rootEl: HTMLElement, initialData: T) => {
+  // RFC 0007 (R4): the holder is provided APP-LEVEL and ONLY when the private envelope was present,
+  // so a page whose route declared nothing builds exactly the tree it builds today and one that did
+  // adds no node (a wrapper component would add Fragment anchors the server markup does not have).
+  // Every seeded entry is ALREADY SETTLED, so a hydrating boundary's `await` resolves on the first
+  // microtask: no loader (there is none on this side), no refetch, no second data phase.
+  const mountCSR = (rootEl: HTMLElement, initialData: T, deferred?: DeferredHolder) => {
     rootEl.innerHTML = '';
 
     const store = createSSRStore(initialData);
@@ -109,6 +116,8 @@ export function hydrateApp<T>({
       name: 'TauJsCSR',
       render: () => h(SSRStoreProvider, { store }, { default: () => h(normalizeRoot()) }),
     });
+
+    if (deferred) provideDeferredHolder(app, deferred);
 
     try {
       // Same setupApp runs on the CSR path so it works whether the client hydrates or falls
@@ -131,7 +140,7 @@ export function hydrateApp<T>({
     }
   };
 
-  const startHydration = (rootEl: HTMLElement, initialData: T) => {
+  const startHydration = (rootEl: HTMLElement, initialData: T, deferred?: DeferredHolder) => {
     // Lifecycle messages only - the route-data payload and the store object are NOT logged, so debug
     // logging cannot disclose request data through a supplied (e.g. Pino) logger.
     if (enableDebug) log('Hydration started');
@@ -163,6 +172,8 @@ export function hydrateApp<T>({
         name: 'TauJsHydration',
         render: () => h(SSRStoreProvider, { store }, { default: () => h(normalizeRoot()) }),
       });
+
+      if (deferred) provideDeferredHolder(app, deferred);
 
       // R4: configure the app (setupApp) before notifying, so onStart/onSuccess and the
       // mount all see a fully-configured app. A throw here is caught below and routed to
@@ -240,14 +251,26 @@ export function hydrateApp<T>({
 
     const data = (window as any)[dataKey] as T | undefined;
 
+    // RFC 0007 (R4): read the private envelope at the EXACT rendezvous `window[dataKey]` is already
+    // read at, and drop the carrier - one synchronous property access, no event, no listener, no
+    // network. `taujs:data-ready` is deliberately NOT used: it dispatches before this code runs.
+    //
+    // VUE DIVERGENCE FROM REACT, and it is load-bearing: @taujs/vue writes its bootstrap tag as
+    // `<script type="module" async>` BEFORE the host appends the data script, so an `async` module
+    // can execute while the document is still parsing. `bootstrap()` runs from the existing
+    // DOMContentLoaded deferral below, which is the only point at which BOTH scripts are guaranteed
+    // to have executed. React's module-evaluation-time reasoning must not be copied here.
+    const deferredState = takeDeferredHydrationState();
+    const deferred = deferredState ? createHydrationHolder(deferredState) : undefined;
+
     if (data === undefined) {
       const empty = {} as T;
       if (enableDebug) warn(`No initial SSR data at window["${dataKey}"]. Mounting CSR.`);
-      mountCSR(rootEl, empty);
+      mountCSR(rootEl, empty, deferred);
       return;
     }
 
-    startHydration(rootEl, data);
+    startHydration(rootEl, data, deferred);
   };
 
   if (document.readyState !== 'loading') {

--- a/packages/vue/src/SSRRender.ts
+++ b/packages/vue/src/SSRRender.ts
@@ -305,7 +305,13 @@ export function createRenderer<
     // The R narrowing seam (RFC 0004 H6).
     const routeContext = opts?.routeContext as R | undefined;
     const effectiveShellTimeout = opts?.shellTimeoutMs ?? shellTimeoutMs;
-    const effectiveDeferredTimeout = opts?.deferredTimeoutMs ?? deferredTimeoutMs;
+    // RFC 0007 (decision 18): the deferred deadline is NOT per-call overridable. It is "one latched
+    // deadline per response, positive finite only, VALIDATED AT BOOT" - and a per-call seam is not
+    // boot, so honouring `opts.deferredTimeoutMs` would put an unvalidated value (0, -1, NaN,
+    // Infinity, a string from untyped JS) straight into the timer and the operator warning. The
+    // factory-validated value is the only one this renderer uses; Solid takes no override either.
+    // The field remains legal on the call bag only because `StreamCallOptions` intersects
+    // `StreamOptions`; it is deliberately ignored here.
     // RFC 0007 (decision 18): the deadline's time ORIGIN. It is armed later (at shell commit) but
     // measured from here, so the bound is a property of the configuration rather than of how long
     // the first chunk happened to take.
@@ -332,9 +338,9 @@ export function createRenderer<
           // LATCH FIRST, unconditionally: a read registering later must be born `aborted` rather
           // than start a fresh unbounded wait. The count only decides whether to say anything.
           const abandoned = deferredHolder?.expire() ?? 0;
-          if (abandoned > 0) warn(`Deferred data not ready after ${effectiveDeferredTimeout}ms; abandoning the pending boundaries`, { location, abandoned });
+          if (abandoned > 0) warn(`Deferred data not ready after ${deferredTimeoutMs}ms; abandoning the pending boundaries`, { location, abandoned });
         },
-        Math.max(effectiveDeferredTimeout - (Date.now() - renderStartedAt), 1),
+        Math.max(deferredTimeoutMs - (Date.now() - renderStartedAt), 1),
       );
     };
 

--- a/packages/vue/src/SSRRender.ts
+++ b/packages/vue/src/SSRRender.ts
@@ -50,7 +50,8 @@ export type StreamOptions = {
    * POSITIVE FINITE only, validated at the factory - there is no disable sentinel, because this
    * deadline is what keeps "bounded total response time" true. Default 15_000ms: `@taujs/vue`
    * declares no finite post-shell fatal backstop for it to halve (`shellTimeoutMs` bounds the
-   * pre-shell phase only and is stopped before this deadline is armed).
+   * pre-shell phase only and is stopped before this deadline is armed). FACTORY-ONLY: there is no
+   * per-call form, because a per-call seam is not boot.
    */
   deferredTimeoutMs?: number;
 };
@@ -93,7 +94,10 @@ type SSRResult = {
   teleports?: Record<string, string>;
 };
 
-type StreamCallOptions<R> = StreamOptions & {
+// RFC 0007 (decision 18): `deferredTimeoutMs` is OMITTED rather than silently ignored. The deferred
+// deadline is "one latched deadline per response, positive finite only, VALIDATED AT BOOT" - a
+// per-call seam is not boot, so there is no per-call form of it and the call bag must not offer one.
+type StreamCallOptions<R> = Omit<StreamOptions, 'deferredTimeoutMs'> & {
   logger?: LoggerLike;
   // RFC 0004 (H6): broad at the contract boundary; narrowed to R/H at the internal seams.
   routeContext?: unknown;
@@ -305,13 +309,6 @@ export function createRenderer<
     // The R narrowing seam (RFC 0004 H6).
     const routeContext = opts?.routeContext as R | undefined;
     const effectiveShellTimeout = opts?.shellTimeoutMs ?? shellTimeoutMs;
-    // RFC 0007 (decision 18): the deferred deadline is NOT per-call overridable. It is "one latched
-    // deadline per response, positive finite only, VALIDATED AT BOOT" - and a per-call seam is not
-    // boot, so honouring `opts.deferredTimeoutMs` would put an unvalidated value (0, -1, NaN,
-    // Infinity, a string from untyped JS) straight into the timer and the operator warning. The
-    // factory-validated value is the only one this renderer uses; Solid takes no override either.
-    // The field remains legal on the call bag only because `StreamCallOptions` intersects
-    // `StreamOptions`; it is deliberately ignored here.
     // RFC 0007 (decision 18): the deadline's time ORIGIN. It is armed later (at shell commit) but
     // measured from here, so the bound is a property of the configuration rather than of how long
     // the first chunk happened to take.

--- a/packages/vue/src/SSRRender.ts
+++ b/packages/vue/src/SSRRender.ts
@@ -2,10 +2,12 @@ import { createSSRApp, h, type App, type Component, type VNode } from 'vue';
 import { renderToSimpleStream, renderToString, type SimpleReadable, type SSRContext } from '@vue/server-renderer';
 
 import { createSSRStore, SSRStoreProvider, type SSRStore } from './SSRDataStore.js';
+import { createDeferredHolder, provideDeferredHolder } from './SSRDeferredData.js';
 import { escapeHtml } from './utils/Html.js';
 import { createUILogger } from './utils/Logger.js';
 
 import type { Writable } from 'node:stream';
+import type { DeferredDataRegistry, DeferredHolder } from './SSRDeferredData.js';
 import type { LoggerLike } from './utils/Logger.js';
 
 import { createStreamController, isBenignStreamErr, startShellTimer, wireWritableGuards } from './utils/Streaming.js';
@@ -33,6 +35,24 @@ export type StreamOptions = {
    * boundaries — there is no React-style shell phase, so this guards first-byte latency.
    */
   shellTimeoutMs?: number;
+  /**
+   * RFC 0007 (decision 18): the ONE response-level deferred completion deadline.
+   *
+   * Measured from `renderStream` ENTRY, armed at shell commit (the first streamed chunk) with
+   * whatever remains of the budget, never reset per key, and LATCHED - a boundary whose first read
+   * arrives after expiry is born `aborted` rather than starting a fresh unbounded wait. Vue streams
+   * strictly in order and has no client-render instruction, so the Vue spelling of "abandon the
+   * boundary" is to settle every still-pending consumed read as `aborted`: the application's own
+   * `aborted` branch renders INTO the response, the stream resumes and the document terminates
+   * normally. The stream controller is never touched - abandoning a boundary is a normal
+   * completion, not a stream failure.
+   *
+   * POSITIVE FINITE only, validated at the factory - there is no disable sentinel, because this
+   * deadline is what keeps "bounded total response time" true. Default 15_000ms: `@taujs/vue`
+   * declares no finite post-shell fatal backstop for it to halve (`shellTimeoutMs` bounds the
+   * pre-shell phase only and is stopped before this deadline is armed).
+   */
+  deferredTimeoutMs?: number;
 };
 
 /**
@@ -82,9 +102,16 @@ type StreamCallOptions<R> = StreamOptions & {
   // shouldHydrate is the host-resolved hydration policy.
   cspNonce?: string;
   shouldHydrate?: boolean;
+  // RFC 0007 (decision 14): the host's request-local deferred registry - present ONLY when the
+  // route declares `attr.deferred`. Already started, already pre-observed; the renderer neither
+  // starts nor re-observes them, it only projects them onto Vue's async-`setup()` model.
+  deferredData?: DeferredDataRegistry;
 };
 
 const NOOP = () => {};
+
+/** RFC 0007 (decision 18): the deferred deadline's default, and the cap on any derivation of it. */
+const DEFERRED_TIMEOUT_DEFAULT_MS = 15_000;
 
 function normalizeRootComponent(root: Component | ((props: any) => VNode), props: any): Component {
   // Treat as render function if it doesn't look like a Vue component
@@ -97,13 +124,25 @@ function normalizeRootComponent(root: Component | ((props: any) => VNode), props
   return { name: 'TauJsRoot', render: () => h(root as any, props) };
 }
 
-function createAppWithStore<T>(store: SSRStore<T>, root: Component | ((props: any) => VNode), rootProps: any): ReturnType<typeof createSSRApp> {
+function createAppWithStore<T>(
+  store: SSRStore<T>,
+  root: Component | ((props: any) => VNode),
+  rootProps: any,
+  // RFC 0007: applied ONLY when the host passed a registry, and as an APP-LEVEL provide rather than
+  // a wrapper component, so a route declaring deferred entries adds no node and no markup (see
+  // `provideDeferredHolder`).
+  deferred?: DeferredHolder,
+): ReturnType<typeof createSSRApp> {
   const Root = normalizeRootComponent(root, rootProps);
 
-  return createSSRApp({
+  const app = createSSRApp({
     name: 'TauJsSSR',
     render: () => h(SSRStoreProvider, { store }, { default: () => h(Root) }),
   });
+
+  if (deferred) provideDeferredHolder(app, deferred);
+
+  return app;
 }
 
 /**
@@ -160,7 +199,15 @@ export function createRenderer<
    */
   setupApp?: (app: App) => void;
 }) {
-  const { shellTimeoutMs = 10_000 } = streamOptions;
+  const { shellTimeoutMs = 10_000, deferredTimeoutMs = DEFERRED_TIMEOUT_DEFAULT_MS } = streamOptions;
+
+  // RFC 0007 (decision 18): POSITIVE FINITE only - there is no 0/Infinity disable sentinel, because
+  // this deadline is what bounds the response.
+  if (!(typeof deferredTimeoutMs === 'number' && Number.isFinite(deferredTimeoutMs) && deferredTimeoutMs > 0)) {
+    throw new TypeError(
+      `createRenderer: streamOptions.deferredTimeoutMs must be a positive finite number of milliseconds (received ${String(deferredTimeoutMs)})`,
+    );
+  }
 
   // RFC 0004 (H6): contract-facing parameter types are BROAD (the H2 regularisation model) so a
   // renderer instantiated with non-default generics stays assignable to the host contracts under
@@ -258,8 +305,38 @@ export function createRenderer<
     // The R narrowing seam (RFC 0004 H6).
     const routeContext = opts?.routeContext as R | undefined;
     const effectiveShellTimeout = opts?.shellTimeoutMs ?? shellTimeoutMs;
+    const effectiveDeferredTimeout = opts?.deferredTimeoutMs ?? deferredTimeoutMs;
+    // RFC 0007 (decision 18): the deadline's time ORIGIN. It is armed later (at shell commit) but
+    // measured from here, so the bound is a property of the configuration rather than of how long
+    // the first chunk happened to take.
+    const renderStartedAt = Date.now();
 
     const controller = createStreamController(writable, { log, warn, error });
+
+    // RFC 0007. Declared ABOVE the guards-cleanup composition below, so EVERY terminal the
+    // controller owns disarms the deadline and releases the holder.
+    let deferredHolder: DeferredHolder | undefined;
+    let deferredTimer: ReturnType<typeof setTimeout> | undefined;
+    const stopDeferredDeadline = () => {
+      if (deferredTimer !== undefined) clearTimeout(deferredTimer);
+      deferredTimer = undefined;
+    };
+    const armDeferredDeadline = () => {
+      if (!deferredHolder || deferredTimer !== undefined) return;
+
+      deferredTimer = setTimeout(
+        () => {
+          deferredTimer = undefined;
+          if (controller.isAborted) return;
+
+          // LATCH FIRST, unconditionally: a read registering later must be born `aborted` rather
+          // than start a fresh unbounded wait. The count only decides whether to say anything.
+          const abandoned = deferredHolder?.expire() ?? 0;
+          if (abandoned > 0) warn(`Deferred data not ready after ${effectiveDeferredTimeout}ms; abandoning the pending boundaries`, { location, abandoned });
+        },
+        Math.max(effectiveDeferredTimeout - (Date.now() - renderStartedAt), 1),
+      );
+    };
 
     // Advisory observers are ISOLATED (hardening-lessons §1): a throw is logged and swallowed - it
     // must never enter the fatal path, escape the framework boundary (these run inside Vue's
@@ -317,7 +394,22 @@ export function createRenderer<
       fatalAbort: (err) => fail(err),
       onFinish: () => controller.complete('Stream finished (normal completion)'),
     });
-    controller.setGuardsCleanup(guardsCleanup);
+    // RFC 0007 (renderer contract item 8): release the holder on every terminal, composed into the
+    // controller's existing single cleanup path. Release also SETTLES anything still pending as
+    // `aborted`, so a mid-flight `unrollBuffer` await is never left waiting on a promise nothing
+    // will settle.
+    controller.setGuardsCleanup(() => {
+      try {
+        guardsCleanup();
+      } catch {}
+      try {
+        stopDeferredDeadline();
+      } catch {}
+      try {
+        deferredHolder?.release();
+      } catch {}
+      deferredHolder = undefined;
+    });
 
     // Time-to-first-content watchdog: fires only if no chunk is produced before it expires.
     const stopShellTimer = startShellTimer(effectiveShellTimeout, () => {
@@ -381,6 +473,10 @@ export function createRenderer<
             stopShellTimer();
           } catch {}
           log('Shell ready:', location);
+          // RFC 0007 (decision 18): armed at shell commit, with the remainder of a budget measured
+          // from renderStream entry. Before the shell there is no document to complete, and a
+          // pre-shell stall is the shell timer's to report.
+          armDeferredDeadline();
           try {
             cb.onShellReady();
           } catch (cbErr) {
@@ -411,7 +507,10 @@ export function createRenderer<
       // strategy's T narrowing seam (RFC 0004 H6).
       const s = createSSRStore(initialData as T | Promise<T> | (() => Promise<T>));
       store = s;
-      const app = createAppWithStore(s, appComponent, { location, routeContext });
+      // RFC 0007: the holder exists ONLY when the host passed a registry, so a no-deferred route
+      // builds the identical tree and emits identical bytes.
+      deferredHolder = opts?.deferredData ? createDeferredHolder(opts.deferredData) : undefined;
+      const app = createAppWithStore(s, appComponent, { location, routeContext }, deferredHolder);
 
       // App-instance customization before render (a throw is caught by this try and routed
       // through fail → onError + fatal abort).

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,4 +1,11 @@
 export * from './SSRDataStore.js';
+// RFC 0007 (decision 19, renderer contract item 9): the package's PUBLIC surface for this feature
+// is the component-facing accessors and their result/error types, and NOTHING else. The carrier
+// constant, both holders, the injection key, the provider and the hydration reader are private
+// transport and stay unexported - a private transport must not become an importable package
+// surface. Pinned by `test/SSRDeferredData.exports.test.ts`.
+export { createDeferredAccessor, DeferredDataError, useDeferredData, useDeferredDataResult } from './SSRDeferredData.js';
+export type { DeferredResult } from './SSRDeferredData.js';
 export * from './SSRHydration.js';
 export * from './SSRRender.js';
 

--- a/packages/vue/src/test/SSRDeferredData.exports.test.ts
+++ b/packages/vue/src/test/SSRDeferredData.exports.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment node
+// RFC 0007 (decision 10 / renderer contract item 9): the package's PUBLIC surface for this feature
+// is the component-facing accessors and their result/error types - and nothing else.
+import { describe, it, expect } from 'vitest';
+
+import * as pkg from '../index';
+import * as internals from '../SSRDeferredData';
+
+const PUBLIC = ['createDeferredAccessor', 'DeferredDataError', 'useDeferredData', 'useDeferredDataResult'];
+
+const FORBIDDEN = [
+  'DEFERRED_STATE_CARRIER',
+  'DEFERRED_DATA_KEY',
+  'createDeferredHolder',
+  'createHydrationHolder',
+  'provideDeferredHolder',
+  'takeDeferredHydrationState',
+];
+
+describe('@taujs/vue deferred-data export hygiene', () => {
+  it('exports exactly the frozen public spellings (decision 19)', () => {
+    for (const name of PUBLIC) expect(Object.keys(pkg)).toContain(name);
+  });
+
+  it('exports NONE of the private transport', () => {
+    for (const name of FORBIDDEN) {
+      expect(internals).toHaveProperty(name);
+      expect(Object.keys(pkg)).not.toContain(name);
+    }
+  });
+
+  it('never exposes the carrier NAME through any exported value', () => {
+    for (const value of Object.values(pkg)) {
+      if (typeof value === 'string') expect(value).not.toContain('__TAUJS_DEFERRED_STATE__');
+    }
+  });
+});

--- a/packages/vue/src/test/SSRDeferredData.hydration.test.ts
+++ b/packages/vue/src/test/SSRDeferredData.hydration.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+// RFC 0007 (R4): hydration seeding from the private envelope - read at the SAME rendezvous
+// `window.__INITIAL_DATA__` is read at, carrier deleted after the read, absent carrier normal.
+import { createSSRApp, defineComponent, h, Suspense } from 'vue';
+import { renderToString } from '@vue/server-renderer';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { hydrateApp } from '../SSRHydration';
+import {
+  createDeferredHolder,
+  createHydrationHolder,
+  DeferredDataError,
+  provideDeferredHolder,
+  takeDeferredHydrationState,
+  useDeferredDataResult,
+} from '../SSRDeferredData';
+
+const CARRIER = '__TAUJS_DEFERRED_STATE__';
+
+const flush = (ms = 40) => new Promise<void>((r) => setTimeout(r, ms));
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="root"></div>';
+  delete (window as unknown as Record<string, unknown>)[CARRIER];
+  delete (window as unknown as Record<string, unknown>)['__INITIAL_DATA__'];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('takeDeferredHydrationState', () => {
+  it('reads the carrier ONCE and deletes it', () => {
+    (window as unknown as Record<string, unknown>)[CARRIER] = { reviews: { status: 'complete', value: { count: 3 } } };
+
+    expect(takeDeferredHydrationState()).toEqual({ reviews: { status: 'complete', value: { count: 3 } } });
+    expect(CARRIER in window).toBe(false);
+    expect(takeDeferredHydrationState()).toBeUndefined();
+  });
+
+  it('an ABSENT or hostile carrier is the ordinary case, never an error', () => {
+    expect(takeDeferredHydrationState()).toBeUndefined();
+    for (const hostile of [null, 42, 'nope', [1, 2]]) {
+      (window as unknown as Record<string, unknown>)[CARRIER] = hostile;
+      expect(takeDeferredHydrationState()).toBeUndefined();
+    }
+  });
+});
+
+describe('the client holder seeds from the envelope with NO refetch', () => {
+  it('every entry is already settled and detail-free', async () => {
+    const holder = createHydrationHolder({
+      reviews: { status: 'complete', value: { count: 3 } },
+      blurb: { status: 'failed' },
+      stock: { status: 'aborted' },
+    });
+
+    await expect(holder.result('reviews')).resolves.toEqual({ status: 'complete', value: { count: 3 } });
+    await expect(holder.result('blurb')).resolves.toEqual({ status: 'failed' });
+    await expect(holder.result('stock')).resolves.toEqual({ status: 'aborted' });
+
+    const err = await holder.resource('blurb').catch((e) => e as DeferredDataError);
+    expect(err).toBeInstanceOf(DeferredDataError);
+    expect(err.outcome).toBe('failed');
+  });
+
+  it('an unknown key is a deterministic developer error naming the declared set', () => {
+    const holder = createHydrationHolder({ reviews: { status: 'complete', value: {} } });
+
+    expect(() => holder.result('nope')).toThrow(/unknown deferred data key "nope"/);
+  });
+});
+
+describe('hydrateApp seeds consumed boundaries from the envelope', () => {
+  const Reviews = defineComponent({
+    name: 'Reviews',
+    async setup() {
+      const result = await useDeferredDataResult<{ count: number }>('reviews');
+      return () =>
+        result.status === 'complete'
+          ? h('p', { id: 'reviews' }, `reviews: ${result.value.count}`)
+          : h('p', { id: 'fallback' }, `reviews unavailable (${result.status})`);
+    },
+  });
+  // The authoring shape a Vue application uses for an async `setup()`: on the client an async
+  // setup needs a `<Suspense>` boundary, and Vue SSR renders that boundary's DEFAULT slot - so the
+  // server and client trees are the same tree.
+  const Page = defineComponent({ name: 'Page', setup: () => () => h('main', [h(Suspense, null, { default: () => h(Reviews) })]) });
+
+  /** Render the SAME tree through @vue/server-renderer, so hydration runs against real SSR markup. */
+  const serverHtml = async (outcome: Record<string, unknown>) => {
+    const app = createSSRApp({ name: 'TauJsHydration', render: () => h(Page) });
+    provideDeferredHolder(app, createDeferredHolder(Object.freeze({ reviews: outcome['reviews'] as Promise<Record<string, unknown>> })));
+
+    return renderToString(app);
+  };
+
+  it('renders the complete value with no loader and no fetch', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    document.getElementById('root')!.innerHTML = await serverHtml({ reviews: Promise.resolve({ count: 3 }) });
+    (window as unknown as Record<string, unknown>)['__INITIAL_DATA__'] = { critical: 1 };
+    (window as unknown as Record<string, unknown>)[CARRIER] = { reviews: { status: 'complete', value: { count: 3 } } };
+
+    hydrateApp({ appComponent: Page });
+    await flush();
+
+    expect(document.getElementById('reviews')!.textContent).toBe('reviews: 3');
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(CARRIER in window).toBe(false);
+  });
+
+  it('an `aborted` outcome hydrates the SAME detail-free branch the server rendered', async () => {
+    const abandoned = createDeferredHolder(Object.freeze({ reviews: new Promise<Record<string, unknown>>(() => {}) }));
+    abandoned.expire();
+    const app = createSSRApp({ name: 'TauJsHydration', render: () => h(Page) });
+    provideDeferredHolder(app, abandoned);
+    document.getElementById('root')!.innerHTML = await renderToString(app);
+    expect(document.getElementById('root')!.innerHTML).toContain('reviews unavailable (aborted)');
+    (window as unknown as Record<string, unknown>)['__INITIAL_DATA__'] = {};
+    (window as unknown as Record<string, unknown>)[CARRIER] = { reviews: { status: 'aborted' } };
+
+    const onHydrationError = vi.fn();
+    hydrateApp({ appComponent: Page, onHydrationError });
+    await flush();
+
+    expect(document.getElementById('fallback')!.textContent).toBe('reviews unavailable (aborted)');
+    expect(onHydrationError).not.toHaveBeenCalled();
+  });
+
+  it('a page with NO carrier hydrates exactly as it does today', async () => {
+    document.getElementById('root')!.innerHTML = '<main><p id="plain">plain</p></main>';
+    (window as unknown as Record<string, unknown>)['__INITIAL_DATA__'] = {};
+
+    const Plain = defineComponent({ name: 'Plain', setup: () => () => h('main', [h('p', { id: 'plain' }, 'plain')]) });
+    const onHydrationError = vi.fn();
+    hydrateApp({ appComponent: Plain, onHydrationError });
+    await flush();
+
+    expect(document.getElementById('plain')!.textContent).toBe('plain');
+    expect(onHydrationError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/vue/src/test/SSRDeferredData.stream.test.ts
+++ b/packages/vue/src/test/SSRDeferredData.stream.test.ts
@@ -3,12 +3,13 @@
 // @vue/server-renderer and a REAL PassThrough.
 import { PassThrough } from 'node:stream';
 
-import { defineComponent, h } from 'vue';
+import { defineComponent, h, inject } from 'vue';
 import { describe, it, expect, vi } from 'vitest';
 
 import { createRenderer, type StreamOptions } from '../SSRRender';
-import { createDeferredAccessor, createDeferredHolder, DeferredDataError, useDeferredData, useDeferredDataResult } from '../SSRDeferredData';
+import { createDeferredAccessor, createDeferredHolder, DeferredDataError, DEFERRED_DATA_KEY, useDeferredData, useDeferredDataResult } from '../SSRDeferredData';
 
+import type { DeferredHolder } from '../SSRDeferredData';
 import type { Component } from 'vue';
 
 const settle = (ms = 60) => new Promise<void>((r) => setTimeout(r, ms));
@@ -323,15 +324,35 @@ describe('@taujs/vue deferred adapter - retention (renderer contract 8)', () => 
     expect(() => holder.result('reviews')).toThrow(/read after the response terminal/);
   });
 
-  it('a manual abort releases the holder through the controller’s single cleanup path', async () => {
+  it('the RENDERER releases the holder at a terminal: a later read of the INJECTED holder is refused', async () => {
+    // The holder is captured from inside the render, through the adapter's own injection key, so
+    // the assertion reads the SAME holder the production path provided - the test never releases
+    // it, so deleting the renderer's cleanup call fails this cell.
+    let captured: DeferredHolder | undefined;
+    const Capture = defineComponent({
+      name: 'Capture',
+      async setup() {
+        captured = inject(DEFERRED_DATA_KEY, undefined);
+        const result = await useDeferredDataResult<{ count: number }>('reviews');
+
+        return () => h('p', { id: 'reviews' }, result.status === 'complete' ? `reviews: ${result.value.count}` : `reviews unavailable (${result.status})`);
+      },
+    });
+
     const writable = new PassThrough();
     const registry = deferredRegistry({ reviews: new Promise<Record<string, unknown>>(() => {}) });
-    const { renderStream } = createRenderer({ appComponent: page(ReviewsResult), headContent: () => '' });
+    const { renderStream } = createRenderer({ appComponent: page(Capture), headContent: () => '' });
     const handle = renderStream(writable, { onHead: () => {} }, {}, '/x', undefined, {}, undefined, { deferredData: registry });
     await settle(40);
+    expect(captured).toBeDefined();
+
     handle.abort();
 
+    // A caller abort is a BENIGN terminal, never a fatal one.
     await expect(handle.done).resolves.toBeUndefined();
+    await settle(20);
+
+    expect(() => captured!.result('reviews')).toThrow(/read after the response terminal/);
   });
 });
 

--- a/packages/vue/src/test/SSRDeferredData.stream.test.ts
+++ b/packages/vue/src/test/SSRDeferredData.stream.test.ts
@@ -21,11 +21,18 @@ const deferredRegistry = (entries: Record<string, Promise<Record<string, unknown
   return Object.freeze({ ...entries });
 };
 
-const drive = async (appComponent: Component, opts: { deferredData?: Registry; streamOptions?: StreamOptions; wait?: number } = {}) => {
+const drive = async (
+  appComponent: Component,
+  opts: { deferredData?: Registry; streamOptions?: StreamOptions; wait?: number; onChunk?: (text: string) => void } = {},
+) => {
   const writable = new PassThrough();
   const chunks: { at: number; text: string }[] = [];
   const t0 = Date.now();
-  writable.on('data', (c) => chunks.push({ at: Date.now() - t0, text: c.toString() }));
+  writable.on('data', (c) => {
+    const text = c.toString();
+    chunks.push({ at: Date.now() - t0, text });
+    opts.onChunk?.(text);
+  });
 
   const { renderStream } = createRenderer({ appComponent, headContent: () => '<title>t</title>', streamOptions: opts.streamOptions });
   const errors: unknown[] = [];
@@ -79,19 +86,36 @@ describe('@taujs/vue deferred adapter - native projection (renderer contract 1-3
     let resolveReviews!: (v: Record<string, unknown>) => void;
     const reviews = new Promise<Record<string, unknown>>((r) => (resolveReviews = r));
 
-    const driven = drive(page(Reviews), { deferredData: deferredRegistry({ reviews }) });
-    await settle(120);
-    resolveReviews({ count: 3 });
+    // Settlement is GATED on the flushed preceding content, never on a timer: a timed release can
+    // lose the race to Vue's first flush on a slow machine, collapsing everything into one chunk
+    // and turning the ordering assertions into scheduler luck.
+    let sawPreceding = false;
+    const driven = drive(page(Reviews), {
+      deferredData: deferredRegistry({ reviews }),
+      onChunk: (text) => {
+        if (!sawPreceding && text.includes('independent content')) {
+          sawPreceding = true;
+          resolveReviews({ count: 3 });
+        }
+      },
+    });
     const { chunks, html } = await driven;
 
-    const beforeAt = chunks.find((c) => c.text.includes('independent content'))!.at;
-    const valueAt = chunks.find((c) => c.text.includes('reviews: 3'))!.at;
-    const afterAt = chunks.find((c) => c.text.includes('after the boundary'))!.at;
+    expect(sawPreceding).toBe(true);
 
-    expect(beforeAt).toBeLessThan(valueAt);
+    // Chunk INDICES, not timestamps: order is the claim, and a same-millisecond flush after the
+    // gated release would make a time comparison probe clock resolution instead of the stream.
+    const beforeIdx = chunks.findIndex((c) => c.text.includes('independent content'));
+    const valueIdx = chunks.findIndex((c) => c.text.includes('reviews: 3'));
+    const afterIdx = chunks.findIndex((c) => c.text.includes('after the boundary'));
+
+    expect(beforeIdx).toBeGreaterThanOrEqual(0);
+    // The gate released the value only after the preceding-content chunk was already emitted, so
+    // a strictly later chunk must carry it.
+    expect(valueIdx).toBeGreaterThan(beforeIdx);
     // Vue's in-order stream holds everything AFTER an awaited boundary - the honest ordering class,
     // and the reason the authoring rule is "place the boundary last in the region you care about".
-    expect(afterAt).toBeGreaterThanOrEqual(valueAt);
+    expect(afterIdx).toBeGreaterThanOrEqual(valueIdx);
     expect(html).toContain('reviews: 3');
   });
 

--- a/packages/vue/src/test/SSRDeferredData.stream.test.ts
+++ b/packages/vue/src/test/SSRDeferredData.stream.test.ts
@@ -240,6 +240,45 @@ describe('@taujs/vue deferred deadline (decision 18)', () => {
     expect(armed.filter((ms) => ms >= 10_000)).toEqual([10_000, deferred[0]!]);
   });
 
+  it('TIME ORIGIN: a costly shell arms what REMAINS of the budget, measured from renderStream ENTRY', async () => {
+    // The magnitude cell above cannot see decision 18's time-ORIGIN clause: with a ~0ms shell the
+    // remaining budget and the full budget are the same number. A CONTROLLED clock (no real waiting)
+    // charges the pre-shell phase exactly 6_000ms of the 15_000 budget, so the arming site must hand
+    // `setTimeout` 9_000. Arming the FULL budget instead would make the bound a property of how long
+    // the first chunk happened to take rather than of the configuration - the total response time
+    // would run to entry+21s here, and further with a slower shell.
+    const base = Date.now();
+    let elapsed = 0;
+    const inner = page(Reviews);
+    // `setup` runs DURING the shell render - after renderStream entry, before the first chunk.
+    const CostlyPage = defineComponent({
+      name: 'CostlyPage',
+      setup() {
+        elapsed = 6_000;
+
+        return () => h(inner);
+      },
+    });
+
+    const clock = vi.spyOn(Date, 'now').mockImplementation(() => base + elapsed);
+    const spy = vi.spyOn(globalThis, 'setTimeout');
+    let armed: number[] = [];
+
+    try {
+      await drive(CostlyPage, { deferredData: deferredRegistry({ reviews: Promise.resolve({ count: 3 }) }), wait: 300 });
+      armed = spy.mock.calls.map((call) => Number(call[1]));
+    } finally {
+      spy.mockRestore();
+      clock.mockRestore();
+    }
+
+    expect(armed).toContain(9_000); // 15_000 budget, 6_000 of it already spent before the shell
+    expect(armed.filter((ms) => ms > 14_000 && ms <= 15_000)).toHaveLength(0); // never the full budget
+    // The shell timer is armed AT entry and is not re-based, so the moved value is attributable to
+    // the deferred arming site rather than to a global clock shift.
+    expect(armed).toContain(10_000);
+  });
+
   it('leg 4 - on expiry the still-pending boundary renders its `aborted` branch INTO the response and the document terminates', async () => {
     const { html, handle } = await drive(page(ReviewsResult), {
       deferredData: deferredRegistry({ reviews: new Promise<Record<string, unknown>>(() => {}) }),

--- a/packages/vue/src/test/SSRDeferredData.stream.test.ts
+++ b/packages/vue/src/test/SSRDeferredData.stream.test.ts
@@ -4,7 +4,7 @@
 import { PassThrough } from 'node:stream';
 
 import { defineComponent, h } from 'vue';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 import { createRenderer, type StreamOptions } from '../SSRRender';
 import { createDeferredAccessor, createDeferredHolder, DeferredDataError, useDeferredData, useDeferredDataResult } from '../SSRDeferredData';
@@ -218,16 +218,26 @@ describe('@taujs/vue deferred deadline (decision 18)', () => {
     }
   });
 
-  it('DEFAULT CONFIGURATION: the deadline is 15_000 and no other post-shell deadline competes with it', () => {
-    // Proven deterministically from the shipped defaults rather than by a 15-second run: the
-    // package's only other bound, `shellTimeoutMs`, guards the PRE-shell phase and is stopped at
-    // the first chunk - which is the exact moment this deadline is armed. They cannot race.
-    const DEFAULT_DEFERRED = 15_000;
-    const DEFAULT_SHELL = 10_000;
+  it('DEFAULT CONFIGURATION: the SHIPPED deadline arms at 15_000, and no other post-shell deadline competes with it', async () => {
+    // Deterministic (no 15-second run) and it OBSERVES THE MODULE rather than restating it: the
+    // delay handed to `setTimeout` at the arming site is the shipped default minus what the shell
+    // already spent, so this cell fails the moment the default moves in EITHER direction.
+    const spy = vi.spyOn(globalThis, 'setTimeout');
 
-    expect(() => createRenderer({ appComponent: page(Reviews), headContent: () => '' })).not.toThrow();
-    expect(DEFAULT_DEFERRED).toBeGreaterThan(0);
-    expect(Number.isFinite(DEFAULT_SHELL)).toBe(true);
+    await drive(page(Reviews), { deferredData: deferredRegistry({ reviews: Promise.resolve({ count: 3 }) }), wait: 300 });
+
+    const armed = spy.mock.calls.map((call) => Number(call[1]));
+    spy.mockRestore();
+
+    // Armed at shell commit with what REMAINS of a 15_000 budget measured from renderStream entry.
+    const deferred = armed.filter((ms) => ms > 14_000 && ms <= 15_000);
+    expect(deferred).toHaveLength(1);
+
+    // The package's only other bound, `shellTimeoutMs`, guards the PRE-shell phase and is stopped at
+    // the first chunk - the exact moment this deadline is armed. They cannot race, and there is no
+    // third armed bound between them.
+    expect(armed).toContain(10_000);
+    expect(armed.filter((ms) => ms >= 10_000)).toEqual([10_000, deferred[0]!]);
   });
 
   it('leg 4 - on expiry the still-pending boundary renders its `aborted` branch INTO the response and the document terminates', async () => {

--- a/packages/vue/src/test/SSRDeferredData.stream.test.ts
+++ b/packages/vue/src/test/SSRDeferredData.stream.test.ts
@@ -175,6 +175,40 @@ describe('@taujs/vue deferred adapter - failure legs (renderer contract 6, 7)', 
   });
 });
 
+describe('@taujs/vue deferred adapter - CSP and hydration policy (renderer contract 5)', () => {
+  it('every inline script the renderer emits on a deferred route carries the nonce', async () => {
+    const writable = new PassThrough();
+    const chunks: string[] = [];
+    writable.on('data', (c) => chunks.push(c.toString()));
+    const { renderStream } = createRenderer({ appComponent: page(Reviews), headContent: () => '' });
+    const handle = renderStream(writable, { onHead: () => {} }, {}, '/x', '/bootstrap.js', {}, undefined, {
+      deferredData: deferredRegistry({ reviews: Promise.resolve({ count: 3 }) }),
+      cspNonce: 'NONCE123',
+      shouldHydrate: true,
+    });
+    await Promise.race([handle.done.catch(() => {}), settle(400)]);
+    const html = chunks.join('');
+
+    const scripts = html.match(/<script[^>]*>/g) ?? [];
+    expect(scripts.length).toBeGreaterThan(0);
+    for (const tag of scripts) expect(tag).toContain('nonce="NONCE123"');
+  });
+
+  it('hydrate:false still streams the late boundary natively (the envelope is the host’s concern)', async () => {
+    const writable = new PassThrough();
+    const chunks: string[] = [];
+    writable.on('data', (c) => chunks.push(c.toString()));
+    const { renderStream } = createRenderer({ appComponent: page(Reviews), headContent: () => '' });
+    const handle = renderStream(writable, { onHead: () => {} }, {}, '/x', undefined, {}, undefined, {
+      deferredData: deferredRegistry({ reviews: Promise.resolve({ count: 3 }) }),
+      shouldHydrate: false,
+    });
+    await Promise.race([handle.done.catch(() => {}), settle(400)]);
+
+    expect(chunks.join('')).toContain('reviews: 3');
+  });
+});
+
 describe('@taujs/vue deferred deadline (decision 18)', () => {
   it('rejects a non positive-finite value at the factory - there is no disable sentinel', () => {
     for (const bad of [0, Infinity, -1, NaN, '5' as unknown as number]) {

--- a/packages/vue/src/test/SSRDeferredData.stream.test.ts
+++ b/packages/vue/src/test/SSRDeferredData.stream.test.ts
@@ -1,0 +1,271 @@
+// @vitest-environment node
+// RFC 0007 - @taujs/vue server adapter: renderer contract items 1-9 against REAL
+// @vue/server-renderer and a REAL PassThrough.
+import { PassThrough } from 'node:stream';
+
+import { defineComponent, h } from 'vue';
+import { describe, it, expect } from 'vitest';
+
+import { createRenderer, type StreamOptions } from '../SSRRender';
+import { createDeferredAccessor, createDeferredHolder, DeferredDataError, useDeferredData, useDeferredDataResult } from '../SSRDeferredData';
+
+import type { Component } from 'vue';
+
+const settle = (ms = 60) => new Promise<void>((r) => setTimeout(r, ms));
+
+type Registry = Record<string, Promise<Record<string, unknown>>>;
+
+const deferredRegistry = (entries: Record<string, Promise<Record<string, unknown>>>): Registry => {
+  for (const promise of Object.values(entries)) promise.catch(() => {}); // the host pre-observes
+  return Object.freeze({ ...entries });
+};
+
+const drive = async (appComponent: Component, opts: { deferredData?: Registry; streamOptions?: StreamOptions; wait?: number } = {}) => {
+  const writable = new PassThrough();
+  const chunks: { at: number; text: string }[] = [];
+  const t0 = Date.now();
+  writable.on('data', (c) => chunks.push({ at: Date.now() - t0, text: c.toString() }));
+
+  const { renderStream } = createRenderer({ appComponent, headContent: () => '<title>t</title>', streamOptions: opts.streamOptions });
+  const errors: unknown[] = [];
+  const handle = renderStream(
+    writable,
+    { onHead: () => {}, onAllReady: () => {}, onError: (e) => errors.push(e) },
+    { critical: 1 },
+    '/product/42',
+    undefined,
+    {},
+    undefined,
+    { ...(opts.deferredData ? { deferredData: opts.deferredData } : {}), shouldHydrate: true },
+  );
+
+  await Promise.race([handle.done.catch(() => {}), settle(opts.wait ?? 500)]);
+  await settle(20);
+
+  return { chunks, html: chunks.map((c) => c.text).join(''), errors, handle, t0 };
+};
+
+const Reviews = defineComponent({
+  name: 'Reviews',
+  async setup() {
+    const data = await useDeferredData<{ count: number }>('reviews');
+    return () => h('p', { id: 'reviews' }, `reviews: ${data.count}`);
+  },
+});
+
+const ReviewsResult = defineComponent({
+  name: 'ReviewsResult',
+  async setup() {
+    const result = await useDeferredDataResult<{ count: number }>('reviews');
+    return () =>
+      result.status === 'complete'
+        ? h('p', { id: 'reviews' }, `reviews: ${result.value.count}`)
+        : h('p', { id: 'fallback' }, `reviews unavailable (${result.status})`);
+  },
+});
+
+const page = (boundary: Component) =>
+  defineComponent({
+    name: 'Page',
+    setup() {
+      return () =>
+        h('main', [h('p', { id: 'before' }, 'independent content, before the boundary'), h(boundary), h('p', { id: 'after' }, 'after the boundary')]);
+    },
+  });
+
+describe('@taujs/vue deferred adapter - native projection (renderer contract 1-3)', () => {
+  it('IN-ORDER class (decision 12): independent content PRECEDING the boundary streams before the value', async () => {
+    let resolveReviews!: (v: Record<string, unknown>) => void;
+    const reviews = new Promise<Record<string, unknown>>((r) => (resolveReviews = r));
+
+    const driven = drive(page(Reviews), { deferredData: deferredRegistry({ reviews }) });
+    await settle(120);
+    resolveReviews({ count: 3 });
+    const { chunks, html } = await driven;
+
+    const beforeAt = chunks.find((c) => c.text.includes('independent content'))!.at;
+    const valueAt = chunks.find((c) => c.text.includes('reviews: 3'))!.at;
+    const afterAt = chunks.find((c) => c.text.includes('after the boundary'))!.at;
+
+    expect(beforeAt).toBeLessThan(valueAt);
+    // Vue's in-order stream holds everything AFTER an awaited boundary - the honest ordering class,
+    // and the reason the authoring rule is "place the boundary last in the region you care about".
+    expect(afterAt).toBeGreaterThanOrEqual(valueAt);
+    expect(html).toContain('reviews: 3');
+  });
+
+  it('delivers the late boundary through VUE’s own stream - there is no patch protocol and τjs emits no bytes', async () => {
+    const { html } = await drive(page(Reviews), { deferredData: deferredRegistry({ reviews: Promise.resolve({ count: 3 }) }) });
+
+    expect(html).toContain('reviews: 3');
+    expect(html).not.toMatch(/\$RC|\$RV|\$RX|<template id=|<div hidden id=/);
+    expect(html).not.toContain('__TAUJS_DEFERRED_STATE__');
+    expect(html).not.toContain('__INITIAL_DATA__');
+  });
+
+  it('a route with NO registry renders byte-identical output (the provide adds no node)', async () => {
+    const Plain = defineComponent({ name: 'Plain', setup: () => () => h('p', 'content') });
+
+    const a = await drive(page(Plain));
+    const b = await drive(page(Plain), { deferredData: deferredRegistry({ reviews: Promise.resolve({ count: 3 }) }) });
+
+    // A declared-but-UNCONSUMED registry must not add a single byte - no Fragment anchors.
+    expect(b.html).toBe(a.html);
+  });
+});
+
+describe('@taujs/vue deferred adapter - failure legs (renderer contract 6, 7)', () => {
+  it('leg 1 - a consumed rejection completes the RESPONSE through the detail-free result accessor', async () => {
+    const { html, errors } = await drive(page(ReviewsResult), {
+      deferredData: deferredRegistry({ reviews: Promise.reject(new Error('REVIEWS_BACKEND_SECRET')) }),
+    });
+
+    expect(html).toContain('reviews unavailable (failed)');
+    expect(html).not.toContain('REVIEWS_BACKEND_SECRET');
+    expect(errors).toEqual([]);
+  });
+
+  it('leg 2 - an UNCONSUMED rejection raises no unhandledRejection and does not reverse the document', async () => {
+    const seen: unknown[] = [];
+    const onUnhandled = (e: unknown) => seen.push(e);
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      const Plain = defineComponent({ name: 'Plain', setup: () => () => h('p', 'shell only') });
+      const { html, errors } = await drive(page(Plain), { deferredData: deferredRegistry({ reviews: Promise.reject(new Error('nobody reads me')) }) });
+      await settle(30);
+      expect(html).toContain('shell only');
+      expect(errors).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+    expect(seen).toEqual([]);
+  });
+
+  it('an unknown key is a deterministic DEVELOPER error naming the declared set', () => {
+    const holder = createDeferredHolder(deferredRegistry({ reviews: Promise.resolve({ count: 1 }) }));
+
+    expect(() => holder.result('nope')).toThrow(/unknown deferred data key "nope"/);
+    expect(() => holder.result('nope')).toThrow(/"reviews"/);
+  });
+
+  it('reading outside a provider is a deterministic developer error', async () => {
+    const Orphan = defineComponent({
+      name: 'Orphan',
+      async setup() {
+        await useDeferredData('reviews');
+        return () => h('p');
+      },
+    });
+    const { errors } = await drive(page(Orphan));
+
+    expect(String((errors[0] as Error)?.message)).toContain('was called outside a deferred-data provider');
+  });
+
+  it('the THROWING read rejects with the loader error server-side (Vue’s native error channel)', async () => {
+    const holder = createDeferredHolder(deferredRegistry({ reviews: Promise.reject(new Error('loader detail')) }));
+
+    await expect(holder.resource('reviews')).rejects.toThrow('loader detail');
+  });
+
+  it('the CLIENT never sees server detail: the hydration holder rejects with a DeferredDataError only', async () => {
+    const { createHydrationHolder } = await import('../SSRDeferredData');
+    const holder = createHydrationHolder({ reviews: { status: 'failed' } });
+
+    await expect(holder.resource('reviews')).rejects.toBeInstanceOf(DeferredDataError);
+  });
+});
+
+describe('@taujs/vue deferred deadline (decision 18)', () => {
+  it('rejects a non positive-finite value at the factory - there is no disable sentinel', () => {
+    for (const bad of [0, Infinity, -1, NaN, '5' as unknown as number]) {
+      expect(() => createRenderer({ appComponent: page(Reviews), headContent: () => '', streamOptions: { deferredTimeoutMs: bad } })).toThrow(
+        /deferredTimeoutMs must be a positive finite number/,
+      );
+    }
+  });
+
+  it('DEFAULT CONFIGURATION: the deadline is 15_000 and no other post-shell deadline competes with it', () => {
+    // Proven deterministically from the shipped defaults rather than by a 15-second run: the
+    // package's only other bound, `shellTimeoutMs`, guards the PRE-shell phase and is stopped at
+    // the first chunk - which is the exact moment this deadline is armed. They cannot race.
+    const DEFAULT_DEFERRED = 15_000;
+    const DEFAULT_SHELL = 10_000;
+
+    expect(() => createRenderer({ appComponent: page(Reviews), headContent: () => '' })).not.toThrow();
+    expect(DEFAULT_DEFERRED).toBeGreaterThan(0);
+    expect(Number.isFinite(DEFAULT_SHELL)).toBe(true);
+  });
+
+  it('leg 4 - on expiry the still-pending boundary renders its `aborted` branch INTO the response and the document terminates', async () => {
+    const { html, handle } = await drive(page(ReviewsResult), {
+      deferredData: deferredRegistry({ reviews: new Promise<Record<string, unknown>>(() => {}) }),
+      streamOptions: { deferredTimeoutMs: 80 },
+      wait: 800,
+    });
+
+    await expect(handle.done).resolves.toBeUndefined();
+    expect(html).toContain('reviews unavailable (aborted)');
+    expect(html).toContain('after the boundary'); // the in-order stream resumed
+  });
+
+  it('the deadline LATCHES: a read whose first access arrives after expiry is born `aborted`', async () => {
+    const holder = createDeferredHolder(deferredRegistry({ reviews: new Promise<Record<string, unknown>>(() => {}) }));
+
+    expect(holder.expire()).toBe(0); // nothing consumed yet
+    await expect(holder.result('reviews')).resolves.toEqual({ status: 'aborted' });
+  });
+
+  it('the deadline is ONE per response, never per key: a second key pending at expiry is abandoned with the first', async () => {
+    const holder = createDeferredHolder(
+      deferredRegistry({ reviews: new Promise<Record<string, unknown>>(() => {}), stock: new Promise<Record<string, unknown>>(() => {}) }),
+    );
+
+    void holder.result('reviews');
+    void holder.result('stock');
+    expect(holder.expire()).toBe(2);
+    await expect(holder.result('reviews')).resolves.toEqual({ status: 'aborted' });
+    await expect(holder.result('stock')).resolves.toEqual({ status: 'aborted' });
+  });
+});
+
+describe('@taujs/vue deferred adapter - retention (renderer contract 8)', () => {
+  it('release settles anything pending FIRST, then refuses later reads', async () => {
+    const holder = createDeferredHolder(deferredRegistry({ reviews: new Promise<Record<string, unknown>>(() => {}) }));
+
+    const pending = holder.result('reviews');
+    holder.release();
+
+    // A mid-flight `unrollBuffer` await must never be left waiting on a promise nothing settles.
+    await expect(pending).resolves.toEqual({ status: 'aborted' });
+    expect(() => holder.result('reviews')).toThrow(/read after the response terminal/);
+  });
+
+  it('a manual abort releases the holder through the controller’s single cleanup path', async () => {
+    const writable = new PassThrough();
+    const registry = deferredRegistry({ reviews: new Promise<Record<string, unknown>>(() => {}) });
+    const { renderStream } = createRenderer({ appComponent: page(ReviewsResult), headContent: () => '' });
+    const handle = renderStream(writable, { onHead: () => {} }, {}, '/x', undefined, {}, undefined, { deferredData: registry });
+    await settle(40);
+    handle.abort();
+
+    await expect(handle.done).resolves.toBeUndefined();
+  });
+});
+
+describe('@taujs/vue deferred adapter - typed facade', () => {
+  it('createDeferredAccessor derives both reads from the route config', async () => {
+    type Deferred = { reviews: { count: number } };
+    const deferred = createDeferredAccessor<Deferred>();
+    const Typed = defineComponent({
+      name: 'Typed',
+      async setup() {
+        const outcome = await deferred.result('reviews');
+        return () => h('p', { id: 'typed' }, outcome.status === 'complete' ? `count: ${outcome.value.count}` : 'unavailable');
+      },
+    });
+
+    const { html } = await drive(page(Typed), { deferredData: deferredRegistry({ reviews: Promise.resolve({ count: 3 }) }) });
+
+    expect(html).toContain('count: 3');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.17)
+      playwright-core:
+        specifier: 1.44.1
+        version: 1.44.1
       tsx:
         specifier: ^4.19.3
         version: 4.23.0
@@ -63,6 +66,9 @@ importers:
       vite:
         specifier: ^7.3.6
         version: 7.3.6(@types/node@20.19.43)(tsx@4.23.0)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(@types/node@20.19.43)(@vitest/ui@3.2.7)(happy-dom@20.11.0)(jsdom@25.0.1)(tsx@4.23.0)
 
   fixtures/playground-solid:
     dependencies:
@@ -125,6 +131,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: ^6.0.0
         version: 6.0.7(vite@7.3.6(@types/node@20.19.43)(tsx@4.23.0))(vue@3.5.39(typescript@5.9.3))
+      playwright-core:
+        specifier: 1.44.1
+        version: 1.44.1
       tsx:
         specifier: ^4.19.3
         version: 4.23.0
@@ -134,6 +143,9 @@ importers:
       vite:
         specifier: ^7.1.11
         version: 7.3.6(@types/node@20.19.43)(tsx@4.23.0)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(@types/node@20.19.43)(@vitest/ui@3.2.7)(happy-dom@20.11.0)(jsdom@25.0.1)(tsx@4.23.0)
       vue-tsc:
         specifier: ^2.1.10
         version: 2.2.12(typescript@5.9.3)

--- a/website/src/content/docs/guides/data-loading.md
+++ b/website/src/content/docs/guides/data-loading.md
@@ -164,6 +164,11 @@ once per request outside the component tree, cancels it with the request, record
 async work a component starts for itself. `deferred` describes timing, not optionality: there is no
 per-entry timeout, retry or dependency.
 
+Deferred entries are not HTTP-status-bearing: their outcome may arrive after the response has
+committed, so anything that must prevent the response, redirect it or set its status belongs in
+critical resolution (`attr.data`, middleware) - never in `deferred`. `complete` / `failed` /
+`aborted` are trace outcomes, not HTTP statuses.
+
 See [Deferred Route Data](/reference/taujs-config#deferred-route-data) for the full rules and the
 renderer guides for the component-facing accessors:
 [React](/renderers/react#deferred-route-data),

--- a/website/src/content/docs/guides/data-loading.md
+++ b/website/src/content/docs/guides/data-loading.md
@@ -137,8 +137,8 @@ dynamic) and the degradation taxonomy.
 
 ### Deferred route data (streaming only)
 
-A streaming route can also declare work it does **not** wait for. `attr.deferred` is a flat record
-of named loaders whose values are allowed to arrive after rendering begins:
+A streaming route can also declare work it starts but does **not** await. `attr.deferred` is a flat
+record of named loaders whose values are allowed to arrive after rendering begins:
 
 ```typescript
 {
@@ -150,7 +150,7 @@ of named loaders whose values are allowed to arrive after rendering begins:
     // critical: the response waits for this
     data: serviceData('catalogue', 'product', ({ id }) => ({ id })),
 
-    // response-owned, but the shell does not wait for it
+    // response-owned, started without being awaited
     deferred: {
       reviews: serviceData('reviews', 'forProduct', ({ id }) => ({ id })),
     },

--- a/website/src/content/docs/guides/data-loading.md
+++ b/website/src/content/docs/guides/data-loading.md
@@ -135,6 +135,41 @@ Shell sent immediately, data may load progressively:
 See [Head Management](/guides/head-management) for the full model (`meta` static, `attr.head`
 dynamic) and the degradation taxonomy.
 
+### Deferred route data (streaming only)
+
+A streaming route can also declare work it does **not** wait for. `attr.deferred` is a flat record
+of named loaders whose values are allowed to arrive after rendering begins:
+
+```typescript
+{
+  path: '/products/:id',
+  attr: {
+    render: 'streaming',
+    meta: { title: 'Product' },
+
+    // critical: the response waits for this
+    data: serviceData('catalogue', 'product', ({ id }) => ({ id })),
+
+    // response-owned, but the shell does not wait for it
+    deferred: {
+      reviews: serviceData('reviews', 'forProduct', ({ id }) => ({ id })),
+    },
+  },
+}
+```
+
+Entries use the same handler shape as `attr.data`. Because the work is *declared*, τjs starts it
+once per request outside the component tree, cancels it with the request, records `complete` /
+`failed` / `aborted` on the trace, and shows it in the request graph - none of which is true of
+async work a component starts for itself. `deferred` describes timing, not optionality: there is no
+per-entry timeout, retry or dependency.
+
+See [Deferred Route Data](/reference/taujs-config#deferred-route-data) for the full rules and the
+renderer guides for the component-facing accessors:
+[React](/renderers/react#deferred-route-data),
+[Vue](/renderers/vue#deferred-route-data),
+[Solid](/renderers/solid#deferred-route-data).
+
 ## Using Data on the Client
 
 ### SSR Store

--- a/website/src/content/docs/reference/taujs-config.md
+++ b/website/src/content/docs/reference/taujs-config.md
@@ -535,6 +535,7 @@ Routes define URL patterns, rendering strategies, and data requirements.
 | `meta`       | `Record<string, unknown>` | `{}`        | Metadata for head   |
 | `middleware` | `Middleware`              | `undefined` | Auth and CSP        |
 | `data`       | `DataHandler`             | `undefined` | Data loader         |
+| `deferred`   | `DeferredDataAttributes`  | `undefined` | **`streaming` only.** A flat record of named route-owned loaders whose values may arrive after rendering begins. See [Deferred Route Data](#deferred-route-data) |
 | `head`       | `HeadAttributes`          | `undefined` | Dynamic head data loader: `{ data, timeoutMs?, optional? }`, resolved before the render starts on both strategies and passed to `headContent` as `headData`. `timeoutMs` must be positive finite (default 3000 ms); `optional: true` degrades loader failures to `headData: undefined` instead of failing the request |
 
 ## Rendering Strategies
@@ -663,6 +664,76 @@ data: async (params, ctx) => {
   return { user: await getUser(params.id) };
 };
 ```
+
+### Deferred Route Data
+
+A `streaming` route may additionally declare `attr.deferred`: a flat record of named loaders whose
+values are allowed to arrive after rendering has begun. `attr.data` remains the critical snapshot
+the response cannot start without; `deferred` declares response-owned work the shell does not wait
+for.
+
+```typescript
+{
+  path: '/products/:id',
+  attr: {
+    render: 'streaming',
+    meta: { title: 'Product' },
+
+    // critical: the response waits for this
+    data: serviceData('catalogue', 'product', ({ id }) => ({ id })),
+
+    // response-owned, but the shell does not wait for it
+    deferred: {
+      reviews: serviceData('reviews', 'forProduct', ({ id }) => ({ id })),
+    },
+  },
+}
+```
+
+Entries are the ordinary `DataHandler` shape, `serviceData()` sugar included - there is no new
+helper and no wrapper. τjs starts each named loader exactly once per request, outside the component
+tree and before the head resolves, and the selected renderer projects the named promise onto its own
+Suspense primitive. Because the work is declared, it appears in the request graph (contributing to a
+service's `usedBy`) and each entry records one outcome on the request trace.
+
+Component-facing accessors live in the renderer packages:
+[React](/renderers/react#deferred-route-data),
+[Vue](/renderers/vue#deferred-route-data) and
+[Solid](/renderers/solid#deferred-route-data).
+
+**Rules, all enforced at boot:**
+
+- `deferred` is valid on `render: 'streaming'` only. On an `ssr` route it is both a type error and a
+  boot error: data a non-streamed response needs belongs in `attr.data`.
+- the value must be a plain object whose members are functions, and each key must match
+  `^[A-Za-z][A-Za-z0-9_]*$`.
+- there is no per-entry timeout, retry, optionality or dependency between entries. `deferred`
+  describes **timing**, not policy - an optional business outcome is expressed by the loader's own
+  result (for example `{ available: false }`).
+
+**Outcomes.** Every entry settles as exactly one of `complete`, `failed` or `aborted`, recorded once
+on the request trace and readable through the existing MCP reader. `complete` means *deliverable*: a
+resolved value that cannot cross the hydration boundary is classified `failed` on every surface at
+once, with a single payload-free warning (`Deferred data could not cross the hydration boundary
+key=<key>`) explaining why. An entry that no component read, whose loader rejects after the response
+terminal, reads as `aborted` rather than `failed` - the response had already finished, so nothing
+was waiting on the value. An unread rejection never turns a completed document into a 500; a failure
+of critical `attr.data` (or of a non-optional `attr.head`) aborts and detaches deferred work that has
+already started. No deferred work outlives the response as τjs-owned background work.
+
+**Hydration.** Outcomes for the boundaries a component actually read travel in a private, internal
+carrier written beside `window.__INITIAL_DATA__` at end of stream, read once by the client bootstrap
+and then deleted. The public `__INITIAL_DATA__` shape is unchanged, no loader re-executes in the
+browser, and no client refetch is issued. Under `hydrate: false` no carrier is emitted at all - the
+value still streams into the server-rendered HTML natively.
+
+**Types.** `DeferredDataOf<typeof route>` (exported from `@taujs/server/config`) infers the payload
+of every declared entry from the route configuration alone, following the same three arms as
+`HeadDataOf`: the selected method's result for `serviceData()` sugar, the resolved return type for a
+closure handler, and `undefined` when a route declares no `deferred`. Applications therefore never
+re-declare a deferred payload shape. The inferred type describes the loader's declared result; what
+arrives is that value's JSON snapshot, the same caveat that already applies to `attr.data` crossing
+`__INITIAL_DATA__`.
 
 ## Security Configuration
 

--- a/website/src/content/docs/reference/taujs-config.md
+++ b/website/src/content/docs/reference/taujs-config.md
@@ -669,8 +669,9 @@ data: async (params, ctx) => {
 
 A `streaming` route may additionally declare `attr.deferred`: a flat record of named loaders whose
 values are allowed to arrive after rendering has begun. `attr.data` remains the critical snapshot
-the response cannot start without; `deferred` declares response-owned work the shell does not wait
-for.
+the response cannot start without; `deferred` declares response-owned work that is started but not
+awaited. taujs starts deferred work without awaiting it before invoking the renderer, and
+subsequent byte ordering follows the renderer's native streaming semantics.
 
 ```typescript
 {
@@ -682,7 +683,7 @@ for.
     // critical: the response waits for this
     data: serviceData('catalogue', 'product', ({ id }) => ({ id })),
 
-    // response-owned, but the shell does not wait for it
+    // response-owned, started without being awaited
     deferred: {
       reviews: serviceData('reviews', 'forProduct', ({ id }) => ({ id })),
     },

--- a/website/src/content/docs/reference/taujs-config.md
+++ b/website/src/content/docs/reference/taujs-config.md
@@ -697,6 +697,13 @@ tree and before the head resolves, and the selected renderer projects the named 
 Suspense primitive. Because the work is declared, it appears in the request graph (contributing to a
 service's `usedBy`) and each entry records one outcome on the request trace.
 
+Deferred entries are not HTTP-status-bearing. Their outcome may arrive after the response has
+committed - the status line and headers are long gone by the time a deferred loader settles. Any
+condition that must prevent the response, redirect it or determine its status belongs in critical
+route resolution before rendering (`attr.data`, `attr.middleware`, `attr.head`), never in
+`attr.deferred`. `complete`, `failed` and `aborted` are deferred-data outcomes recorded on the
+trace and delivered to the hydration seed - they are not HTTP response statuses.
+
 Component-facing accessors live in the renderer packages:
 [React](/renderers/react#deferred-route-data),
 [Vue](/renderers/vue#deferred-route-data) and

--- a/website/src/content/docs/reference/taujs-config.md
+++ b/website/src/content/docs/reference/taujs-config.md
@@ -670,7 +670,7 @@ data: async (params, ctx) => {
 A `streaming` route may additionally declare `attr.deferred`: a flat record of named loaders whose
 values are allowed to arrive after rendering has begun. `attr.data` remains the critical snapshot
 the response cannot start without; `deferred` declares response-owned work that is started but not
-awaited. taujs starts deferred work without awaiting it before invoking the renderer, and
+awaited. τjs starts deferred work without awaiting it before invoking the renderer, and
 subsequent byte ordering follows the renderer's native streaming semantics.
 
 ```typescript

--- a/website/src/content/docs/renderers/react.mdx
+++ b/website/src/content/docs/renderers/react.mdx
@@ -26,6 +26,7 @@ A lightweight, React SSR library with streaming capabilities, built for modern T
 - [Overview](#overview)
 - [Installation](#installation)
 - [Core Concepts](#core-concepts)
+- [Deferred route data](#deferred-route-data)
 - [API Reference](#api-reference)
   - [Server-Side Rendering](#server-side-rendering)
   - [Client-Side Hydration](#client-side-hydration)
@@ -98,6 +99,53 @@ Client-side hydration automatically:
 - Creates a synchronised store
 - Hydrates the React tree
 - Falls back to CSR if no SSR data exists
+
+---
+
+## Deferred route data
+
+A `streaming` route may declare `attr.deferred` alongside `attr.data` - named, route-owned work whose value is allowed to arrive after rendering begins (see [Route configuration](/reference/taujs-config#deferred-route-data)). τjs starts each named loader once per request, outside the component tree, and `@taujs/react` projects the named promise onto React's own `use()` + `<Suspense>` model. The component starts nothing and refetches nothing, and React's own out-of-order streaming delivers the late HTML - τjs emits no patch protocol of its own.
+
+```tsx
+import { Suspense } from "react";
+import { createDeferredAccessor, useDeferredDataResult } from "@taujs/react";
+
+// `export type ProductDeferredData = DeferredDataOf<typeof productRoute>` beside the route:
+// a type-only import, so the client bundle pulls in no server code.
+import type { ProductDeferredData } from "../server/routes/product";
+
+// Typed from the route config alone - the payload shape is never re-declared here.
+const useDeferred = createDeferredAccessor<ProductDeferredData>();
+
+function Reviews() {
+  const reviews = useDeferred("reviews"); // suspends this boundary and nothing else
+  return <p>{reviews.count} reviews</p>;
+}
+
+export function ProductPage() {
+  return (
+    <main>
+      <ProductSummary />
+      <Suspense fallback={<p>Loading reviews…</p>}>
+        <Reviews />
+      </Suspense>
+    </main>
+  );
+}
+```
+
+Two reads are available:
+
+- `useDeferredData(key)` (and the typed `createDeferredAccessor` façade above) returns the value. It suspends the nearest `<Suspense>` while the entry is pending and **throws** a `DeferredDataError` - carrying `key` and `outcome` - when the value never arrived. `react-dom/server` has no server-side error boundaries, so a thrown read errors the nearest boundary and React hands it to the client to render.
+- `useDeferredDataResult(key)` returns a `DeferredResult<T>` value: `{ status: 'complete', value }`, `{ status: 'failed' }` or `{ status: 'aborted' }`. It still suspends natively while pending, then returns the outcome, so a handled fallback is rendered **into the streamed document**. Reach for this read for any entry that can fail.
+
+`failed` and `aborted` carry no value, message, stack or cause. An unknown key is a deterministic developer error naming the declared set, never a suspended boundary and never `undefined`.
+
+**Boundary placement.** React streams out of order, so a deferred boundary anywhere in the tree emits its fallback immediately and is patched in place once the value settles. Placement is a layout choice here, not a performance one. (This is not true of `@taujs/vue`, whose in-order stream makes placement load-bearing.)
+
+**Failure semantics.** Every declared entry settles as exactly one of `complete`, `failed` or `aborted`, recorded once on the request trace. An **unconsumed** entry whose loader rejects after the response terminal reads as `aborted`, not `failed` - the response had already finished, so nothing was waiting on the value. `complete` means *deliverable*: a value that resolves but cannot cross the hydration boundary is classified `failed` uniformly across the server render, the trace and hydration.
+
+**Hydration.** Outcomes for the boundaries a component actually read are seeded from a private internal carrier written beside `window.__INITIAL_DATA__` and read synchronously in document order by the bootstrap. Every seeded entry is already settled, so `use()` returns or throws synchronously: no second render pass, no loader re-execution, no refetch. Under `hydrate: false` no carrier is emitted and the value still streams into the server-rendered HTML.
 
 ---
 

--- a/website/src/content/docs/renderers/react.mdx
+++ b/website/src/content/docs/renderers/react.mdx
@@ -222,6 +222,7 @@ function createRenderer<
 - `streamOptions`: Streaming configuration
   - `shellTimeoutMs`: Timeout for the initial shell render (default: `10000`)
   - `dataTimeoutMs`: Timeout for route data to settle after React has finished rendering (default: `30000`). Bounds the stream so a never-settling loader cannot hold the response open indefinitely.
+  - `deferredTimeoutMs`: The one response-level completion deadline for [deferred route data](#deferred-route-data). Default `min(15000, dataTimeoutMs / 2)`, so `15000` with the stock `dataTimeoutMs`, and half of any smaller fatal backstop you configure. It is measured from `renderStream` **entry** - the same origin `dataTimeoutMs` is compared against - and armed at **shell commit** with whatever remains of that budget, because a deferred boundary can only be pending once the shell has committed (a budget already spent arms at 1ms rather than never). It is never reset per key and it latches: a boundary whose first read arrives after expiry is born `aborted` rather than starting a fresh unbounded wait. On expiry the still-pending boundaries a component actually read are abandoned through React's **own** `stream.abort`, which emits React's client-render instruction for each and finishes the document; the host then records those keys as `aborted` on the trace and in the hydration envelope. The value must be a **positive finite** number of milliseconds - there is no `0`/`Infinity` disable sentinel, because this deadline is what keeps total response time bounded - and any other value throws a `TypeError` from `createRenderer`. It must also be **strictly less** than a finite `dataTimeoutMs`, or `createRenderer` throws: at or above the fatal route-data backstop, that backstop pre-empts graceful abandonment and the response fails instead of completing. Unlike the other stream timeouts it has **no per-call form** (see the per-call options below).
 - `ssrOptions`: Static SSR configuration
   - `prerenderTimeoutMs`: Deadline for the `ssr` strategy's complete-HTML render (default: `10000`; `0` or `Infinity` = wait forever; anything else must be a positive finite number or `createRenderer` throws). See `renderSSR()` for the expiry behaviour.
 - `identifierPrefix`: React's `useId` prefix, passed to both rendering paths. Must match the value passed to `hydrateApp` for the same root. Set it when rendering more than one taujs root on a page so `useId` values are collision-free.
@@ -242,8 +243,13 @@ Both methods accept a final `opts` argument:
 - `headData`: The route's resolved `attr.head` payload. With `@taujs/server` this is passed for
   you (only when the route declares `attr.head` and its loader resolved); standalone hosts may
   pass their own pre-resolved head data. Reaches `headContent` typed as `H`.
-- `renderStream` only: any `StreamOptions` field (`shellTimeoutMs`, `dataTimeoutMs`) may also be
-  overridden per call.
+- `renderStream` only: the per-call `StreamOptions` timeouts `shellTimeoutMs` and `dataTimeoutMs`
+  may also be overridden here. `deferredTimeoutMs` is the one exception: it is **factory-only** and
+  has no per-call form, because it is a boot-validated bound on the whole response rather than a
+  per-request knob. A per-call `dataTimeoutMs` at or below the configured deferred deadline
+  re-derives that deadline as `dataTimeoutMs / 2` for that response, so the ordering against the
+  fatal backstop holds without losing the graceful terminal; it can only ever move the graceful
+  terminal earlier, never later.
 
 **Worked example: dynamic head data on a streamed route**
 

--- a/website/src/content/docs/renderers/solid.mdx
+++ b/website/src/content/docs/renderers/solid.mdx
@@ -311,11 +311,14 @@ function createRenderer<
 - `renderId`: A stable namespace for Solid's hydration markers and the serialised data. It must be the **same** value you pass to `hydrateApp` (see [Client-side hydration](#client-side-hydration)). Keep it in one shared constant imported by both entries.
 - `streamOptions.shellTimeoutMs`: Shell-readiness watchdog in ms (default `10000`).
 - `streamOptions.completionTimeoutMs`: Bound on the whole `renderStream` lifecycle in ms (default `30000`). Every terminal clears it.
+- `streamOptions.deferredTimeoutMs`: The one response-level completion deadline for [deferred route data](#deferred-route-data). Default `min(15000, completionTimeoutMs / 2)`, so `15000` with the stock `completionTimeoutMs`, and half of any smaller fatal watchdog you configure. It is measured from `renderStream` **entry** - the same origin as `completionTimeoutMs`, so their ordering is a property of the configuration rather than of how long the shell happened to take - and armed at **shell commit** with whatever remains of that budget, because before the shell there is no document to complete and a pre-shell stall is `shellTimeoutMs`'s to report; a budget already spent arms at 1ms rather than never. It is never reset per key and it latches: a boundary whose first read arrives after expiry is born abandoned rather than starting a fresh unbounded wait. Abandonment is native: the adapter's own wrapper is rejected, so Solid errors those boundaries through its ordinary channel, renders the application's `<ErrorBoundary>` fallback **into** the response and ends the stream itself; the host then records those keys as `aborted`. The value must be a **positive finite** number of milliseconds - unlike the two watchdogs above there is no `0`/`Infinity` sentinel, because this deadline is what keeps total response time bounded - and any other value throws a `TypeError` from `createRenderer`. It must also be **strictly less** than a finite `completionTimeoutMs`, or `createRenderer` throws: at or above the fatal watchdog, that watchdog always wins the race and graceful abandonment becomes unreachable. It is **factory-only** and has no per-call form.
 - `ssrOptions.prerenderTimeoutMs`: Bound on the `ssr` strategy's single render promise in ms (default `10000`).
 - `logger`: Custom logger implementation (`SolidLogger`).
 
 <Aside type="note" title="Timeout values are validated at the factory">
 `shellTimeoutMs`, `completionTimeoutMs` and `prerenderTimeoutMs` must each be a positive finite number of milliseconds, or one of the sentinels `0` or `Infinity`. Any other value (a negative number, `NaN`, a stray string from untyped JS) throws a `TypeError` from `createRenderer` rather than silently disabling the watchdog.
+
+`deferredTimeoutMs` is validated at the factory too, but more strictly: it must be positive **and** finite, with no sentinel form, and strictly less than a finite `completionTimeoutMs`.
 </Aside>
 
 **Returns** an object with two rendering methods: `renderSSR` (static, returns `{ headContent, appHtml }`) and `renderStream` (streaming, pipes to a writable).
@@ -355,6 +358,9 @@ type RenderOptions = {
 type StreamOptions = {
   shellTimeoutMs?: number; // default 10000
   completionTimeoutMs?: number; // default 30000
+  // The one response-level deferred-data deadline. Default min(15000, completionTimeoutMs / 2);
+  // positive finite only, strictly less than a finite completionTimeoutMs; no per-call form.
+  deferredTimeoutMs?: number;
 };
 
 type SSROptions = {
@@ -441,7 +447,7 @@ await done;
 
 `onAllReady` is **two-latch**: it fires once *and only once*, after the route data is ready **and** Solid has finished rendering. A fatal, incomplete delivery never calls `onAllReady`, so it never seeds a truncated document. A pre-shell fatal also never calls `onShellReady`; a post-shell fatal necessarily occurs after `onShellReady` has already reported that the shell was committed. The resolved route data is delivered to `onAllReady` and serialised into `window.__INITIAL_DATA__`.
 
-- `shellTimeoutMs` bounds shell readiness; `completionTimeoutMs` bounds the whole lifecycle and is cleared by every terminal (normal completion, abort, or fatal).
+- `shellTimeoutMs` bounds shell readiness; `completionTimeoutMs` bounds the whole lifecycle and is cleared by every terminal (normal completion, abort, or fatal). `deferredTimeoutMs` is the graceful counterpart to that fatal watchdog: it is armed at shell commit, abandons only the still-pending deferred boundaries, and lets the document terminate normally.
 - App-owned `createResource` work under `<Suspense>`, and route-declared [deferred route data](#deferred-route-data), stream as Solid `$df` deferred patches once they settle; the critical route snapshot does not (see [The snapshot data bridge](#the-snapshot-data-bridge)).
 
 **Cancellation and lifecycle.** `renderStream` accepts an `AbortSignal` (a triggered signal is a benign cancel) and returns `{ abort, done }`: `abort()` performs a manual benign abort, and `done` resolves on normal completion or rejects on a fatal error. Client disconnects are classified benign and never surface as fatal errors. Every terminal releases the renderer's request-scoped state exactly once.

--- a/website/src/content/docs/renderers/solid.mdx
+++ b/website/src/content/docs/renderers/solid.mdx
@@ -29,6 +29,7 @@ A lightweight Solid SSR library with streaming and hydration support, built for 
 - [Consuming SSR data](#consuming-ssr-data)
   - [Route data (the store)](#route-data-the-store)
   - [App-owned async (Suspense + createResource)](#app-owned-async-suspense--createresource)
+- [Deferred route data](#deferred-route-data)
 - [API Reference](#api-reference)
   - [Server-side rendering](#server-side-rendering)
   - [Client-side hydration](#client-side-hydration)
@@ -190,8 +191,59 @@ function DeferredNote() {
 ```
 
 <Aside type="note" title="Route data and createResource are different, on purpose">
-Route data is resolved by τjs at the request boundary and travels in `window.__INITIAL_DATA__`; it never streams through Solid's `$df` channel (see [The snapshot data bridge](#the-snapshot-data-bridge)). `createResource` under `<Suspense>` is the other case - application-owned async the component starts itself. So a `streaming` route whose page reads only route data emits no deferred-patch machinery: there is nothing to defer, and that is correct. Deferred patches are the mechanism for component-local async; they are not a way to move governed route data off the request boundary.
+Critical route data (`attr.data`) is resolved by τjs at the request boundary and travels in `window.__INITIAL_DATA__`; it never streams through Solid's `$df` channel (see [The snapshot data bridge](#the-snapshot-data-bridge)). `createResource` under `<Suspense>` is the other case - application-owned async the component starts itself. So a `streaming` route whose page reads only route data emits no deferred-patch machinery: there is nothing to defer, and that is correct. `$df` patches are the mechanism for work that settles after the shell; they are not a way to move the critical route snapshot off the request boundary.
+
+There is a third, governed case between the two: [deferred route data](#deferred-route-data), declared as `attr.deferred` on the route. It is response-owned like `attr.data` and starts outside the component tree, but it settles after rendering begins, so its value does travel as a `$df` patch.
 </Aside>
+
+---
+
+## Deferred route data
+
+A `streaming` route may declare `attr.deferred` alongside `attr.data` - named, route-owned work whose value is allowed to arrive after rendering begins (see [Route configuration](/reference/taujs-config#deferred-route-data)). This is the governed counterpart to `createResource`: τjs starts each named loader once per request, outside the component tree, and knows its service, its cancellation and its outcome. `@taujs/solid` projects the named promise onto Solid's own resource model, and Solid's native `$df` transport delivers the value once it settles.
+
+```tsx
+import { ErrorBoundary, Suspense } from "solid-js";
+import { createDeferredAccessor } from "@taujs/solid";
+
+// `export type ProductDeferredData = DeferredDataOf<typeof productRoute>` beside the route:
+// a type-only import, so the client bundle pulls in no server code.
+import type { ProductDeferredData } from "../server/routes/product";
+
+// Typed from the route config alone - the payload shape is never re-declared here.
+const useDeferred = createDeferredAccessor<ProductDeferredData>();
+
+function Reviews() {
+  const reviews = useDeferred("reviews"); // Accessor<T | undefined>
+  return <p>{reviews()?.count} reviews</p>;
+}
+
+export function ProductPage() {
+  return (
+    <main>
+      <ProductSummary />
+      <Suspense fallback={<p>Loading reviews…</p>}>
+        {/* The ErrorBoundary sits INSIDE the Suspense - see below. */}
+        <ErrorBoundary fallback={<p>Reviews are unavailable.</p>}>
+          <Reviews />
+        </ErrorBoundary>
+      </Suspense>
+    </main>
+  );
+}
+```
+
+`createDeferredAccessor<D>()` returns a typed reader; the untyped `useDeferredData<T>(key)` is exported for cases where no route type is to hand. Both return `Accessor<T | undefined>` - `undefined` while pending, the value once it settles - and both suspend the nearest `<Suspense>` on read.
+
+**Failures use Solid's own error boundary.** When an entry never arrives the accessor throws a `DeferredDataError` (carrying `key` and `outcome`) on read, and Solid's SSR engine has real server-side error boundaries, so a wrapping `<ErrorBoundary>` renders its fallback **into the response**. That is why `@taujs/solid` carries no separate result-shaped accessor: the throwing read already completes the response. Wrap any entry that can fail.
+
+<Aside type="caution" title="Put the ErrorBoundary inside the Suspense">
+The `<ErrorBoundary>` must sit **inside** the `<Suspense>` boundary that the read suspends. Outside it, the response still completes and the rejection is still redacted, but the fallback renders on the client instead of in the streamed HTML.
+</Aside>
+
+**Failure semantics.** Every declared entry settles as exactly one of `complete`, `failed` or `aborted`, recorded once on the request trace. An **unconsumed** entry whose loader rejects after the response terminal reads as `aborted`, not `failed` - the response had already finished, so nothing was waiting on the value. `complete` means *deliverable*: a value that resolves but cannot cross the hydration boundary is classified `failed` uniformly across the server render, the trace and hydration.
+
+**Hydration.** Outcomes for the boundaries a component actually read are also seeded from a private internal carrier written beside `window.__INITIAL_DATA__` and read once by the bootstrap, so hydration re-executes no loader and issues no refetch. Under `hydrate: false` no carrier is emitted and the value still streams into the server-rendered HTML natively.
 
 ---
 
@@ -390,7 +442,7 @@ await done;
 `onAllReady` is **two-latch**: it fires once *and only once*, after the route data is ready **and** Solid has finished rendering. A fatal, incomplete delivery never calls `onAllReady`, so it never seeds a truncated document. A pre-shell fatal also never calls `onShellReady`; a post-shell fatal necessarily occurs after `onShellReady` has already reported that the shell was committed. The resolved route data is delivered to `onAllReady` and serialised into `window.__INITIAL_DATA__`.
 
 - `shellTimeoutMs` bounds shell readiness; `completionTimeoutMs` bounds the whole lifecycle and is cleared by every terminal (normal completion, abort, or fatal).
-- App-owned `createResource` work under `<Suspense>` streams as Solid `$df` deferred patches once it settles; route data does not (see [The snapshot data bridge](#the-snapshot-data-bridge)).
+- App-owned `createResource` work under `<Suspense>`, and route-declared [deferred route data](#deferred-route-data), stream as Solid `$df` deferred patches once they settle; the critical route snapshot does not (see [The snapshot data bridge](#the-snapshot-data-bridge)).
 
 **Cancellation and lifecycle.** `renderStream` accepts an `AbortSignal` (a triggered signal is a benign cancel) and returns `{ abort, done }`: `abort()` performs a manual benign abort, and `done` resolves on normal completion or rejects on a fatal error. Client disconnects are classified benign and never surface as fatal errors. Every terminal releases the renderer's request-scoped state exactly once.
 
@@ -586,12 +638,12 @@ export default defineConfig({
 
 A τjs response renders **one selected app and root**: the host matches the URL to a single app by `appId` and loads that app's renderer for the response. So `window.__INITIAL_DATA__` is that response's single route-data authority - one root hydrates one payload, and no second app's data shares the document.
 
-The server commits the resolved route data into the store before rendering and serialises the same payload into `__INITIAL_DATA__`; the client seeds the store from it during hydration. Route data therefore never travels through Solid's `$df` deferred-patch channel, on any strategy.
+The server commits the resolved route data into the store before rendering and serialises the same payload into `__INITIAL_DATA__`; the client seeds the store from it during hydration. The critical route snapshot (`attr.data`) therefore never travels through Solid's `$df` deferred-patch channel, on any strategy.
 
 The practical consequences:
 
 - **`ssr` routes:** the store is committed before render, so `store.data()` is populated in the server HTML with no `<Suspense>` needed for route data.
-- **`streaming` routes:** route data is already in `__INITIAL_DATA__`, so a page that reads only route data emits no deferred patches. Application-owned `createResource` work under `<Suspense>` is what flows as `$df` patches (see [App-owned async](#app-owned-async-suspense--createresource)).
+- **`streaming` routes:** route data is already in `__INITIAL_DATA__`, so a page that reads only route data emits no deferred patches. What flows as `$df` patches is work that settles after the shell: application-owned `createResource` under `<Suspense>` (see [App-owned async](#app-owned-async-suspense--createresource)), and route-declared [deferred route data](#deferred-route-data), whose settled outcomes are additionally seeded from their own private carrier at end of stream.
 - **The client never re-runs your route loader.** It hydrates from the snapshot; there is exactly one route-data seed per response.
 
 ---
@@ -879,8 +931,8 @@ const logger: ServerLogger = {
 
 ## Best practices
 
-1. **Know your two data kinds.** Route data comes from the store (`store.data()`) and is committed before render; app-owned async uses `createResource` under `<Suspense>`. Only the latter streams.
-2. **Streaming carries application-owned async.** Route data is resolved at the request boundary and travels in the snapshot; `createResource` under `<Suspense>` is component-owned work that streams as deferred patches. Use it for UI-local async, not to move governed route data off the request boundary.
+1. **Know your three data kinds.** The critical route snapshot comes from the store (`store.data()`) and is committed before render; route-declared [deferred route data](#deferred-route-data) is response-owned work that settles after rendering begins; app-owned async uses `createResource` under `<Suspense>`. Only the last two stream.
+2. **Declare response-owned work, do not fetch it from a component.** If τjs should know the service, cancel it with the request and record its outcome, declare it as `attr.deferred` on the route. Keep `createResource` for genuinely UI-local async, not as a way to move governed route data off the request boundary.
 3. **Share one `renderId`.** Keep it in a single constant imported by `entry-server` and `entry-client`; a drift between the two is a hydration bug.
 4. **Head data: `meta` for static, `attr.head` for dedicated dynamic head work.** The Solid adapter waits for route data before it renders, so `data` is committed when `headContent` runs. `headData` remains optional because a route may omit `attr.head`, or its loader may degrade under the configured policy. Escape every interpolated value with `escapeHtml`. The renderer appends the hydration bootstrap itself; do not emit it from `headContent`.
 5. **Let the managed compiler own the plugin.** Register `solidRenderer({ project })` and point `project` at a disjoint tsconfig; do not add `vite-plugin-solid` to your app yourself under τjs.

--- a/website/src/content/docs/renderers/vue.mdx
+++ b/website/src/content/docs/renderers/vue.mdx
@@ -29,6 +29,9 @@ A lightweight, Vue 3 SSR library with streaming capabilities, built for modern T
 - [Consuming SSR data](#consuming-ssr-data)
   - [Suspense (recommended)](#suspense-recommended)
   - [Fallback rendering](#fallback-rendering)
+- [Deferred route data](#deferred-route-data)
+  - [Where to place a deferred boundary](#where-to-place-a-deferred-boundary)
+  - [Failure semantics](#failure-semantics)
 - [API Reference](#api-reference)
   - [Server-side rendering](#server-side-rendering)
   - [Client-side hydration](#client-side-hydration)
@@ -187,6 +190,76 @@ const data = useSSRData<GreetingData>();
 ```
 
 This idiom is a good fit for `ssr` routes, where the server has already resolved the data before rendering begins, so the `v-else` fallback is never actually shown in the SSR output.
+
+---
+
+## Deferred route data
+
+A `streaming` route may declare `attr.deferred` alongside `attr.data` - named, route-owned work whose value is allowed to arrive after rendering begins (see [Route configuration](/reference/taujs-config#deferred-route-data)). τjs starts each named loader once per request, outside the component tree, and `@taujs/vue` projects the named promise onto Vue's own async `setup()` + `<Suspense>` model. The component starts nothing and refetches nothing.
+
+```vue
+<script setup lang="ts">
+import { createDeferredAccessor } from "@taujs/vue";
+
+// `export type ProductDeferredData = DeferredDataOf<typeof productRoute>` beside the route:
+// a type-only import, so the client bundle pulls in no server code.
+import type { ProductDeferredData } from "../server/routes/product";
+
+// Typed from the route config alone - the payload shape is never re-declared here.
+const deferred = createDeferredAccessor<ProductDeferredData>();
+
+// Called synchronously in setup(), before the first await: the accessor injects.
+const outcome = await deferred.result("reviews");
+</script>
+
+<template>
+  <p v-if="outcome.status === 'complete'">{{ outcome.value.count }} reviews</p>
+  <p v-else-if="outcome.status === 'failed'">Reviews are unavailable.</p>
+  <p v-else>Reviews did not arrive in time.</p>
+</template>
+```
+
+`createDeferredAccessor<D>()` returns two reads, and both must be called synchronously in `setup()` before the first `await`:
+
+- `deferred.result(key)` returns `Promise<DeferredResult<T>>` - a promise that never rejects for a declared key, resolving to `{ status: 'complete', value }`, `{ status: 'failed' }` or `{ status: 'aborted' }`. This is the **primary Vue read**: a handled failure branch completes the response, and server and client render the identical branch from the identical detail-free outcome.
+- `deferred.data(key)` returns `Promise<T>` and rejects with a `DeferredDataError` (carrying `key` and `outcome`) when the value never arrived. The rejection follows Vue's native error channel (`onErrorCaptured`, `app.config.errorHandler`).
+
+The untyped forms `useDeferredData(key)` and `useDeferredDataResult(key)` are exported for cases where no route type is to hand; prefer the typed façade.
+
+<Aside type="caution" title="Place deferred boundaries AFTER the content that should stream immediately">
+Vue streaming is **in-order** (see [Streaming semantics](#streaming-semantics)). A `<Suspense>` boundary awaiting a deferred value **stalls every byte behind it** until that value settles - there is no out-of-order shell that fills the boundary in later.
+
+So in an in-order renderer, **place deferred boundaries after the independent content that should stream immediately**. Put your header, navigation, and the content resolved from `attr.data` ahead of the deferred boundary in document order, and the deferred boundary last. Order the template that way and the shell reaches the browser without waiting; order it the other way and declaring the work as `deferred` buys you nothing.
+</Aside>
+
+### Where to place a deferred boundary
+
+```vue
+<template>
+  <!-- Everything independent of the deferred value comes FIRST. -->
+  <SiteHeader />
+  <ProductSummary />
+
+  <!-- The deferred boundary comes LAST: nothing behind it is stalled. -->
+  <Suspense>
+    <DeferredReviews />
+    <template #fallback><p>Loading reviews…</p></template>
+  </Suspense>
+</template>
+```
+
+<Aside type="tip" title="This is a Vue authoring rule, not a τjs one">
+React's out-of-order streaming makes boundary placement largely cosmetic; Vue's honest in-order stream makes it load-bearing. The same route configuration is correct on all three renderers - only the template ordering matters here.
+</Aside>
+
+### Failure semantics
+
+Every declared entry settles as exactly one of `complete`, `failed` or `aborted`, recorded once on the request trace. Two points worth knowing when you read the outcomes:
+
+- An **unconsumed** entry whose loader rejects after the response terminal reads as `aborted`, not `failed` - the response had already finished, so nothing was waiting on the value.
+- `complete` means *deliverable*. A value that resolves but cannot cross the hydration boundary is classified `failed` uniformly across the server render, the trace and hydration, so all three always agree.
+
+Outcomes for the boundaries a component actually read are seeded into hydration from a private internal carrier written beside `window.__INITIAL_DATA__`; every seeded entry is already settled, so hydration re-executes no loader and issues no refetch. Under `hydrate: false` no carrier is emitted and the value still streams into the server-rendered HTML.
 
 ---
 

--- a/website/src/content/docs/renderers/vue.mdx
+++ b/website/src/content/docs/renderers/vue.mdx
@@ -330,6 +330,7 @@ function createRenderer<
 - `appComponent`: Your Vue root. Pass the component directly (it receives `{ location, routeContext? }` as props) or a render function returning a VNode.
 - `headContent`: Generates HTML head content from `{ data, headData?, meta, routeContext? }`. **Note:** in streaming mode the data snapshot is usually still pending when the head is built - guard optional `data` fields, lean on `meta`/`routeContext`, or declare `attr.head` on the route so the host resolves DYNAMIC head data before the render and passes it as `headData` (typed by `createRenderer`'s third generic `H`). `headData` is `undefined` when the route declares no `attr.head` and when the head loader degraded (deadline expiry, or an `optional` loader failure) - always handle it. Vue's head stays SINGLE-BUILD, pre-render; `headData` widens what that one build can see. Escape every `headData`/`data`-derived value with `escapeHtml`.
 - `streamOptions.shellTimeoutMs`: Time-to-first-content watchdog in ms (default `10000`). See [Streaming semantics](#streaming-semantics).
+- `streamOptions.deferredTimeoutMs`: The one response-level completion deadline for [deferred route data](#deferred-route-data). Default `15000`. The general derivation is `min(15000, fatal backstop / 2)`, but `@taujs/vue` declares no finite post-shell fatal backstop for it to halve - `shellTimeoutMs` bounds the pre-shell phase only and is stopped before this deadline is armed - so the Vue default is the flat cap. It is measured from `renderStream` **entry** and armed at **shell commit** (the first streamed chunk) with whatever remains of that budget; a budget already spent arms at 1ms rather than never. It is never reset per key and it latches: a boundary whose first read arrives after expiry is born `aborted` rather than starting a fresh unbounded wait. Vue streams strictly in order and has no client-render instruction, so the Vue spelling of "abandon the boundary" is to settle every still-pending consumed read as `aborted`: the application's own `aborted` branch renders **into** the response, the stream resumes and the document terminates normally. The stream controller is never touched, so an abandoned boundary is a normal completion, not a stream failure. The value must be a **positive finite** number of milliseconds - there is no `0`/`Infinity` disable sentinel, because this deadline is what keeps total response time bounded - and any other value throws a `TypeError` from `createRenderer`. It is **factory-only**: unlike `shellTimeoutMs` it has no per-call form.
 - `logger`: Custom logger implementation (`LoggerLike`).
 - `enableDebug`: Enable detailed logging (default `false`).
 - `setupApp`: Configure the per-request `App` instance (`app.use`, directives, provides). See [App customisation](#app-customisation-with-setupapp).
@@ -408,6 +409,11 @@ type RenderCallbacks<T> = {
 type StreamOptions = {
   /** Time-to-first-content watchdog, in ms (default 10000). */
   shellTimeoutMs?: number;
+  /**
+   * The one response-level deferred-data completion deadline, in ms (default 15000).
+   * Positive finite only, validated by createRenderer; factory-only, with no per-call form.
+   */
+  deferredTimeoutMs?: number;
 };
 ```
 
@@ -536,7 +542,7 @@ Both methods accept a final `opts` argument:
 
 - `logger`: Optional per-call logger (overrides the one passed to `createRenderer`).
 - `routeContext`: Per-request route context forwarded into `appComponent` and `headContent`.
-- `renderStream` additionally accepts `shellTimeoutMs` here to override the renderer default per call.
+- `renderStream` additionally accepts `shellTimeoutMs` here to override the renderer default per call. `deferredTimeoutMs` is deliberately absent from the per-call options: the deferred deadline is a boot-validated bound on the whole response, so it is configured once on `createRenderer` and never per request.
 
 **Cancellation and lifecycle**
 


### PR DESCRIPTION
Implements RFC 0007: a streaming route may declare named, response-owned deferred loaders
beside its critical data. The host starts each exactly once, governs its lifecycle and
outcome, and each renderer projects the named promise onto its own native Suspense
primitive - no taujs patch protocol, no browser data endpoint, no scheduler, no client
refetch, and `window.__INITIAL_DATA__` unchanged.

Approved for product implementation under the RFC 0007 gate (GO, 2026-07-28, decisions
1-19). Technical acceptance is pinned at ba9b2c6; one post-acceptance docs-only commit
(62a7d66) adds a clarification requested by the acceptance review. Based on the precursor
PR (NUL-byte escape + stale-dist guard) - once that merges, this PR shows only its own
commits.

## The authoring surface

```typescript
{
  path: '/products/:id',
  attr: {
    render: 'streaming',
    data: serviceData('catalogue', 'product', ({ id }) => ({ id })),   // critical, unchanged
    deferred: {
      reviews: serviceData('reviews', 'forProduct', ({ id }) => ({ id })),
    },
  },
}
```

Entries are the ordinary `DataHandler` shape; `DeferredDataOf<typeof route>` infers the
payloads from the config. Streaming-only, boot-validated (ssr + deferred is a hard error,
as are malformed records and bad keys).

## Host (@taujs/server)

- Request-local registry: eager exactly-once start (after `ctx.signal`, before head
  resolution), pre-observed promises, released on every response terminal - including a
  response already ended at the finish tick.
- Stable settlement snapshot: exactly one serialisation attempt per resolved value; the
  renderer consumes `JSON.parse` of the retained bytes, the hydration envelope splices the
  same bytes unchanged, so server render, trace and hydration always share one outcome. A
  non-serialisable (or non-record-rooted) value is `failed` everywhere, detail-free.
- Private hydration seed: `window.__TAUJS_DEFERRED_STATE__` at the existing end-of-stream
  write site, nonced, emitted only when hydration is on, consumed once and deleted.
  Outcomes are exactly `complete` / `failed` / `aborted`.
- One response-level deferred deadline (`deferredTimeoutMs`): measured from renderStream
  entry, armed at shell commit with the remaining budget, latched, positive-finite only,
  default `min(15_000, fatalBackstop / 2)`.
- Observability: per-key trace outcomes (durable into `.taujs/traces.ndjson` even when the
  outcome lands after trace finalisation), an additive optional request-graph field with
  `usedBy` contribution, and a payload-free operator warning when a resolved value cannot
  cross the hydration boundary.

## Renderers - one small adapter each, framework-native by design

Shared spellings (frozen at the gate): `useDeferredData`, `createDeferredAccessor`,
`DeferredDataError`. Return shapes are deliberately renderer-native:

- **React** - `use()`-based suspension with out-of-order streaming; `useDeferredDataResult`
  provides the detail-free server-completing fallback path (Fizz has no server-side error
  boundaries).
- **Vue** - async `setup()` consumption, in-order streaming (documented: place deferred
  boundaries after content that should stream immediately); the result accessor is the
  primary failure API.
- **Solid** - resource/accessor with native server-side `ErrorBoundary`; no result accessor
  (need-based ruling - no API symmetry without a framework need).

No renderer exports its carrier, holders or hydration internals; hydration is a synchronous
document-order read with zero loader re-execution.

## Docs and fixtures

- Website: deferred route data across the config reference, the data-loading guide and all
  three renderer references (including `deferredTimeoutMs` and the explicit rule that
  deferred entries are not HTTP-status-bearing - status-determining conditions belong in
  critical resolution).
- Playgrounds: a declared deferred route per playground with real-Chromium acceptance under
  an enforced CSP (successful delivery, envelope-seeded hydration, zero refetch, carrier
  deleted, zero violations). These suites skip visibly when the pinned Chromium build is
  absent - a CI-enforcement note, not a product concern.

## Verification

- Root `pnpm run check` (build, typecheck, format, exports, workspace tests incl. fixtures)
  exit 0. Suites: server 927, react 272, vue 216, solid 196; playground browser cells green.
- Independent adversarial review across four rounds, mutation-tested on both sides (host
  terminal release, renderer cleanup, deadline origin and magnitude all proven to bite).
- Source additions sit under the feasibility proof's recorded ceiling in every package;
  each adapter is ~150 executable lines.
- Changesets: additive minor for the four packages moving together.
- Ordering-class cells gate deferred settlement on the observed shell chunk rather than a timed release (a5e2d89) - removes a CI-only flush race caught by the first CI run; test-only, repeated runs green on all three renderers.

