### PR TITLE
feat: derive the generated app type chain from taujs.config.ts

### DIFF
--- a/.changeset/create-taujs-derived-types.md
+++ b/.changeset/create-taujs-derived-types.md
@@ -1,0 +1,5 @@
+---
+'@taujs/create-taujs': minor
+---
+
+Generated projects now demonstrate the derived type chain from `taujs.config.ts` through the renderer to the store. A type-only `src/client/app-types.ts` exports `AppRouteContext = RouteContext<typeof config>` and `AppData = RouteData<typeof config>`; the generated config declares registry-typed `serviceData()` edges instead of a hand-built descriptor; `createRenderer` receives `<AppData, AppRouteContext>` in all three frameworks; and every hand-written payload type is replaced by the derived `AppData`. The lifecycle gate typechecks a generated project end to end against packed tarballs.

--- a/.changeset/route-data-brand-arm.md
+++ b/.changeset/route-data-brand-arm.md
@@ -1,0 +1,5 @@
+---
+'@taujs/server': patch
+---
+
+`RouteData` now resolves `serviceData()` routes to the selected service method's result instead of the runtime descriptor - the `RouteDataOf` brand arm the `SERVICE_RESULT` comment always promised, mirroring `HeadDataOf`. Hand-built descriptor closures collapse to `Record<string, unknown>` (the dispatch result is untyped), plain closures are unchanged, and a route without `attr.data` resolves to the new exported `EmptyRouteData` (`Record<string, undefined>` - the honest type of the `{}` the server supplies), so a data-less route unions cleanly into an app-wide `RouteData` instead of collapsing it to `unknown`. All arms pinned by the internal and public type gates.

