### PR TITLE
fix(server): align RouteContext with runtime shape and repair public …

### DIFF
--- a/.changeset/route-context-ruled-shape.md
+++ b/.changeset/route-context-ruled-shape.md
@@ -1,0 +1,7 @@
+---
+'@taujs/server': minor
+---
+
+Align the public RouteContext type with the runtime value - the context is `{ appId, path, attr, params }`, exactly what renderers receive. The `data` field is removed from the type (it was never supplied at runtime; route data reaches the renderer store) and the runtime-supplied `params` is typed as `RouteParams`.
+
+This also repairs the public aliases: `RouteContext` and `RouteData` from `@taujs/server/config` previously collapsed to `never` (optional `routes` on the broad config failed an internal array test), so neither was usable; there were no in-repository consumers of the collapsed aliases. `RouteContext` is now generic with a broad default - bare for the runtime shape, `RouteContext<typeof config>` for per-route precision - and a route without `attr` types its context `attr` as `undefined` rather than `never`. `RoutesData` and `RouteData` derive the same data unions as before from route declarations; path-specific `RouteData` lookup requires the concrete config type. Minor rather than patch because removing the declared `data` field can break downstream code typed against it, even though that field was always `undefined` at runtime.

--- a/packages/server/src/Config.ts
+++ b/packages/server/src/Config.ts
@@ -64,7 +64,14 @@ export { createServiceData, getServiceDataMetadata } from './core/services/Servi
 
 export type { ServiceDataMetadata } from './core/services/ServiceData';
 
-export type RouteContext = CoreRouteContext<TaujsConfig>;
+/**
+ * Public-alias repair (2026-07-30): generic with a broad default, mirroring `RouteData` below.
+ * Bare `RouteContext` is the broad runtime shape `{ appId, path, attr, params }`; supply your
+ * config - `RouteContext<typeof config>` - for per-route precision. The previous non-generic
+ * alias collapsed to `never` (optional `routes` failed RoutesOfApp's array test) and was
+ * unusable. Pinned by `test/PublicRouteContext.test-d.ts`.
+ */
+export type RouteContext<C extends TaujsConfig = TaujsConfig> = CoreRouteContext<C>;
 export type RouteData<C extends TaujsConfig = TaujsConfig, P extends string = string> = CoreRouteData<C, P>;
 
 // RFC 0004 (H1): the config-side head-data surface. `HeadDataOf<R>` infers what `headContent`

--- a/packages/server/src/core/config/test/RouteContext.test-d.ts
+++ b/packages/server/src/core/config/test/RouteContext.test-d.ts
@@ -1,0 +1,55 @@
+// Followup ruling (2026-07-29) - HARD GATE: `RouteContext<C>` must mirror the runtime value
+// HandleRender constructs - `{ appId, path, attr, params }` - with `data` ABSENT (route data
+// reaches the renderer store, never routeContext) and `params` typed as the broad `RouteParams`
+// every data handler receives. `RoutesData`/`RouteData` must keep deriving the same data unions
+// they derived before the ruling, now from route declarations rather than the context.
+//
+// Type-level test in the HeadDataOf.test-d.ts idiom: enforced by `pnpm --filter @taujs/server
+// typecheck` (tsc); the `.test-d.ts` suffix is outside vitest's test glob so it never runs as a
+// spec. Uses invariant-Equal (not mere assignability) so width-subtyping cannot fake a pass.
+import type { RouteContext, RouteData, RouteParams, RoutesData } from '../types';
+
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+type Home = { hero: string };
+type Product = { sku: string; title: string };
+
+const config = {
+  apps: [
+    {
+      appId: 'storefront',
+      entryPoint: '',
+      routes: [
+        {
+          path: '/',
+          attr: { render: 'ssr', data: async (): Promise<Home> => ({ hero: 'x' }) },
+        },
+        {
+          path: '/products/:id',
+          attr: { render: 'streaming', data: async (): Promise<Product> => ({ sku: 's', title: 't' }) },
+        },
+      ],
+    },
+  ],
+} as const;
+
+type C = typeof config;
+type Ctx = RouteContext<C>;
+
+// --- 1. The context's keys are EXACTLY the runtime keys - no more, no fewer. ---
+type _Keys = Expect<Equal<keyof Ctx, 'appId' | 'path' | 'attr' | 'params'>>;
+
+// --- 2. `data` is absent from the context (it was never supplied at runtime). ---
+// @ts-expect-error - routeContext does not carry route data; use the renderer store / RouteData
+type _NoData = Ctx['data'];
+
+// --- 3. Fields carry the ruled types. ---
+type _AppId = Expect<Equal<Ctx['appId'], 'storefront'>>;
+type _Paths = Expect<Equal<Ctx['path'], '/' | '/products/:id'>>;
+type _Params = Expect<Equal<Ctx['params'], RouteParams>>;
+
+// --- 4. RoutesData/RouteData derive the same unions as before the ruling. ---
+type _RoutesData = Expect<Equal<RoutesData<C>, Home | Product>>;
+type _RouteData = Expect<Equal<RouteData<C, '/products/:id'>, Product>>;
+type _HomeData = Expect<Equal<RouteData<C, '/'>, Home>>;

