### PR TITLE
fix(server): honour staticAssets false as production opt-out

### DIFF
--- a/.changeset/static-assets-false-opt-out.md
+++ b/.changeset/static-assets-false-opt-out.md
@@ -1,0 +1,5 @@
+---
+'@taujs/server': patch
+---
+
+Honour `staticAssets: false` as a production opt-out - explicit `false` now installs no static plugin in production or development, while omitting the option keeps the default `@fastify/static` registration. Previously a falsy value was treated the same as omission and the default plugin was installed anyway, so a CDN-only deployment could not disable Fastify static serving.

--- a/packages/server/src/CreateServer.ts
+++ b/packages/server/src/CreateServer.ts
@@ -38,7 +38,11 @@ type CreateServerOptions = {
   fastify?: FastifyInstance;
   debug?: DebugConfig;
   logger?: BaseLogger;
-  staticAssets?: false | StaticAssetsRegistration;
+  /**
+   * Static assets in production: omit for the default `@fastify/static` registration, pass a
+   * custom registration, or pass `false` to install no static plugin at all (CDN-owned assets).
+   */
+  staticAssets?: StaticAssetsRegistration;
   port?: number;
 };
 
@@ -143,7 +147,9 @@ export const createServer = async (opts: CreateServerOptions): Promise<CreateSer
       configs,
       routes,
       serviceRegistry: opts.serviceRegistry,
-      staticAssets: opts.staticAssets ?? false,
+      // Passed through verbatim: `undefined` requests the default production registration and
+      // explicit `false` is the opt-out, so coalescing here would erase the distinction.
+      staticAssets: opts.staticAssets,
       debug: opts.debug,
       runtimeLogger,
       alias: opts.alias,

--- a/packages/server/src/SSRServer.ts
+++ b/packages/server/src/SSRServer.ts
@@ -82,7 +82,10 @@ const installOwnedScope = async (scope: FastifyInstance, opts: SSRServerOptions,
     { logger },
   );
 
