### PR TITLE
fix(fixtures): remove playground-react's template-declared client ent…

### DIFF
--- a/fixtures/playground-react/src/client/index.html
+++ b/fixtures/playground-react/src/client/index.html
@@ -6,7 +6,12 @@
     <!--ssr-head-->
   </head>
   <body>
+    <!-- The client entry is deliberately NOT declared here. The host injects it per-route
+         (React's `bootstrapModules` on the streaming path, the bootstrap tag on the SSR path) and
+         withholds it under `hydrate: false`. Declaring it in the template - as this fixture used
+         to - made every BUILT page load the client entry regardless of the route's hydration
+         policy, so `hydrate: false` was not observable in a production build. The playground-vue
+         and playground-solid templates have never declared it; this keeps the three in line. -->
     <div id="root"><!--ssr-html--></div>
-    <script type="module" src="/entry-client.tsx"></script>
   </body>
 </html>

--- a/fixtures/playground-react/test/browser.test.ts
+++ b/fixtures/playground-react/test/browser.test.ts
@@ -32,7 +32,9 @@ const BROWSERS_PATH = process.env.PLAYWRIGHT_BROWSERS_PATH ?? path.join(homedir(
 // browser and run everywhere - the hydrate:false regression guard must not be local-only.
 const HAS_PINNED_BROWSER = existsSync(path.join(BROWSERS_PATH, 'chromium-1117'));
 if (!HAS_PINNED_BROWSER)
-  console.warn(`[browser.test] chromium-1117 not under ${BROWSERS_PATH} - skipping the real-browser tests, byte-level assertions still run (install the pinned browser for the full cell)`);
+  console.warn(
+    `[browser.test] chromium-1117 not under ${BROWSERS_PATH} - skipping the real-browser tests, byte-level assertions still run (install the pinned browser for the full cell)`,
+  );
 
 let browser: Browser | undefined;
 let server: ChildProcess | undefined;

--- a/fixtures/playground-react/test/browser.test.ts
+++ b/fixtures/playground-react/test/browser.test.ts
@@ -23,13 +23,16 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 const PROJECT = fileURLToPath(new URL('../', import.meta.url));
 const PORT = 5301;
 const BASE = `http://127.0.0.1:${PORT}`;
-const BROWSERS_PATH = path.join(homedir(), '.cache', 'ms-playwright');
-// The real-browser leg needs the pinned chromium-1117 (playwright-core 1.44.1). It runs locally,
-// where that browser is installed; CI installs no Playwright browser, so the suite SKIPS VISIBLY
-// there rather than hard-failing.
+// Honour the same override playwright-core itself reads (vitest.config.ts pins it before import),
+// so detection and launch always consult the same directory.
+const BROWSERS_PATH = process.env.PLAYWRIGHT_BROWSERS_PATH ?? path.join(homedir(), '.cache', 'ms-playwright');
+// The real-browser legs need the pinned chromium-1117 (playwright-core 1.44.1). They run locally,
+// where that browser is installed; CI installs no Playwright browser, so those tests SKIP VISIBLY
+// there rather than hard-failing. The build, the server and the byte-level assertions need no
+// browser and run everywhere - the hydrate:false regression guard must not be local-only.
 const HAS_PINNED_BROWSER = existsSync(path.join(BROWSERS_PATH, 'chromium-1117'));
 if (!HAS_PINNED_BROWSER)
-  console.warn(`[browser.test] chromium-1117 not under ${BROWSERS_PATH} - skipping the real-browser deferred cell (install the pinned browser to run it)`);
+  console.warn(`[browser.test] chromium-1117 not under ${BROWSERS_PATH} - skipping the real-browser tests, byte-level assertions still run (install the pinned browser for the full cell)`);
 
 let browser: Browser | undefined;
 let server: ChildProcess | undefined;
@@ -118,7 +121,7 @@ const expectClean = (faults: PageFaults) => {
   expect(faults.consoleErrors, 'console errors').toEqual([]);
 };
 
-describe.skipIf(!HAS_PINNED_BROWSER)('RFC 0007 product cell - React deferred route data (production build, enforced CSP)', () => {
+describe('RFC 0007 product cell - React deferred route data (production build, enforced CSP)', () => {
   beforeAll(async () => {
     // Freshness guard (docs/followups/fixture-stale-dist-evidence-trap.md): this fixture resolves
     // @taujs/server and @taujs/react through their gitignored dist, so a stale package build
@@ -150,7 +153,7 @@ describe.skipIf(!HAS_PINNED_BROWSER)('RFC 0007 product cell - React deferred rou
       await new Promise((r) => setTimeout(r, 250));
     }
 
-    browser = await chromium.launch({ args: ['--no-sandbox'] });
+    if (HAS_PINNED_BROWSER) browser = await chromium.launch({ args: ['--no-sandbox'] });
   }, 300_000);
 
   afterAll(async () => {
@@ -159,7 +162,7 @@ describe.skipIf(!HAS_PINNED_BROWSER)('RFC 0007 product cell - React deferred rou
     await stopServer();
   });
 
-  it('delivers a declared deferred entry in the browser, hydrates from the envelope and never refetches', async () => {
+  it.skipIf(!HAS_PINNED_BROWSER)('delivers a declared deferred entry in the browser, hydrates from the envelope and never refetches', async () => {
     // The policy must actually be enforced, or every violation assertion below is vacuous.
     const response = await fetch(`${BASE}/deferred`);
     const enforced = response.headers.get('content-security-policy');
@@ -190,6 +193,55 @@ describe.skipIf(!HAS_PINNED_BROWSER)('RFC 0007 product cell - React deferred rou
       await page.click('#counter');
       await waitForText(page, '#counter', 'count: 1');
 
+      expectClean(await collectFaults(page, faults));
+    } finally {
+      await page.context().close();
+    }
+  });
+
+  it('withholds the client entry under hydrate:false at the byte level and injects exactly one bootstrap when hydrating', async () => {
+    // This half needs no browser, so it runs in CI too - the hydrate:false regression guard is
+    // exactly these bytes, and it must gate merges, not just local runs.
+    //
+    // The host injects the bootstrap module only when the route hydrates; the always-injected
+    // inline __INITIAL_DATA__ script is expected and not asserted against. The template must not
+    // declare the entry itself - a template-declared entry loads on every BUILT page and silently
+    // defeats the route's hydration policy
+    // (docs/followups/done/playground-react-client-entry-hydrate-false.md).
+    const termsResponse = await fetch(`${BASE}/terms`);
+    const termsHtml = await termsResponse.text();
+    // Anchor the negative: prove these are the real rendered /terms bytes, or the no-module-script
+    // assertion below passes vacuously against an error page or empty body.
+    expect(termsResponse.status).toBe(200);
+    expect(termsHtml, 'not the rendered /terms page').toContain('id="counter"');
+    expect(termsHtml, 'hydrate:false page carries a module script').not.toMatch(/type="module"/);
+
+    // Control: a hydrating SSR route carries EXACTLY ONE module script - the injected bootstrap.
+    // Exactly one also catches the reintroduction shape, where template + injection double up.
+    // The nonce proves the tag is host-injected: a template-declared script cannot know the
+    // per-request nonce (the old template entry rode in on script-src 'self' instead).
+    const homeHtml = await (await fetch(`${BASE}/`)).text();
+    expect(homeHtml.match(/<script[^>]*type="module"/g) ?? [], 'hydrating route must carry exactly the injected bootstrap').toHaveLength(1);
+    expect(homeHtml).toMatch(/<script nonce="[^"]+" type="module" src="[^"]+" defer><\/script>/);
+  });
+
+  it.skipIf(!HAS_PINNED_BROWSER)('keeps a hydrate:false page inert in the browser - no script requested, no interactivity', async () => {
+    // The negative twin of the deferred cell's interactivity proof. An inline module script would
+    // evade the network assertion, which is why the byte-level test above stays the primary guard.
+    const { page, faults } = await openPage();
+    const scriptRequests: string[] = [];
+    page.on('request', (r) => {
+      if (r.resourceType() === 'script') scriptRequests.push(r.url());
+    });
+    try {
+      await page.goto(`${BASE}/terms`, { waitUntil: 'networkidle' });
+
+      expect(await page.textContent('#counter')).toContain('count: 0');
+      await page.click('#counter');
+      await new Promise((r) => setTimeout(r, 500));
+      expect(await page.textContent('#counter'), 'hydrate:false page became interactive').toContain('count: 0');
+
+      expect(scriptRequests, 'hydrate:false page requested a script').toEqual([]);
       expectClean(await collectFaults(page, faults));
     } finally {
       await page.context().close();


### PR DESCRIPTION
…ry - hydrate:false now observable

The playground template declared its own <script type="module" src="/entry-client.tsx">, so every BUILT page loaded the client runtime regardless of the route's hydration policy - hydrate:false (the existing /terms route) was silently defeated in any production build. The host already injects the bootstrap per-route (React bootstrapModules on the streaming path, the SSR bootstrap tag) and withholds it under hydrate:false; the template line was the only counterparty. Removing it brings the react template in line with playground-vue and playground-solid, which never declared one. Found and first fixed on the RFC 0007 proof branch (aedb32e); this ports the fix to main.

Evidence, added to the fixture's production cell:

- Byte level, ungated so it runs in CI: /terms (hydrate:false) serves 200 with the rendered app and NO module script; / carries EXACTLY ONE module script matching the nonce'd injected shape - a template script cannot know the per-request nonce, and exactly-one catches the template-plus-injection reintroduction shape. Red against the old template, green after.
- Browser level, gated on the pinned chromium as before: /terms requests no script at all and the server-rendered counter stays inert on click - the negative twin of the deferred cell's interactivity proof.

The suite-level chromium gate moved to the individual browser tests so the byte-level regression guard gates merges rather than running only where the pinned browser is installed; browser detection now honours PLAYWRIGHT_BROWSERS_PATH, the same override playwright-core reads, so detection and launch always consult the same directory.

Dev mode verified by hand: the host injects a nonce'd /entry-client.tsx tag on hydrating routes only, /terms gets none, and the entry resolves
200. pnpm -r typecheck and pnpm -r test green; fixture suite 3/3 with the browser, 1 passed + 2 visibly skipped without it.