--- a/packages/server/src/core/config/types.ts
+++ b/packages/server/src/core/config/types.ts
@@ -122,9 +122,13 @@ export type AppId<C extends { apps: readonly { appId: string }[] }> = C['apps'][
 
 export type AppOf<C extends { apps: readonly any[] }, A extends AppId<C>> = Extract<C['apps'][number], { appId: A }>;
 
-export type RoutesOfApp<C extends { apps: readonly any[] }, A extends AppId<C>> = AppOf<C, A>['routes'] extends readonly any[]
-  ? AppOf<C, A>['routes'][number]
-  : never;
+// NonNullable is load-bearing (public-alias repair, 2026-07-30): the broad config family declares
+// `routes?:` (optional), so the raw property is `readonly AppRoute[] | undefined` and would fail
+// the array test - collapsing every derived context and data type to `never`, including the
+// public `RouteContext`/`RouteData` aliases. Literal configs with a required routes tuple are
+// unaffected. Pinned by `test/PublicRouteContext.test-d.ts`.
+export type RoutesOfApp<C extends { apps: readonly any[] }, A extends AppId<C>> =
+  NonNullable<AppOf<C, A>['routes']> extends readonly any[] ? NonNullable<AppOf<C, A>['routes']>[number] : never;
 
 export type RouteDataOf<R> = R extends { attr?: { data?: (...args: any) => infer Ret } } ? Awaited<Ret> : unknown;
 
@@ -182,12 +186,25 @@ type DescriptorMemberToRecord<V> = V extends ServiceDescriptor ? Record<string, 
 
 export type RoutePathOf<R> = R extends { path: infer P } ? P : never;
 
+/**
+ * Ruled 2026-07-29 (followup: RouteContext type/runtime drift): the public context type mirrors
+ * the runtime value HandleRender constructs - `{ appId, path, attr, params }` - EXACTLY. `data`
+ * was never supplied at runtime (route data reaches the renderer's store, not the context) and is
+ * deliberately absent; `params` is the matched route parameters, typed as the same broad
+ * `RouteParams` every data handler receives. Pinned by `test/RouteContext.test-d.ts` and by the
+ * HandleRender runtime assertions on both render strategies.
+ */
 export type SingleRouteContext<C extends { apps: readonly any[] }, A extends AppId<C>, R extends RoutesOfApp<C, A>> = R extends any
   ? {
       appId: A;
       path: RoutePathOf<R>;
-      data: RouteDataOf<R>;
-      attr: R extends { attr?: infer Attr } ? Attr : never;
+      // Three arms, mirroring the runtime (the context key always exists; its value is the
+      // route's attr or `undefined`): a required `attr` keeps its declared type; an optional
+      // `attr?:` declaration admits `undefined`; a route with no attr member types `undefined`.
+      // The single optional-probe arm this replaces resolved no-attr routes to `never` (the
+      // weak-type rule fails the probe outright) - a field the runtime populates with undefined.
+      attr: R extends { attr: infer Attr } ? Attr : R extends { attr?: infer Attr } ? Attr | undefined : undefined;
+      params: RouteParams;
     }
   : never;
 
@@ -195,9 +212,20 @@ export type RouteContext<C extends { apps: readonly any[] }> = {
   [A in AppId<C>]: SingleRouteContext<C, A, RoutesOfApp<C, A>>;
 }[AppId<C>];
 
-export type RoutesData<C extends { apps: readonly any[] }> = RouteContext<C>['data'];
+// Internal: preserves the exact pre-ruling data derivation for RoutesData/RouteData after `data`
+// left the public context. Distribution mechanics are identical to SingleRouteContext's, so the
+// derived unions are unchanged by the ruling.
+type SingleRouteDataEntry<C extends { apps: readonly any[] }, A extends AppId<C>, R extends RoutesOfApp<C, A>> = R extends any
+  ? { path: RoutePathOf<R>; data: RouteDataOf<R> }
+  : never;
 
-export type RouteData<C extends { apps: readonly any[] }, Path extends string> = Extract<RouteContext<C>, { path: Path }>['data'];
+type RouteDataEntry<C extends { apps: readonly any[] }> = {
+  [A in AppId<C>]: SingleRouteDataEntry<C, A, RoutesOfApp<C, A>>;
+}[AppId<C>];
+
+export type RoutesData<C extends { apps: readonly any[] }> = RouteDataEntry<C>['data'];
+
+export type RouteData<C extends { apps: readonly any[] }, Path extends string> = Extract<RouteDataEntry<C>, { path: Path }>['data'];
 
 export type CoreSecurityConfig = {
   csp?: {

--- a/packages/server/src/test/PublicRouteContext.test-d.ts
+++ b/packages/server/src/test/PublicRouteContext.test-d.ts
@@ -1,0 +1,79 @@
+// Public-alias repair (2026-07-30) - HARD GATE on the PUBLIC ENTRY: these imports come from
+// '../Config', exercising exactly what ships as '@taujs/server/config'. The internal derivation
+// gate (core/config/test/RouteContext.test-d.ts) cannot substitute for this file - the previous
+// non-generic alias collapsed to `never` while every internal assertion stayed green.
+//
+// Proves: bare `RouteContext` is the usable broad runtime shape; `RouteContext<typeof config>`
+// is per-route precise; required/optional/absent `attr` arms are honest; `data` is absent;
+// public `RouteData` stays precise on a concrete config and non-degenerate bare.
+// Same idiom as HeadDataOf.test-d.ts: enforced by `pnpm --filter @taujs/server typecheck` (tsc);
+// invariant-Equal so width-subtyping cannot fake a pass.
+import type { AppConfig, RouteContext, RouteData, RouteParams, TaujsConfig } from '../Config';
+import type { RouteAttributes } from '../core/config/types';
+
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+type Home = { hero: string };
+type Product = { sku: string; title: string };
+
+// A concrete configuration in TYPE space: `declare` keeps it value-free (the branded renderer
+// has no constructible test value); the literal members mirror an `as const` defineConfig call.
+// Four routes cover the attr arms: required attr (x2), absent attr, optional attr.
+declare const config: {
+  apps: readonly [
+    {
+      appId: 'storefront';
+      entryPoint: '';
+      renderer: AppConfig['renderer'];
+      routes: readonly [
+        { path: '/'; attr: { render: 'ssr'; data: () => Promise<Home> } },
+        { path: '/products/:id'; attr: { render: 'streaming'; meta: Record<string, unknown>; data: () => Promise<Product> } },
+        { path: '/bare' },
+        { path: '/opt'; attr?: { render: 'ssr' } },
+      ];
+    },
+  ];
+};
+
+// The sample must remain a real TaujsConfig, or the precise-form assertions test nothing.
+type _ConfigIsTaujsConfig = Expect<typeof config extends TaujsConfig ? true : false>;
+
+// --- 1. The bare alias is usable (the repaired defect: it used to be `never`). ---
+type _BareNotNever = Expect<Equal<[RouteContext] extends [never] ? true : false, false>>;
+
+// --- 2. Bare keys are exactly the four runtime keys. ---
+type _BareKeys = Expect<Equal<keyof RouteContext, 'appId' | 'path' | 'attr' | 'params'>>;
+
+// --- 3. Bare field types: the broad runtime shape. ---
+type _BareAppId = Expect<Equal<RouteContext['appId'], string>>;
+type _BarePath = Expect<Equal<RouteContext['path'], string>>;
+type _BareAttr = Expect<Equal<RouteContext['attr'], RouteAttributes<RouteParams> | undefined>>;
+type _BareParams = Expect<Equal<RouteContext['params'], RouteParams>>;
+
+// --- 4. `data` is absent from the public context. ---
+// @ts-expect-error - routeContext does not carry route data; use the renderer store / RouteData
+type _NoData = RouteContext['data'];
+
+// --- 5. The precise form preserves route-specific appId, path and attr. ---
+type PreciseCtx = RouteContext<typeof config>;
+
+type _PreciseAppId = Expect<Equal<PreciseCtx['appId'], 'storefront'>>;
+type _PrecisePaths = Expect<Equal<PreciseCtx['path'], '/' | '/products/:id' | '/bare' | '/opt'>>;
+type _PreciseParams = Expect<Equal<PreciseCtx['params'], RouteParams>>;
+
+// attr arms, member by member:
+type _AttrRequired = Expect<Equal<Extract<PreciseCtx, { path: '/' }>['attr'], { render: 'ssr'; data: () => Promise<Home> }>>;
+type _AttrAbsent = Expect<Equal<Extract<PreciseCtx, { path: '/bare' }>['attr'], undefined>>;
+type _AttrOptional = Expect<Equal<Extract<PreciseCtx, { path: '/opt' }>['attr'], { render: 'ssr' } | undefined>>;
+
+// --- 6. Public RouteData: precise on a concrete config (`/typo` against a concrete config
+// stays `never` - typo detection), non-degenerate bare, and the broad + literal-path form is
+// RULED unsupported (stays `never`): TaujsConfig contains no evidence about '/x', and we decline
+// the extra conditional machinery that could return `unknown` for that case. Path-specific
+// lookup requires the concrete configuration type. ---
+type _RouteDataPrecise = Expect<Equal<RouteData<typeof config, '/products/:id'>, Product>>;
+type _RouteDataHome = Expect<Equal<RouteData<typeof config, '/'>, Home>>;
+type _RouteDataTypo = Expect<Equal<RouteData<typeof config, '/typo'>, never>>;
+type _RouteDataBareNotNever = Expect<Equal<[RouteData] extends [never] ? true : false, false>>;
+type _RouteDataBroadLiteralPath = Expect<Equal<RouteData<TaujsConfig, '/x'>, never>>;

--- a/packages/server/src/utils/test/HandleRender.test.ts
+++ b/packages/server/src/utils/test/HandleRender.test.ts
@@ -506,6 +506,10 @@ describe('handleRender', () => {
           },
         }),
       );
+
+      // Ruled shape gate (followup 2026-07-29): exactly the four runtime keys, matching the
+      // public RouteContext type - `data` must never appear.
+      expect(Object.keys(options.routeContext).sort()).toEqual(['appId', 'attr', 'params', 'path']);
     });
 
     it('should throw error when renderSSR is missing', async () => {
@@ -999,17 +1003,9 @@ describe('handleRender', () => {
         }),
       );
 
-      expect(options).toEqual(
-        expect.objectContaining({
-          logger: mockLogger,
-          routeContext: {
-            appId: 'test-app',
-            path: '/articles/:slug',
-            attr,
-            params,
-          },
-        }),
-      );
+      // Ruled shape gate (followup 2026-07-29): exactly the four runtime keys, matching the
+      // public RouteContext type - `data` must never appear.
+      expect(Object.keys(options.routeContext).sort()).toEqual(['appId', 'attr', 'params', 'path']);
     });
 
     // ESC-2: cspNonce + shouldHydrate are the symmetric RenderOptions - computed ONCE by the host and