-  if (!isDevelopment && !opts.staticAssets) {
+  // Tri-state contract: `undefined` installs the default production registration, explicit
+  // `false` installs no static plugin (CDN-owned assets), and a registration object/array is
+  // honoured below. `=== undefined` keeps `false` out of this branch.
+  if (!isDevelopment && opts.staticAssets === undefined) {
     const fastifyStatic = await import('@fastify/static');
 
     await registerStaticAssets(scope, clientRoot, { plugin: fastifyStatic.default });

--- a/packages/server/src/test/CreateServer.test.ts
+++ b/packages/server/src/test/CreateServer.test.ts
@@ -157,7 +157,7 @@ describe('createServer', () => {
     process.env.NODE_ENV = 'test';
   });
 
-  it('creates Fastify instance, registers plugins, and defaults staticAssets to false, returns { app, net }', async () => {
+  it('creates Fastify instance, registers plugins, passes omitted staticAssets through as undefined, returns { app, net }', async () => {
     const { createServer } = await importer();
 
     const result = await createServer({
@@ -182,11 +182,16 @@ describe('createServer', () => {
       2,
       SSRServerPlugin,
       expect.objectContaining({
-        staticAssets: false,
         clientRoot: expect.stringContaining('/client'),
         devNet: { host: netResolved.host, hmrPort: netResolved.hmrPort },
       }),
     );
+
+    // Omitted staticAssets must reach SSRServer as `undefined` (request for the default
+    // production registration), NOT be coalesced to `false` (the explicit opt-out).
+    const ssrCallArgs = registerMock.mock.calls[1]?.[1] as any;
+    expect('staticAssets' in ssrCallArgs).toBe(true);
+    expect(ssrCallArgs.staticAssets).toBeUndefined();
 
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('[bgGreen:[black: [τjs] ]]'));
     expect(console.log).toHaveBeenCalledWith(expect.stringContaining('configured in 675ms'));

--- a/packages/server/src/test/SSRServer.test.ts
+++ b/packages/server/src/test/SSRServer.test.ts
@@ -351,6 +351,92 @@ describe('SSRServer', () => {
     expect(res.body).toBe('static-ok');
   });
 
+  // staticAssets tri-state: `undefined` requests the default production registration (proved by
+  // the auto-register tests above); explicit `false` must install NO static plugin anywhere. The
+  // not-found fallthrough is the proof - if any static plugin had claimed the route, the scope's
+  // not-found handler could never answer it.
+  it('staticAssets: false installs no static plugin in production', async () => {
+    devRef.value = false;
+
+    await app.register(SSRServer, {
+      alias: {},
+      configs: [],
+      routes: [],
+      clientRoot: '/client',
+      debug: false,
+      staticAssets: false,
+    });
+
+    const res = await app.inject({ method: 'GET', url: '/auto-default' });
+    expect(res.body).toBe('OK:notFound');
+  });
+
+  it('staticAssets: false installs no static plugin in development', async () => {
+    devRef.value = true;
+
+    await app.register(SSRServer, {
+      alias: {},
+      configs: [],
+      routes: [],
+      clientRoot: '/client',
+      debug: false,
+      staticAssets: false,
+    });
+
+    const res = await app.inject({ method: 'GET', url: '/auto-default' });
+    expect(res.body).toBe('OK:notFound');
+  });
+
+  it('custom staticAssets registers exactly once and suppresses the default in production', async () => {
+    devRef.value = false;
+
+    const impl: FastifyPluginCallback<any> = (inst, _opts, done) => {
+      inst.get('/custom-static', async (_req, reply) => reply.send('custom-ok'));
+      done();
+    };
+    const staticPlugin = vi.fn(impl);
+
+    await app.register(SSRServer, {
+      alias: {},
+      configs: [],
+      routes: [],
+      clientRoot: '/client',
+      debug: false,
+      staticAssets: { plugin: staticPlugin },
+    });
+
+    const custom = await app.inject({ method: 'GET', url: '/custom-static' });
+    expect(custom.body).toBe('custom-ok');
+    expect(staticPlugin).toHaveBeenCalledTimes(1);
+
+    const auto = await app.inject({ method: 'GET', url: '/auto-default' });
+    expect(auto.body).toBe('OK:notFound');
+  });
+
+  it('caller-owned host keeps its own static facilities when τjs opts out', async () => {
+    devRef.value = false;
+
+    const CallerOwnedSSRServer = ssrServerPlugin({ callerOwnedHost: true });
+    app.get('/host-static', async (_req, reply) => reply.send('host-ok'));
+
+    await app.register(CallerOwnedSSRServer, {
+      alias: {},
+      configs: [],
+      routes: [],
+      clientRoot: '/client',
+      debug: false,
+      staticAssets: false,
+    });
+
+    const host = await app.inject({ method: 'GET', url: '/host-static' });
+    expect(host.body).toBe('host-ok');
+
+    // Encapsulated scope: τjs's not-found handler does NOT leak to the caller's root, so an
+    // unclaimed URL gets Fastify's own 404 (RFC 0010) - and no static plugin ever claimed it.
+    const auto = await app.inject({ method: 'GET', url: '/auto-default' });
+    expect(auto.statusCode).toBe(404);
+  });
+
   it('registers CSP reporting when configured', async () => {
     const onViolation = vi.fn();
 

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -38,6 +38,7 @@ export type SSRServerOptions = {
   routes: Route<RouteParams>[];
   serviceRegistry?: ServiceRegistry;
   security?: SecurityConfig;
+  /** `undefined` → default production registration; `false` → no static plugin; otherwise the caller's registration. */
   staticAssets?: StaticAssetsRegistration;
   debug?: DebugConfig;
   /** Internal runtime logger selection threaded from createServer; not a public createServer option. */

--- a/website/src/content/docs/guides/build-deployment.md
+++ b/website/src/content/docs/guides/build-deployment.md
@@ -543,11 +543,11 @@ npm run build:server
 
 **CDN cache rules:**
 
-````
-/assets/*        → max-age=31536000, immutable
-/*.html          → no-cache
-Other files      → no-cache unless hashed
-```#
+```text
+/assets/*        -> max-age=31536000, immutable
+/*.html          -> no-cache
+Other files      -> no-cache unless hashed
+```
 
 For pages that don't need per-user data:
 
@@ -555,20 +555,20 @@ For pages that don't need per-user data:
 - Configure cache headers on static assets
 - Use CDN/edge caching for HTML
 
-See [Edge-Cached Static Pages](/guides/static-assets/#static-caching-pattern) for the full pattern.
+See [CDN-owned assets](/guides/static-assets/#cdn-owned-assets) and [Caching](/guides/static-assets/#caching) for the full pattern.
 
 **Server configuration:**
 
 ```typescript
-// Don't serve static assets - CDN handles them
+// Install no static plugin - the CDN owns the files
 await createServer({
   fastify,
   config,
   serviceRegistry,
   clientRoot: "dist/client", // Still needed for manifests
-  registerStaticAssets: false, // Disable static middleware
+  staticAssets: false,
 });
-````
+```
 
 ### Option C: Reverse Proxy (Nginx)
 

--- a/website/src/content/docs/guides/static-assets.md
+++ b/website/src/content/docs/guides/static-assets.md
@@ -42,11 +42,9 @@ On a τjs-created host the facility is installed at the created root. On a suppl
 it is encapsulated with the τjs applications. A caller's own static routes remain the caller's
 responsibility.
 
-:::caution[`staticAssets: false` is not currently a production opt-out]
-The public option accepts `false`, but the current production registration treats a falsy value the
-same as omission and installs the default static plugin. Do not rely on `false` to disable static
-serving. A product correction is tracked separately from this documentation pass.
-:::
+Explicit `staticAssets: false` opts out entirely: no static plugin is installed in production or
+development. Omission and `false` are distinct requests - omit the option to receive the default
+registration, pass `false` when another system owns the files.
 
 ## Custom static registration
 
@@ -251,9 +249,8 @@ cache-safe by itself.
 A CDN or reverse proxy may serve `dist/client` before requests reach Fastify. The HTML server still
 needs the manifests and SSR modules required to generate correct asset references.
 
-Because the current `staticAssets: false` path does not disable default production registration, a
-CDN-only deployment should verify that the additional Fastify static routes do not conflict with host
-routes. Treat a true opt-out as pending product work rather than relying on undocumented behaviour.
+Set `staticAssets: false` for a CDN-only deployment: τjs installs no static plugin, so Fastify
+serves documents while the CDN owns the files under `dist/client`.
 
 ## Troubleshooting
 

--- a/website/src/content/docs/reference/app-shell-pattern.md
+++ b/website/src/content/docs/reference/app-shell-pattern.md
@@ -243,7 +243,7 @@ The shell stays the same - τjs changes the streaming/SSR/hydration mode.
 
 ### Static assets setup without the boilerplate
 
-Your existing `registerStaticAssets` option lets you plug in your own static handler (like `@fastify/static`) without wiring errors.
+The `staticAssets` option lets you plug in your own static handler (like `@fastify/static`) without wiring errors, or pass `false` to install no static plugin at all.
 
 ### Full SSR and Streaming SSR
 


### PR DESCRIPTION
Explicit false now installs no static plugin in production or development, while omission keeps the default @fastify/static registration. Previously a falsy value was treated the same as omission, so a CDN-only deployment could not disable Fastify static serving.

- CreateServer passes the option through verbatim instead of coalescing to false
- SSRServer's default branch gates on undefined, keeping explicit false out of both registration paths
- Tests cover omission, explicit false in both modes, exactly-once custom registration and the caller-owned host path
- Deployment and app-shell guides correct the option name; the static-assets guide documents the tri-state and drops the caveat