### PR TITLE
feat(server,create-taujs)!: vite-free production runtime - taujsBuild…

### DIFF
--- a/.changeset/vite-free-production-runtime.md
+++ b/.changeset/vite-free-production-runtime.md
@@ -1,0 +1,35 @@
+---
+'@taujs/server': minor
+'@taujs/create-taujs': minor
+---
+
+BREAKING: `taujsBuild` is no longer exported from the `@taujs/server` root. Its only public
+home is the dedicated build entry, `@taujs/server/build`.
+
+Migration is a one-line import-path change with no behavioural change:
+
+```diff
+- import { taujsBuild } from '@taujs/server';
++ import { taujsBuild } from '@taujs/server/build';
+```
+
+The removal separates the production runtime from the build toolchain. Importing
+`@taujs/server` for `createServer` previously executed the build module's static
+`import { build } from 'vite'` through a shared chunk, loading the whole Vite build toolchain
+(Vite, Rollup, esbuild) into every production process. Three changes close that seam:
+
+- the root entry no longer exports `taujsBuild`, so the runtime chunk no longer contains the
+  build module
+- the render path imports `resolveEntryFile` from its runtime home instead of reaching it
+  through the build module
+- the development-only Vite helpers (dev-server setup, dev Vite config resolution, plugin
+  ownership preparation) are loaded dynamically inside the development branch, never at module
+  scope
+
+Importing the `@taujs/server` runtime no longer resolves Vite, and no production
+Vite-toolchain resolution is attributable to `@taujs/server`. Application production boots
+may still load renderer compiler tooling until the coordinated renderer contribution change.
+Development and build behaviour are unchanged; `@taujs/server/build` keeps the entire build
+surface as it was.
+
+`create-taujs` scaffolds generate `build.ts` with the subpath import.