--- a/packages/create-taujs/src/index.ts
+++ b/packages/create-taujs/src/index.ts
@@ -306,6 +306,9 @@ export function planFiles(config: ProjectConfig): FileEntry[] {
     { path: 'CLAUDE.md', content: generateClaudeMd() },
     { path: 'src/client/index.html', content: generateIndexHtml() },
     { path: 'src/client/styles.css', content: generateStyles() },
+    // The derived type contract (framework-independent): AppData/AppRouteContext come from
+    // taujs.config.ts, so client code never hand-writes a payload shape.
+    { path: 'src/client/app-types.ts', content: generateAppTypes() },
     // server (framework-independent — a single shared source)
     { path: 'src/server/index.ts', content: generateServerIndex() },
     { path: 'src/server/services/registry.ts', content: generateServiceRegistry() },
@@ -546,7 +549,15 @@ function generateTaujsConfig(framework: Framework) {
       : framework === 'solid'
         ? `\n      renderer: solidRenderer({ project: './tsconfig.solid.json' }),`
         : `\n      renderer: reactRenderer({ project: './tsconfig.json' }),`;
-  return `import { defineConfig } from '@taujs/server/config';${rendererImport}
+  return `import { createServiceData, defineConfig } from '@taujs/server/config';${rendererImport}
+
+import type { ServiceRegistry } from './src/server/services/registry.ts';
+
+// Registry-typed service declarations: the helper carries each method's RESULT type into
+// RouteData, so the app's types derive from this file instead of being hand-written
+// (see src/client/app-types.ts). Closure handlers and ctx.call remain available for dynamic
+// dispatch - https://taujs.dev/guides/services/
+const serviceData = createServiceData<ServiceRegistry>();
 
 export default defineConfig({
   server: {
@@ -570,10 +581,8 @@ export default defineConfig({
           attr: {
             render: 'ssr',
             hydrate: true,
-            // Direct service invocation: standard SSR
-            data: async (params, ctx) => {
-              return ctx.call('example', 'greet', { name: 'SSR' });
-            },
+            // Declared service edge: RouteData<typeof config, '/'> is greet()'s resolved result
+            data: serviceData('example', 'greet', () => ({ name: 'SSR' })),
           },
         },
         {
@@ -581,12 +590,8 @@ export default defineConfig({
           attr: {
             render: 'streaming',
             hydrate: true,
-            // Descriptor-based data: resolved by the server
-            data: async (params) => ({
-              args: { name: 'Streaming' },
-              serviceName: 'example',
-              serviceMethod: 'greet',
-            }),
+            // The same declared edge on a streaming route: the shell streams while greet() resolves
+            data: serviceData('example', 'greet', () => ({ name: 'Streaming' })),
             // meta recommended for streaming routes for SEO/social and render timing
             meta: {
               title: "τjs — Streaming",
@@ -652,9 +657,11 @@ function generateReadme(projectName: string, packageManager: string, framework: 
       ? `│   │   ├── App.vue             # Root component (route switch)
 │   │   ├── HomePage.vue        # SSR route (useSSRData + v-if)
 │   │   ├── StreamingPage.vue   # Streaming route (await useSSRDataAsync)
+│   │   ├── app-types.ts        # Types derived from taujs.config.ts
 │   │   ├── entry-client.ts     # Client hydration entry
 │   │   ├── entry-server.ts     # SSR render entry`
       : `│   │   ├── App.tsx             # Root component
+│   │   ├── app-types.ts        # Types derived from taujs.config.ts
 │   │   ├── entry-client.tsx    # Client hydration entry
 │   │   ├── entry-server.tsx    # SSR render entry`;
 
@@ -753,13 +760,11 @@ import { useSSRStore } from '@taujs/react';
 
 import "./styles.css";
 
-type GreetingData = {
-  message: string;
-  timestamp: string;
-};
+import type { AppData } from './app-types';
 
 function GreetingCard() {
-  const data = useSSRStore<GreetingData>();
+  // AppData is derived from taujs.config.ts - greet()'s result, never hand-written.
+  const data = useSSRStore<AppData>();
 
   return (
     <section className="card card--primary">
@@ -813,9 +818,9 @@ export function App() {
           which is ideal for predictable latency and caching.
         </p>
         <p>
-          <strong>STREAM:</strong> The <code>/streaming</code> route uses a service descriptor
-          and returns a Promise. The <code>&lt;Suspense&gt;</code> boundary above shows
-          a fallback while the server resolves it, then progressively streams the final content.
+          <strong>STREAM:</strong> The <code>/streaming</code> route declares the same typed
+          service edge with streaming rendering. The <code>&lt;Suspense&gt;</code> boundary above
+          shows a fallback while the server resolves it, then progressively streams the final content.
         </p>
       </section>
 
@@ -1055,6 +1060,34 @@ code {
 }`;
 }
 
+function generateAppTypes() {
+  return `/**
+ * The application's type contract, DERIVED from taujs.config.ts - never hand-written.
+ * Every import here is type-only, so nothing from the config or server reaches the client bundle.
+ */
+import type config from '../../taujs.config.ts';
+import type { RouteContext, RouteData } from '@taujs/server/config';
+
+/** The route-discriminated context the host passes to appComponent and headContent. */
+export type AppRouteContext = RouteContext<typeof config>;
+
+/**
+ * The union of every declared route's resolved data - both scaffold routes resolve greet(), so
+ * one shared type serves the whole app.
+ *
+ * A declared route WITHOUT \`attr.data\` contributes \`Record<string, undefined>\` (the server
+ * supplies \`{}\` for it), so the union stays usable when such routes exist: reads become
+ * \`T | undefined\`, making code account for the no-data route. When routes diverge further,
+ * narrow per route with the derived aliases below - still from the config, never hand-written.
+ */
+export type AppData = RouteData<typeof config>;
+
+// Optional narrowing when routes diverge:
+// export type HomeData = RouteData<typeof config, '/'>;
+// export type StreamingData = RouteData<typeof config, '/streaming'>;
+`;
+}
+
 function generateViteEnv() {
   return `/// <reference types="vite/client" />
 `;
@@ -1148,13 +1181,11 @@ function generateHomePageVue() {
   return `<script setup lang="ts">
 import { useSSRData } from '@taujs/vue';
 
-type GreetingData = {
-  message: string;
-  timestamp: string;
-};
+import type { AppData } from './app-types';
 
 // Fallback idiom: non-blocking; \`data\` is undefined until ready, guarded with v-if.
-const data = useSSRData<GreetingData>();
+// AppData is derived from taujs.config.ts - greet()'s result, never hand-written.
+const data = useSSRData<AppData>();
 </script>
 
 <template>
@@ -1174,13 +1205,11 @@ function generateStreamingPageVue() {
   return `<script setup lang="ts">
 import { useSSRDataAsync } from '@taujs/vue';
 
-type GreetingData = {
-  message: string;
-  timestamp: string;
-};
+import type { AppData } from './app-types';
 
 // Suspense idiom: async setup blocks on the data, so streamed routes deliver it in the payload.
-const data = await useSSRDataAsync<GreetingData>();
+// AppData is derived from taujs.config.ts - greet()'s result, never hand-written.
+const data = await useSSRDataAsync<AppData>();
 </script>
 
 <template>
@@ -1210,13 +1239,17 @@ function generateEntryServerVue() {
 
 import App from './App.vue';
 
-export const { renderSSR, renderStream } = createRenderer({
+import type { AppData, AppRouteContext } from './app-types';
+
+// Generics derived from taujs.config.ts: typed data for headContent and the store, typed
+// routeContext for appComponent.
+export const { renderSSR, renderStream } = createRenderer<AppData, AppRouteContext>({
   appComponent: App,
   headContent: ({ data, meta }) => \`
     <title>\${meta?.title || "τjs - Composing systems, not just apps"}</title>
     <meta name="description" content="\${
       meta?.description ||
-      (data as { message?: string })?.message ||
+      data?.message ||
       "τjs - Composing systems, not just apps"
     }">
   \`,
@@ -1241,7 +1274,11 @@ function generateEntryServer() {
   return `import { createRenderer } from '@taujs/react';
 import { App } from './App';
 
-export const { renderSSR, renderStream } = createRenderer({
+import type { AppData, AppRouteContext } from './app-types';
+
+// Generics derived from taujs.config.ts: typed data for headContent and the store, typed
+// routeContext for appComponent.
+export const { renderSSR, renderStream } = createRenderer<AppData, AppRouteContext>({
   appComponent: () => <App />,
   headContent: ({ data, meta }) => \`
     <title>\${meta?.title || "τjs - Composing systems, not just apps"}</title>
@@ -1284,12 +1321,13 @@ function generateAppComponentSolid() {
   return `import { Show } from 'solid-js';
 import { useSSRStore } from '@taujs/solid';
 
-type RouteData = { message?: string };
+import type { AppData } from './app-types';
 
 export function App() {
   // Route data arrives through the store, which the renderer provides. On the server it is already
   // committed before the render begins; on the client it is seeded from window.__INITIAL_DATA__.
-  const store = useSSRStore<RouteData>();
+  // AppData is derived from taujs.config.ts - greet()'s result, never hand-written.
+  const store = useSSRStore<AppData>();
 
   return (
     <main>
@@ -1326,7 +1364,11 @@ function generateEntryServerSolid() {
 import { App } from './App';
 import { RENDER_ID } from './renderId';
 
-export const { renderSSR, renderStream } = createRenderer({
+import type { AppData, AppRouteContext } from './app-types';
+
+// Generics derived from taujs.config.ts: typed data for headContent and the store, typed
+// routeContext for appComponent.
+export const { renderSSR, renderStream } = createRenderer<AppData, AppRouteContext>({
   appComponent: () => <App />,
   renderId: RENDER_ID,
   headContent: ({ data, meta }) => \`

--- a/packages/create-taujs/src/test/__snapshots__/generate.test.ts.snap
+++ b/packages/create-taujs/src/test/__snapshots__/generate.test.ts.snap
@@ -100,6 +100,7 @@ demo-app/
 ├── src/
 │   ├── client/              
 │   │   ├── App.tsx             # Root component
+│   │   ├── app-types.ts        # Types derived from taujs.config.ts
 │   │   ├── entry-client.tsx    # Client hydration entry
 │   │   ├── entry-server.tsx    # SSR render entry
 │   │   ├── styles.css          # Global styles
@@ -186,13 +187,11 @@ import { useSSRStore } from '@taujs/react';
 
 import "./styles.css";
 
-type GreetingData = {
-  message: string;
-  timestamp: string;
-};
+import type { AppData } from './app-types';
 
 function GreetingCard() {
-  const data = useSSRStore<GreetingData>();
+  // AppData is derived from taujs.config.ts - greet()'s result, never hand-written.
+  const data = useSSRStore<AppData>();
 
   return (
     <section className="card card--primary">
@@ -246,9 +245,9 @@ export function App() {
           which is ideal for predictable latency and caching.
         </p>
         <p>
-          <strong>STREAM:</strong> The <code>/streaming</code> route uses a service descriptor
-          and returns a Promise. The <code>&lt;Suspense&gt;</code> boundary above shows
-          a fallback while the server resolves it, then progressively streams the final content.
+          <strong>STREAM:</strong> The <code>/streaming</code> route declares the same typed
+          service edge with streaming rendering. The <code>&lt;Suspense&gt;</code> boundary above
+          shows a fallback while the server resolves it, then progressively streams the final content.
         </p>
       </section>
 
@@ -272,6 +271,31 @@ export function App() {
   );
 }
 ",
+  "src/client/app-types.ts": "/**
+ * The application's type contract, DERIVED from taujs.config.ts - never hand-written.
+ * Every import here is type-only, so nothing from the config or server reaches the client bundle.
+ */
+import type config from '../../taujs.config.ts';
+import type { RouteContext, RouteData } from '@taujs/server/config';
+
+/** The route-discriminated context the host passes to appComponent and headContent. */
+export type AppRouteContext = RouteContext<typeof config>;
+
+/**
+ * The union of every declared route's resolved data - both scaffold routes resolve greet(), so
+ * one shared type serves the whole app.
+ *
+ * A declared route WITHOUT \`attr.data\` contributes \`Record<string, undefined>\` (the server
+ * supplies \`{}\` for it), so the union stays usable when such routes exist: reads become
+ * \`T | undefined\`, making code account for the no-data route. When routes diverge further,
+ * narrow per route with the derived aliases below - still from the config, never hand-written.
+ */
+export type AppData = RouteData<typeof config>;
+
+// Optional narrowing when routes diverge:
+// export type HomeData = RouteData<typeof config, '/'>;
+// export type StreamingData = RouteData<typeof config, '/streaming'>;
+",
   "src/client/entry-client.tsx": "import { hydrateApp } from '@taujs/react';
 import { App } from './App';
 
@@ -284,7 +308,11 @@ hydrateApp({
   "src/client/entry-server.tsx": "import { createRenderer } from '@taujs/react';
 import { App } from './App';
 
-export const { renderSSR, renderStream } = createRenderer({
+import type { AppData, AppRouteContext } from './app-types';
+
+// Generics derived from taujs.config.ts: typed data for headContent and the store, typed
+// routeContext for appComponent.
+export const { renderSSR, renderStream } = createRenderer<AppData, AppRouteContext>({
   appComponent: () => <App />,
   headContent: ({ data, meta }) => \`
     <title>\${meta?.title || "τjs - Composing systems, not just apps"}</title>
@@ -601,8 +629,16 @@ declare module '@taujs/server/config' {
   }
 }
 ",
-  "taujs.config.ts": "import { defineConfig } from '@taujs/server/config';
+  "taujs.config.ts": "import { createServiceData, defineConfig } from '@taujs/server/config';
 import { reactRenderer } from '@taujs/react/renderer';
+
+import type { ServiceRegistry } from './src/server/services/registry.ts';
+
+// Registry-typed service declarations: the helper carries each method's RESULT type into
+// RouteData, so the app's types derive from this file instead of being hand-written
+// (see src/client/app-types.ts). Closure handlers and ctx.call remain available for dynamic
+// dispatch - https://taujs.dev/guides/services/
+const serviceData = createServiceData<ServiceRegistry>();
 
 export default defineConfig({
   server: {
@@ -627,10 +663,8 @@ export default defineConfig({
           attr: {
             render: 'ssr',
             hydrate: true,
-            // Direct service invocation: standard SSR
-            data: async (params, ctx) => {
-              return ctx.call('example', 'greet', { name: 'SSR' });
-            },
+            // Declared service edge: RouteData<typeof config, '/'> is greet()'s resolved result
+            data: serviceData('example', 'greet', () => ({ name: 'SSR' })),
           },
         },
         {
@@ -638,12 +672,8 @@ export default defineConfig({
           attr: {
             render: 'streaming',
             hydrate: true,
-            // Descriptor-based data: resolved by the server
-            data: async (params) => ({
-              args: { name: 'Streaming' },
-              serviceName: 'example',
-              serviceMethod: 'greet',
-            }),
+            // The same declared edge on a streaming route: the shell streams while greet() resolves
+            data: serviceData('example', 'greet', () => ({ name: 'Streaming' })),
             // meta recommended for streaming routes for SEO/social and render timing
             meta: {
               title: "τjs — Streaming",

--- a/packages/create-taujs/src/test/cli-solid.test.ts
+++ b/packages/create-taujs/src/test/cli-solid.test.ts
@@ -135,7 +135,7 @@ describe('create-taujs - Solid generation (through the package export)', () => {
       const renderId = read('src/client/renderId.ts');
 
       expect(entryServer).toContain("import { createRenderer } from '@taujs/solid';");
-      expect(entryServer).toContain('export const { renderSSR, renderStream } = createRenderer({');
+      expect(entryServer).toContain('export const { renderSSR, renderStream } = createRenderer<AppData, AppRouteContext>({');
       expect(entryClient).toContain("import { hydrateApp } from '@taujs/solid';");
 
       // The renderId is ONE shared constant imported by BOTH entries - a literal duplicated across

--- a/packages/create-taujs/src/test/generate.test.ts
+++ b/packages/create-taujs/src/test/generate.test.ts
@@ -48,6 +48,7 @@ describe('planFiles — Vue template', () => {
       'src/client/App.vue',
       'src/client/HomePage.vue',
       'src/client/StreamingPage.vue',
+      'src/client/app-types.ts',
       'src/client/entry-client.ts',
       'src/client/entry-server.ts',
       'src/client/vite-env.d.ts',
@@ -70,6 +71,8 @@ describe('planFiles — Vue template', () => {
       'build.ts',
       'src/client/index.html',
       'src/client/styles.css',
+      // The derived type contract is framework-independent by design - one source.
+      'src/client/app-types.ts',
       'src/server/tsconfig.json',
       '.mcp.json',
       'CLAUDE.md',
@@ -122,7 +125,28 @@ describe('planFiles — Vue template', () => {
   it('references no removed APIs and no /__taujs paths', () => {
     const all = Object.values(vue).join('\n');
     expect(all).not.toMatch(/__taujs\//);
-    expect(all).not.toMatch(/getSnapshotOrThrow|useSSRDataOrSuspend|RouteData|useRouteClientData/);
+    // `RouteData` left this denylist 2026-07-30: the banned name was a removed CLIENT API, and the
+    // server-derived `RouteData` type is now a legitimate import in app-types.ts - from
+    // '@taujs/server/config' only, asserted below.
+    expect(all).not.toMatch(/getSnapshotOrThrow|useSSRDataOrSuspend|useRouteClientData/);
+  });
+
+  it('derives the type chain from taujs.config.ts instead of hand-writing it', () => {
+    const all = Object.values(vue).join('\n');
+    const appTypes = vue['src/client/app-types.ts']!;
+    expect(appTypes).toContain("import type { RouteContext, RouteData } from '@taujs/server/config';");
+    expect(appTypes).toContain('export type AppRouteContext = RouteContext<typeof config>;');
+    expect(appTypes).toContain('export type AppData = RouteData<typeof config>;');
+
+    // The config declares registry-typed service edges, never a hand-built descriptor.
+    expect(vue['taujs.config.ts']).toContain('const serviceData = createServiceData<ServiceRegistry>();');
+    expect(vue['taujs.config.ts']).not.toContain('serviceName:');
+
+    // Clients consume the derived types; no template hand-writes a payload shape.
+    expect(all).not.toContain('GreetingData');
+    expect(vue['src/client/HomePage.vue']).toContain('useSSRData<AppData>()');
+    expect(vue['src/client/StreamingPage.vue']).toContain('useSSRDataAsync<AppData>()');
+    expect(vue['src/client/entry-server.ts']).toContain('createRenderer<AppData, AppRouteContext>({');
   });
 
   it('README documents the Vue file tree and Vue docs link', () => {

--- a/packages/create-taujs/src/test/lifecycle.test.ts
+++ b/packages/create-taujs/src/test/lifecycle.test.ts
@@ -27,7 +27,8 @@ import { afterAll, describe, expect, it } from 'vitest';
  * - Teardown awaits actual process exit and polls until the port is released - no fixed sleeps.
  *
  * React runs the identical stages as a CONTROL, proving the scaffolder-baseline corrections are
- * shared repairs rather than Solid-specific accommodations.
+ * shared repairs rather than Solid-specific accommodations. Vue joined on 2026-07-30 (derived
+ * type-chain work), so the generated chain is compiler-proven for all three frameworks.
  */
 const REPO_ROOT = fileURLToPath(new URL('../../../../', import.meta.url));
 const CLI = fileURLToPath(new URL('../../dist/index.js', import.meta.url));
@@ -124,7 +125,7 @@ const startServer = (cwd: string, script: string) => {
   return { child, output: () => output };
 };
 
-/** Pack every workspace package once; both frameworks install identical, user-shaped tarballs. */
+/** Pack every workspace package once; all three frameworks install identical, user-shaped tarballs. */
 let packedCache: Record<string, string> | undefined;
 const packAll = (): Record<string, string> => {
   if (packedCache) return packedCache;
@@ -168,7 +169,7 @@ const runTransaction = async (stages: Stage[]): Promise<string[]> => {
   return completed;
 };
 
-describe.each(['solid', 'react'] as const)('slice 6 - generated %s project lifecycle (real CLI, packed tarballs)', (framework) => {
+describe.each(['solid', 'react', 'vue'] as const)('slice 6 - generated %s project lifecycle (real CLI, packed tarballs)', (framework) => {
   it('generates, installs, typechecks, boots dev, builds, and boots production', { timeout: 900_000 }, async () => {
     if (!existsSync(CLI)) throw new Error(`CLI dist missing at ${CLI} - run \`pnpm build\` first`);
 
@@ -194,7 +195,7 @@ describe.each(['solid', 'react'] as const)('slice 6 - generated %s project lifec
         run: () => {
           const read = (rel: string) => readFileSync(path.join(projectDir, rel), 'utf8');
 
-          // Shared scaffolder baseline, asserted for BOTH frameworks.
+          // Shared scaffolder baseline, asserted for ALL THREE frameworks.
           expect(read('src/server/types.d.ts').startsWith("import '@taujs/server/config';")).toBe(true);
           const pkg = JSON.parse(read('package.json')) as { devDependencies: Record<string, string>; scripts: Record<string, string> };
           expect(pkg.devDependencies.esbuild).toBeTruthy();
@@ -206,9 +207,12 @@ describe.each(['solid', 'react'] as const)('slice 6 - generated %s project lifec
             expect(read('src/client/entry-server.tsx')).toContain("import { createRenderer } from '@taujs/solid';");
             expect(read('src/client/entry-client.tsx')).toContain("import { hydrateApp } from '@taujs/solid';");
             expect(JSON.parse(read('tsconfig.solid.json')).include).toEqual(['src/client/**/*.tsx']);
-          } else {
+          } else if (framework === 'react') {
             expect(read('taujs.config.ts')).toContain('reactRenderer({');
             expect(read('src/client/entry-server.tsx')).toContain("import { createRenderer } from '@taujs/react';");
+          } else {
+            expect(read('taujs.config.ts')).toContain('renderer: vueRenderer(),');
+            expect(read('src/client/entry-server.ts')).toContain("import { createRenderer } from '@taujs/vue';");
           }
         },
       },

--- a/packages/server/src/Config.ts
+++ b/packages/server/src/Config.ts
@@ -77,7 +77,7 @@ export type RouteData<C extends TaujsConfig = TaujsConfig, P extends string = st
 // RFC 0004 (H1): the config-side head-data surface. `HeadDataOf<R>` infers what `headContent`
 // receives as `headData` for a route (the phantom-branded service result for `serviceData()`
 // loaders); `ServiceDataHandler` is `serviceData()`'s branded return type.
-export type { HeadAttributes, HeadDataOf, RouteParams, ServiceDataHandler } from './core/config/types';
+export type { EmptyRouteData, HeadAttributes, HeadDataOf, RouteParams, ServiceDataHandler } from './core/config/types';
 
 // RFC 0007 (decision 19): the config-side deferred-data surface, beside `HeadDataOf`.
 // `DeferredDataOf<R>` infers what a renderer's deferred accessor receives for a route;

--- a/packages/server/src/core/config/test/RouteContext.test-d.ts
+++ b/packages/server/src/core/config/test/RouteContext.test-d.ts
@@ -7,7 +7,7 @@
 // Type-level test in the HeadDataOf.test-d.ts idiom: enforced by `pnpm --filter @taujs/server
 // typecheck` (tsc); the `.test-d.ts` suffix is outside vitest's test glob so it never runs as a
 // spec. Uses invariant-Equal (not mere assignability) so width-subtyping cannot fake a pass.
-import type { RouteContext, RouteData, RouteParams, RoutesData } from '../types';
+import type { EmptyRouteData, RouteContext, RouteData, RouteParams, RoutesData } from '../types';
 
 type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
 type Expect<T extends true> = T;
@@ -53,3 +53,97 @@ type _Params = Expect<Equal<Ctx['params'], RouteParams>>;
 type _RoutesData = Expect<Equal<RoutesData<C>, Home | Product>>;
 type _RouteData = Expect<Equal<RouteData<C, '/products/:id'>, Product>>;
 type _HomeData = Expect<Equal<RouteData<C, '/'>, Home>>;
+
+// --- 5. RouteDataOf brand arm (2026-07-30): a `serviceData()` route resolves the SELECTED
+// METHOD's result - never the descriptor the handler honestly returns at runtime - following
+// HeadDataOf's arms exactly. Uses the real helper so the brand seam itself is exercised. ---
+import { createServiceData } from '../../services/ServiceData';
+
+type Sku = { sku: string; price: number };
+
+type Registry = Readonly<{
+  catalog: Readonly<{
+    getSku: (params: { id: string }, ctx: any) => Promise<Sku>;
+  }>;
+}>;
+
+const serviceData = createServiceData<Registry>();
+
+const svcConfig = {
+  apps: [
+    {
+      appId: 'svc',
+      entryPoint: '',
+      routes: [
+        {
+          path: '/sku/:id',
+          attr: { render: 'ssr', data: serviceData('catalog', 'getSku', (p) => ({ id: String(p.id) })) },
+        },
+      ],
+    },
+  ],
+} as const;
+
+type _SvcRouteData = Expect<Equal<RouteData<typeof svcConfig, '/sku/:id'>, Sku>>;
+type _SvcRoutesData = Expect<Equal<RoutesData<typeof svcConfig>, Sku>>;
+
+// --- 6. The other two RouteDataOf arms the changeset promises (matching HeadDataOf's gate):
+// a PURE hand-built descriptor collapses to Record<string, unknown> (the dispatch result is
+// untyped), a MIXED object-or-descriptor return distributes to ObjectType | Record<string,
+// unknown> (the descriptor member must never be silently dropped), and no `attr.data` resolves
+// to EmptyRouteData (the ruling section 7 proves app-wide). ---
+import type { ServiceDescriptor } from '../../services/DataServices';
+
+const descriptorConfig = {
+  apps: [
+    {
+      appId: 'desc',
+      entryPoint: '',
+      routes: [
+        {
+          path: '/pure',
+          attr: {
+            render: 'ssr',
+            data: async () => ({ serviceName: 'catalog', serviceMethod: 'getSku', args: {} }) as ServiceDescriptor,
+          },
+        },
+        {
+          path: '/mixed',
+          attr: {
+            render: 'ssr',
+            data: async (params: { premium?: string }) =>
+              params.premium ? { title: 'direct' } : ({ serviceName: 'catalog', serviceMethod: 'getSku', args: {} } as ServiceDescriptor),
+          },
+        },
+        { path: '/nodata', attr: { render: 'ssr' } },
+      ],
+    },
+  ],
+} as const;
+
+type _PureDescriptor = Expect<Equal<RouteData<typeof descriptorConfig, '/pure'>, Record<string, unknown>>>;
+type _MixedReturn = Expect<Equal<RouteData<typeof descriptorConfig, '/mixed'>, { title: string } | Record<string, unknown>>>;
+type _NoDataArm = Expect<Equal<RouteData<typeof descriptorConfig, '/nodata'>, EmptyRouteData>>;
+
+// --- 7. REVISED ruling (review, 2026-07-30): a concrete no-data route resolves to
+// `EmptyRouteData` (`Record<string, undefined>` - the runtime supplies `{}`), NOT `unknown`.
+// The app-wide union therefore stays USABLE when a CSR-style no-data route participates:
+// `data.field` reads as `T | undefined`, forcing code to account for the no-data route without
+// destroying the whole union. ---
+const mixedAppConfig = {
+  apps: [
+    {
+      appId: 'mixed-app',
+      entryPoint: '',
+      routes: [
+        {
+          path: '/data',
+          attr: { render: 'ssr', data: serviceData('catalog', 'getSku', (p) => ({ id: String(p.id) })) },
+        },
+        { path: '/csr' },
+      ],
+    },
+  ],
+} as const;
+
+type _MixedAppUnion = Expect<Equal<RouteData<typeof mixedAppConfig, string>, Sku | EmptyRouteData>>;

--- a/packages/server/src/core/config/types.ts
+++ b/packages/server/src/core/config/types.ts
@@ -49,8 +49,8 @@ declare const SERVICE_RESULT: unique symbol;
  * method's eventual (post-dispatch) result as a PHANTOM type brand. The callable's declared
  * return stays the honest service DESCRIPTOR - the runtime value really is the descriptor, and
  * the server dispatches it - while the brand tells the type system what that dispatch resolves
- * to, so `HeadDataOf` (and future `RouteDataOf` work) can infer the real payload instead of the
- * descriptor shape.
+ * to, so `HeadDataOf` and `RouteDataOf` (brand arm completed 2026-07-30) can infer the real
+ * payload instead of the descriptor shape.
  */
 export type ServiceDataHandler<Result, Params extends RouteParams = RouteParams, L extends Logs = Logs> = DataHandler<Params, L> & {
   readonly [SERVICE_RESULT]: Result;
@@ -130,7 +130,34 @@ export type AppOf<C extends { apps: readonly any[] }, A extends AppId<C>> = Extr
 export type RoutesOfApp<C extends { apps: readonly any[] }, A extends AppId<C>> =
   NonNullable<AppOf<C, A>['routes']> extends readonly any[] ? NonNullable<AppOf<C, A>['routes']>[number] : never;
 
-export type RouteDataOf<R> = R extends { attr?: { data?: (...args: any) => infer Ret } } ? Awaited<Ret> : unknown;
+/**
+ * What a route WITHOUT `attr.data` resolves to: `fetchInitialData` returns `{}` for such routes
+ * (DataRoutes.ts), so property access honestly yields `undefined` - and unlike `unknown`, this
+ * unions cleanly into an app-wide RouteData instead of absorbing it (review ruling, 2026-07-30).
+ */
+export type EmptyRouteData = Record<string, undefined>;
+
+/**
+ * The type a route's `attr.data` resolves to - the "future RouteDataOf work" the SERVICE_RESULT
+ * brand comment promised, completed 2026-07-30 for the scaffolder type chain. Arms follow
+ * `HeadDataOf`, with a ruled no-data arm:
+ * - `serviceData()` sugar: the SELECTED METHOD's resolved result, read from the phantom brand -
+ *   never the descriptor the handler honestly returns at runtime;
+ * - closure handler: its resolved return type (descriptor returns collapse to
+ *   `Record<string, unknown>` - the dispatch result is untyped for hand-built descriptors);
+ * - no `attr.data`: `EmptyRouteData` - the honest type of the `{}` the server supplies, so an
+ *   app-wide union stays usable (`data.field` reads `T | undefined`) rather than collapsing to
+ *   `unknown`;
+ * - a declared `data` of unrecognisable shape stays `unknown`.
+ * Pinned by `core/config/test/RouteContext.test-d.ts` and `test/PublicRouteContext.test-d.ts`.
+ */
+export type RouteDataOf<R> = R extends { attr?: { data?: infer D } }
+  ? D extends { readonly [SERVICE_RESULT]: infer Res }
+    ? Res
+    : D extends (...args: any) => infer Ret
+      ? DescriptorMemberToRecord<Awaited<Ret>>
+      : unknown
+  : EmptyRouteData;
 
 /**
  * RFC 0004 (H1): the type `headContent` receives as `headData` for a route. Three arms, pinned

--- a/packages/server/src/test/PublicRouteContext.test-d.ts
+++ b/packages/server/src/test/PublicRouteContext.test-d.ts
@@ -8,7 +8,7 @@
 // public `RouteData` stays precise on a concrete config and non-degenerate bare.
 // Same idiom as HeadDataOf.test-d.ts: enforced by `pnpm --filter @taujs/server typecheck` (tsc);
 // invariant-Equal so width-subtyping cannot fake a pass.
-import type { AppConfig, RouteContext, RouteData, RouteParams, TaujsConfig } from '../Config';
+import type { AppConfig, EmptyRouteData, RouteContext, RouteData, RouteParams, ServiceDataHandler, TaujsConfig } from '../Config';
 import type { RouteAttributes } from '../core/config/types';
 
 type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
@@ -75,5 +75,28 @@ type _AttrOptional = Expect<Equal<Extract<PreciseCtx, { path: '/opt' }>['attr'],
 type _RouteDataPrecise = Expect<Equal<RouteData<typeof config, '/products/:id'>, Product>>;
 type _RouteDataHome = Expect<Equal<RouteData<typeof config, '/'>, Home>>;
 type _RouteDataTypo = Expect<Equal<RouteData<typeof config, '/typo'>, never>>;
+type _RouteDataNoData = Expect<Equal<RouteData<typeof config, '/bare'>, EmptyRouteData>>;
 type _RouteDataBareNotNever = Expect<Equal<[RouteData] extends [never] ? true : false, false>>;
 type _RouteDataBroadLiteralPath = Expect<Equal<RouteData<TaujsConfig, '/x'>, never>>;
+
+// --- 7. serviceData() brand arm through the PUBLIC entry (the scaffolder chain, 2026-07-30):
+// a branded route resolves the SELECTED METHOD's result, never the descriptor, and the bare-path
+// form (`RouteData<typeof config>`) - the scaffolder's shared AppData - unions every route's
+// resolved data. ---
+declare const svcConfig: {
+  apps: readonly [
+    {
+      appId: 'scaffold';
+      entryPoint: '';
+      renderer: AppConfig['renderer'];
+      routes: readonly [
+        { path: '/'; attr: { render: 'ssr'; data: ServiceDataHandler<Home> } },
+        { path: '/streaming'; attr: { render: 'streaming'; meta: Record<string, unknown>; data: ServiceDataHandler<Home> } },
+      ];
+    },
+  ];
+};
+
+type _SvcConfigIsTaujsConfig = Expect<typeof svcConfig extends TaujsConfig ? true : false>;
+type _SvcRouteData = Expect<Equal<RouteData<typeof svcConfig, '/'>, Home>>;
+type _SvcAppData = Expect<Equal<RouteData<typeof svcConfig>, Home>>;

--- a/website/src/content/docs/renderers/solid.mdx
+++ b/website/src/content/docs/renderers/solid.mdx
@@ -902,7 +902,7 @@ function Component() {
 
 You do not have to hand-repeat a payload shape. `@taujs/server/config` exports types that derive from your `taujs.config.ts` route table:
 
-- `RouteData<typeof config, "/path">` - the resolved data type of the route with that path (the awaited return of its `attr.data` loader). Path-specific lookup requires the concrete config type - the broad `RouteData` default cannot name your routes.
+- `RouteData<typeof config, "/path">` - the resolved data type of the route with that path (its declared loader's resolved result; `serviceData()` routes resolve the selected service method's result, never the descriptor). Path-specific lookup requires the concrete config type - the broad `RouteData` default cannot name your routes.
 - `HeadDataOf<typeof route>` - what `headContent` receives as `headData` for a route. This is what makes the `attr.head` → `headContent` chain typed end to end (RFC 0004, a signed type gate).
 - `RouteContext<typeof config>` - the union of `{ appId, path, attr, params }` across the config's routes: the value the host passes to `appComponent` and `headContent` as `routeContext`. The bare `RouteContext` (the generic's default) is the broad runtime shape. Route data is not on it - that reaches the renderer's store, typed by `RouteData`.
 


### PR DESCRIPTION
## What

Two commits, reviewed as one effort:

1. `fix(server): resolve serviceData routes to their method results in RouteData` -
   `RouteDataOf` gains the brand arm the `SERVICE_RESULT` comment always promised:
   `serviceData()` routes resolve to the selected method's result, never the
   descriptor the handler returns at runtime. Hand-built descriptor closures
   collapse to `Record<string, unknown>`. A route without `attr.data` resolves to
   the new exported `EmptyRouteData` (`Record<string, undefined>` - the honest type
   of the `{}` the server supplies), so a CSR-style route unions cleanly into an
   app-wide `RouteData` instead of collapsing it to `unknown`.

2. `feat(create-taujs): derive the generated app type chain from taujs.config.ts` -
   generated projects teach derivation instead of duplication: a type-only
   `src/client/app-types.ts` exports `AppRouteContext = RouteContext<typeof config>`
   and `AppData = RouteData<typeof config>`; the generated config declares
   registry-typed `serviceData()` edges instead of a hand-built descriptor;
   `createRenderer<AppData, AppRouteContext>` is threaded through react, vue and
   solid; every hand-written payload type is replaced by the derived `AppData`,
   with per-route narrowing available as commented opt-in.

## Why

`taujs.config.ts` is the type source for the request, the renderer and the
application. PR #50 repaired the public aliases; this completes the inference so
`RouteData` sees through the service brand, and makes the official scaffolder
demonstrate the chain from its first generated route.

## Evidence

- Internal and public type gates pin every `RouteDataOf` arm: brand result,
  descriptor collapse, mixed-return distribution, no-data `EmptyRouteData`, and a
  mixed typed-plus-CSR config proving the app-wide union stays usable.
- Vue joined the packed-tarball lifecycle gate: all three frameworks generate,
  install real tarballs, typecheck, boot dev, build and boot production on every
  test run.
- Server 931/931, create-taujs 41/41, workspace typecheck and formatting green.

## Changesets

- `@taujs/server` patch
- `@taujs/create-taujs` minor