--- a/website/src/content/docs/renderers/react.mdx
+++ b/website/src/content/docs/renderers/react.mdx
@@ -1057,7 +1057,7 @@ export const serviceRegistry = defineServiceRegistry({
 
 ### Typed route context from `taujs.config.ts`
 
-When you use `@taujs/server`, you can derive a typed route context from your config and feed it into `createRenderer`:
+When you use `@taujs/server`, the host builds the route context for you - `{ appId, path, attr, params }` from the matched route. Type the generic with the exported `RouteContext`: the bare form is the broad runtime shape, and `RouteContext<typeof config>` narrows `appId`, `path` and `attr` to the routes your config declares:
 
 ```typescript
 import { createRenderer, escapeHtml } from "@taujs/react";
@@ -1065,7 +1065,7 @@ import { createRenderer, escapeHtml } from "@taujs/react";
 import config from "../taujs.config";
 import { AppBootstrap } from "./AppBootstrap";
 
-import type { RouteContext } from "@taujs/server";
+import type { RouteContext } from "@taujs/server/config";
 
 export const { renderSSR, renderStream } = createRenderer<
   Record<string, unknown>,
@@ -1085,7 +1085,7 @@ export const { renderSSR, renderStream } = createRenderer<
 });
 ```
 
-`@taujs/server` builds a matching routeContext object from the matched route (appId, path, params, attr, data) and passes it into renderSSR / renderStream for you.
+`@taujs/server` builds a matching routeContext object from the matched route (`appId`, `path`, `attr`, `params`) and passes it into renderSSR / renderStream for you. Route data is not on it - that arrives through the SSR store.
 
 ### Key Integration Features
 

--- a/website/src/content/docs/renderers/solid.mdx
+++ b/website/src/content/docs/renderers/solid.mdx
@@ -902,9 +902,9 @@ function Component() {
 
 You do not have to hand-repeat a payload shape. `@taujs/server/config` exports types that derive from your `taujs.config.ts` route table:
 
-- `RouteData<typeof config, "/path">` - the resolved data type of the route with that path (the awaited return of its `attr.data` loader).
+- `RouteData<typeof config, "/path">` - the resolved data type of the route with that path (the awaited return of its `attr.data` loader). Path-specific lookup requires the concrete config type - the broad `RouteData` default cannot name your routes.
 - `HeadDataOf<typeof route>` - what `headContent` receives as `headData` for a route. This is what makes the `attr.head` → `headContent` chain typed end to end (RFC 0004, a signed type gate).
-- `RouteContext<...>` - the union of `{ appId, path, data, attr }` across the config's routes.
+- `RouteContext<typeof config>` - the union of `{ appId, path, attr, params }` across the config's routes: the value the host passes to `appComponent` and `headContent` as `routeContext`. The bare `RouteContext` (the generic's default) is the broad runtime shape. Route data is not on it - that reaches the renderer's store, typed by `RouteData`.
 
 ```ts
 import type { RouteData } from "@taujs/server/config";


### PR DESCRIPTION
…aliases

The public context type now mirrors the runtime value exactly: { appId, path, attr, params }. The never-supplied data field is removed and the runtime-supplied params is typed as RouteParams.

Also repairs the public aliases, which had collapsed to never since their introduction: optional routes on the broad config failed RoutesOfApp's array test, so RouteContext and RouteData from @taujs/server/config were unusable. RouteContext is now generic with a broad default (bare form = runtime shape, RouteContext<typeof config> = per-route precision), NonNullable de-collapses the derivation, and a three-arm attr types no-attr routes as undefined rather than never. RoutesData and RouteData keep their exact pre-ruling unions; RouteData<TaujsConfig, '/x'> is intentionally unsupported - the broad config holds no evidence about the path.

- PublicRouteContext.test-d.ts gates the Config.ts entry: bare shape, precise form, all three attr arms, and the RouteData rulings including concrete-config typo detection
- RouteContext.test-d.ts pins the internal derivation
- HandleRender tests assert the exact four-key runtime shape on both render strategies
- react and solid renderer references corrected; the react example now imports RouteContext from @taujs/server/config with the per-config type argument