--- a/fixtures/playground-react/build.ts
+++ b/fixtures/playground-react/build.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { taujsBuild } from '@taujs/server';
+import { taujsBuild } from '@taujs/server/build';
 import config from './taujs.config.ts';
 
 await taujsBuild({

--- a/fixtures/playground-solid/build.ts
+++ b/fixtures/playground-solid/build.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { taujsBuild } from '@taujs/server';
+import { taujsBuild } from '@taujs/server/build';
 import config from './taujs.config.ts';
 
 await taujsBuild({

--- a/fixtures/playground-vue/build.ts
+++ b/fixtures/playground-vue/build.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { taujsBuild } from '@taujs/server';
+import { taujsBuild } from '@taujs/server/build';
 import config from './taujs.config.ts';
 
 await taujsBuild({

--- a/packages/create-taujs/src/index.ts
+++ b/packages/create-taujs/src/index.ts
@@ -484,7 +484,7 @@ function generatePackageJson(projectName: string, framework: Framework) {
 
 function generateBuildTs() {
   return `import path from "node:path";
-import { taujsBuild } from "@taujs/server";
+import { taujsBuild } from "@taujs/server/build";
 import config from "./taujs.config.ts";
 
 await taujsBuild({

--- a/packages/create-taujs/src/test/__snapshots__/generate.test.ts.snap
+++ b/packages/create-taujs/src/test/__snapshots__/generate.test.ts.snap
@@ -139,7 +139,7 @@ demo-app/
 MIT
 ",
   "build.ts": "import path from "node:path";
-import { taujsBuild } from "@taujs/server";
+import { taujsBuild } from "@taujs/server/build";
 import config from "./taujs.config.ts";
 
 await taujsBuild({

--- a/packages/server/src/SSRServer.ts
+++ b/packages/server/src/SSRServer.ts
@@ -24,14 +24,11 @@ import { createAuthHook } from './security/Auth';
 import { cspPlugin } from './security/CSP';
 import { cspReportPlugin } from './security/CSPReporting';
 import { createMaps, loadAssets, processConfigs } from './utils/AssetManager';
-import { setupDevServer } from './utils/DevServer';
-import { resolveDevViteConfig } from './utils/ViteMergeEngine';
 import { createRequestContext, getRequestContext } from './utils/Telemetry';
 import { handleRender } from './utils/HandleRender';
 import { handleNotFound } from './utils/HandleNotFound';
 import { registerStaticAssets } from './utils/StaticAssets';
 import { pluginCollisionMessage, reservedPluginMessage } from './utils/VitePlugins';
-import { assembleDevPluginChain } from './utils/OwnershipPrepass';
 
 import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
 import type { ViteDevServer } from 'vite';
@@ -113,6 +110,12 @@ const installOwnedScope = async (scope: FastifyInstance, opts: SSRServerOptions,
   });
 
   if (isDevelopment) {
+    // Development-only modules load here, never statically: OwnershipPrepass reaches `vite` at
+    // module scope, and the production module graph must not resolve the Vite toolchain.
+    const { setupDevServer } = await import('./utils/DevServer');
+    const { resolveDevViteConfig } = await import('./utils/ViteMergeEngine');
+    const { assembleDevPluginChain } = await import('./utils/OwnershipPrepass');
+
     // RFC 0005 §1 (VS4): resolve `config.vite` ONCE, with the discriminated `serve` context arm
     // (no `appId` - per-app dev servers are rejected by maintainer ruling). Resolution happens
     // HERE rather than inside the engine so the override's plugins can enter the same §5

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,5 +1,4 @@
 export { createServer } from './CreateServer';
-export { taujsBuild } from './Build';
 export { winstonAdapter } from './logging/Adapters';
 export { AppError } from './core/errors/AppError';
 export { createRequestGraph } from './core/introspection/RequestGraph';

--- a/packages/server/src/test/RootExports.test.ts
+++ b/packages/server/src/test/RootExports.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+
+// The runtime/build separation is a public-surface contract: `taujsBuild` must never return to
+// the root entry, because the root export was the edge that executed the build module's static
+// `import { build } from 'vite'` in every production process. `@taujs/server/build` is its only
+// public home. An accidental re-export would reintroduce the graph edge without any behavioural
+// test failing - this suite is the committed assertion.
+
+describe('root entry public surface', () => {
+  it('does not export taujsBuild', async () => {
+    const root = await import('../index');
+
+    expect('taujsBuild' in root).toBe(false);
+  });
+
+  it('exports exactly the runtime value surface', async () => {
+    const root = await import('../index');
+
+    expect(Object.keys(root).sort()).toEqual(['AppError', 'createRequestGraph', 'createServer', 'winstonAdapter']);
+  });
+});
+
+describe('build entry public surface', () => {
+  it('exports taujsBuild', async () => {
+    const build = await import('../Build');
+
+    expect(typeof build.taujsBuild).toBe('function');
+  });
+});

--- a/packages/server/src/utils/HandleRender.ts
+++ b/packages/server/src/utils/HandleRender.ts
@@ -7,9 +7,9 @@ import { logResponseFailure } from '../core/errors/ResponseFailureLog';
 import { fetchHeadData, fetchInitialData } from '../core/routes/DataRoutes';
 import { buildDeferredEnvelopeJson, createDeferredData } from '../core/routes/DeferredData';
 import { now } from '../core/telemetry/Telemetry';
-import { resolveEntryFile } from '../Build';
 import { createLogger } from '../logging/Logger';
 import { isDevelopment } from '../System';
+import { resolveEntryFile } from './Entry';
 import { createRequestContext, getRequestContext } from './Telemetry';
 import {
   ensureNonNull,

--- a/packages/server/src/utils/test/HandleRender.test.ts
+++ b/packages/server/src/utils/test/HandleRender.test.ts
@@ -60,7 +60,7 @@ vi.mock('../../core/errors/AppError', async () => {
 
 vi.mock('../../logging/Logger');
 
-vi.mock('../../Build', () => ({
+vi.mock('../Entry', () => ({
   resolveEntryFile: vi.fn((clientRoot: string, entryServer: string) => entryServer),
 }));
 

--- a/website/src/content/docs/guides/build-deployment.md
+++ b/website/src/content/docs/guides/build-deployment.md
@@ -380,7 +380,7 @@ Example build script:
 // scripts/build.mjs
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { taujsBuild } from "@taujs/server";
+import { taujsBuild } from "@taujs/server/build";
 import config from "../taujs.config.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
… moves to @taujs/server/build

Unit 1A of the production Vite isolation work (host-neutrality programme, stream 1).

- remove taujsBuild from the @taujs/server root export; @taujs/server/build is its only public home. Pre-v1 clean break: migration is a one-line import-path change with no behavioural change
- the render path imports resolveEntryFile from its runtime home (utils/Entry) instead of reaching it through the build module
- SSRServer loads the development-only helpers (DevServer, ViteMergeEngine, OwnershipPrepass) dynamically inside the development branch; OwnershipPrepass held the only static vite value import left in the runtime graph
- create-taujs generates build.ts with the subpath import; fixture build scripts and the website build guide follow
- RootExports.test.ts pins the public surfaces: taujsBuild absent from the root entry, present from the build entry, root value exports exact

Evidence (packed-consumer recorder runs, classification by package identity): importing the @taujs/server runtime resolves no Vite-toolchain module, and no production Vite-toolchain resolution is attributable to @taujs/server; production boots across react, vue and solid serve SSR, streaming and static assets. The remainder enters through renderer declarations only - one edge per renderer into its compiler plugin - and application production boots may still load renderer compiler tooling until the coordinated renderer contribution change (Unit 1B).