### PR TITLE
feat(server,react,vue,solid)!: lazy-only renderer contribution protocol v2 (Unit 1B)

### DIFF
--- a/.changeset/lazy-renderer-contribution-protocol.md
+++ b/.changeset/lazy-renderer-contribution-protocol.md
@@ -1,0 +1,38 @@
+---
+'@taujs/server': minor
+'@taujs/react': minor
+'@taujs/vue': minor
+'@taujs/solid': minor
+---
+
+BREAKING: the renderer contribution protocol becomes lazy-only v2. `@taujs/server` and the
+three renderers (`@taujs/react`, `@taujs/vue`, `@taujs/solid`) are one coordinated train -
+upgrade the paired packages together. No application source changes: `reactRenderer()`,
+`vueRenderer()` and `solidRenderer()` keep their exact synchronous signatures, and the
+render-module contract does not move.
+
+What changes underneath:
+
+- the renderer-contribution brand is the protocol discriminator; v2 is the lazy protocol
+  and the only one the server accepts. A v1 (eager) contribution - an older renderer
+  against this server - fails at boot and build with an error naming the renderer package
+  and the required upgrade
+- renderer factories no longer import their compiler machinery at declaration time. The
+  compiler contribution is loaded through an async loader invoked only by build and
+  development; a production process never resolves the compiler toolchain
+  (`@vitejs/plugin-react`, `@vitejs/plugin-vue`, `vite-plugin-solid`, and Solid's Babel
+  stack all leave the production module graph)
+- the contribution type is a discriminated union on `managedCompilation`: a managed
+  renderer (React/Solid) carries `loadCompiler`, a non-managed renderer (Vue) carries
+  `loadEnvironmentPlugins` - exactly one, enforced structurally and at runtime
+- Vue's plugin pack stays FRESH per Vite environment exactly as before; only the module
+  import behind the loader is cached
+- no `@taujs/server` peer metadata is declared by the renderers: measurement showed npm's
+  handling of an optional-but-mismatched peer is topology-dependent (warning on a two-step
+  add, but a hard `ETARGET` failure on a fresh install while the range is unsatisfiable
+  from the registry), so the pairing is enforced by the runtime protocol check alone -
+  which is the authoritative failure in every topology
+
+Declaring a renderer without its compiler peers installed now succeeds (identity is
+synchronous and peer-free); the compiler peer is demanded, by name, only when build or
+development actually loads the compiler.

--- a/fixtures/renderer-composition/test/classifier-envelope.test.ts
+++ b/fixtures/renderer-composition/test/classifier-envelope.test.ts
@@ -18,8 +18,9 @@ import type { ManagedContributionShape, RendererContributionShape } from '@taujs
  */
 
 // renderer v1: the ESC-1 managed compiler contribution now rides inside the renderer contribution as
-// its `.compiler`. Reach the ManagedContributionShape (with `.impl.prepare`/...) through it.
-const managedOf = (renderer: unknown): ManagedContributionShape => (renderer as unknown as RendererContributionShape).compiler as ManagedContributionShape;
+// its lazy `loadCompiler` (v2 protocol). Reach the ManagedContributionShape (with `.impl.prepare`/...) through it.
+const managedOf = (renderer: unknown): Promise<ManagedContributionShape> =>
+  (renderer as unknown as RendererContributionShape).loadCompiler!() as Promise<ManagedContributionShape>;
 
 const SOLID_EXPORTS = { '.': { solid: './src/index.jsx', default: './src/index.jsx' } };
 
@@ -85,7 +86,7 @@ afterAll(() => {
 });
 
 async function claims(): Promise<(id: string) => boolean> {
-  const contribution = managedOf(solidRenderer({ project: 'tsconfig.solid.json' }));
+  const contribution = await managedOf(solidRenderer({ project: 'tsconfig.solid.json' }));
   const plan = await contribution.impl.prepare([{ contribution, appId: 'app', appRoot: root }], { projectRoot: root, lifecycle: 'build' });
   return createFilter(plan.claims, plan.exclude);
 }
@@ -135,7 +136,7 @@ describe('ESC-1 fix-3b - tsconfig node_modules exclude vs classifier (through re
       path.join(root, 'tsconfig.excl.json'),
       JSON.stringify({ compilerOptions: { jsx: 'preserve', jsxImportSource: 'solid-js' }, include: ['src/**/*'], exclude: ['node_modules'] }),
     );
-    const contribution = managedOf(solidRenderer({ project: 'tsconfig.excl.json' }));
+    const contribution = await managedOf(solidRenderer({ project: 'tsconfig.excl.json' }));
     await expect(contribution.impl.prepare([{ contribution, appId: 'app', appRoot: root }], { projectRoot: root, lifecycle: 'build' })).rejects.toThrow(
       /cancels the Solid node_modules package/,
     );

--- a/fixtures/renderer-composition/test/composition.test.ts
+++ b/fixtures/renderer-composition/test/composition.test.ts
@@ -27,8 +27,9 @@ const MANAGED_CONTRIBUTION_BRAND = 'taujs.managed-plugin-contribution/v1';
  */
 
 // renderer v1: the ESC-1 managed compiler contribution now rides inside the renderer contribution as
-// its `.compiler`. Reach the ManagedContributionShape (with `.impl`/`.brand`/`.createPlugin`/...) through it.
-const managedOf = (renderer: unknown): ManagedContributionShape => (renderer as unknown as RendererContributionShape).compiler as ManagedContributionShape;
+// its lazy `loadCompiler` (v2 protocol). Reach the ManagedContributionShape (with `.impl`/`.brand`/`.createPlugin`/...) through it.
+const managedOf = (renderer: unknown): Promise<ManagedContributionShape> =>
+  (renderer as unknown as RendererContributionShape).loadCompiler!() as Promise<ManagedContributionShape>;
 
 let root: string;
 let outDir: string;
@@ -68,8 +69,8 @@ afterAll(() => {
 });
 
 async function buildScoped(): Promise<{ reactOut: string; solidOut: string }> {
-  const reactContribution = managedOf(reactRenderer({ project: 'tsconfig.react.json' }));
-  const solidContribution = managedOf(solidRenderer({ project: 'tsconfig.solid.json' }));
+  const reactContribution = await managedOf(reactRenderer({ project: 'tsconfig.react.json' }));
+  const solidContribution = await managedOf(solidRenderer({ project: 'tsconfig.solid.json' }));
   const prepareInput = { projectRoot: root, lifecycle: 'build' as const };
 
   const reactPlan = await reactContribution.impl.prepare(
@@ -118,9 +119,9 @@ async function buildScoped(): Promise<{ reactOut: string; solidOut: string }> {
 }
 
 describe('ESC-1 composition (real Vite build)', () => {
-  it('cross-package brand literal matches the host (dependency-free marker stays in sync)', () => {
-    expect(managedOf(reactRenderer({ project: 'tsconfig.react.json' })).brand).toBe(MANAGED_CONTRIBUTION_BRAND);
-    expect(managedOf(solidRenderer({ project: 'tsconfig.solid.json' })).brand).toBe(MANAGED_CONTRIBUTION_BRAND);
+  it('cross-package brand literal matches the host (dependency-free marker stays in sync)', async () => {
+    expect((await managedOf(reactRenderer({ project: 'tsconfig.react.json' }))).brand).toBe(MANAGED_CONTRIBUTION_BRAND);
+    expect((await managedOf(solidRenderer({ project: 'tsconfig.solid.json' }))).brand).toBe(MANAGED_CONTRIBUTION_BRAND);
   });
 
   it('cases 3 + 12 - React and Solid compile together with no cross-framework contamination', async () => {
@@ -138,7 +139,7 @@ describe('ESC-1 composition (real Vite build)', () => {
   });
 
   it('case 9 - the vitefu classifier claims a node_modules package with a solid export condition', async () => {
-    const contribution = managedOf(solidRenderer({ project: 'tsconfig.solid.json' }));
+    const contribution = await managedOf(solidRenderer({ project: 'tsconfig.solid.json' }));
     const plan = await contribution.impl.prepare([{ contribution, appId: 'admin', appRoot: path.join(root, 'src-solid') }], {
       projectRoot: root,
       lifecycle: 'build',

--- a/packages/react/src/compiler/reactCompiler.ts
+++ b/packages/react/src/compiler/reactCompiler.ts
@@ -8,7 +8,10 @@
  */
 import react from '@vitejs/plugin-react';
 
+import { validateReactRendererOptions } from '../rendererOptions.js';
+
 import type { Plugin, PluginOption } from 'vite';
+import type { ReactRendererOptions } from '../rendererOptions.js';
 import type { CompilerImpl, ManagedContributionBrand, ManagedContributionShape, PreparedPlan } from '@taujs/server/renderer';
 
 type ReactOptions = NonNullable<Parameters<typeof react>[0]>;
@@ -56,9 +59,9 @@ export function tagUnscopedCompiler<T>(value: T, key: string): T {
   return value;
 }
 
-/** Options for {@link buildReactContribution}: a required tsconfig `project`, plus React options; the
- * ownership filters (`include`/`exclude`) are RESERVED - the host computes them from the project. */
-export type ReactCompilerOptions = { project: string } & Omit<ReactOptions, 'include' | 'exclude'>;
+/** Options for {@link buildReactContribution} - the compiler-free shared surface (`rendererOptions.ts`),
+ * so the synchronous factory and this lazy builder validate ONE definition that cannot drift. */
+export type ReactCompilerOptions = ReactRendererOptions;
 
 // Module-local object => REFERENCE identity (safeguard 1): every contribution from THIS installed
 // @taujs/react copy shares it; a second installed copy yields a distinct object, so the host detects
@@ -88,11 +91,7 @@ const reactCompilerImpl: CompilerImpl = {
 
 /** Build the React managed compiler contribution `reactRenderer()` carries (ESC-1 shape). */
 export function buildReactContribution(opts: ReactCompilerOptions): ManagedContributionShape {
-  const { project, ...reactOptions } = opts;
-  if (!project) throw new Error('[taujs] reactRenderer requires a `project` tsconfig path.');
-  if ('include' in reactOptions || 'exclude' in reactOptions) {
-    throw new Error('[taujs] reactRenderer does not accept `include`/`exclude` - ownership is computed from the tsconfig `project`.');
-  }
+  const { project, ...reactOptions } = validateReactRendererOptions(opts);
 
   return {
     brand: MANAGED_BRAND,

--- a/packages/react/src/renderer.ts
+++ b/packages/react/src/renderer.ts
@@ -1,35 +1,44 @@
 /**
- * `@taujs/react/renderer` - the `reactRenderer()` factory (renderer v1, RFC 0006 / renderer design v5).
+ * `@taujs/react/renderer` - the `reactRenderer()` factory (contribution protocol v2, RFC 0006 / renderer
+ * design v5).
  *
- * Declared on an app's REQUIRED singular `renderer:`. It carries the ESC-1 React managed compiler
- * contribution (scoped JSX ownership - the host computes each framework's scope after seeing all apps and
- * constructs the real plugin) internally, and declares the render-module contract the host validates the
- * entry-server's `createRenderer(...)` output against. `plugins:` reverts to ordinary Vite plugins; the raw
- * portable `pluginReact()` stays for plain-Vite use.
+ * Declared on an app's REQUIRED singular `renderer:`. It declares the render-module contract the host
+ * validates the entry-server's `createRenderer(...)` output against, and carries the ESC-1 React managed
+ * compiler contribution LAZILY (v2 protocol): the compiler module - whose graph includes
+ * `@vitejs/plugin-react` and its Vite reach - is imported only when build or development actually loads
+ * it, never at declaration time, so a production process that imports this factory via its config stays
+ * free of the compiler toolchain. `plugins:` holds ordinary Vite plugins; the raw portable `pluginReact()`
+ * stays for plain-Vite use.
  *
  * Brand/version literals are reproduced BY VALUE (never runtime-importing `@taujs/server`); the type-only
  * imports keep them in sync with the host contract at compile time.
  */
-import { buildReactContribution } from './compiler/reactCompiler.js';
 import { REACT_RENDERER_KEY, RENDER_CONTRACT_VERSION } from './renderContract.js';
+import { validateReactRendererOptions } from './rendererOptions.js';
 
-import type { ReactCompilerOptions } from './compiler/reactCompiler.js';
-import type { RendererContributionBrand, RendererContributionShape, TaujsRendererContribution } from '@taujs/server/renderer';
+import type { ReactRendererOptions } from './rendererOptions.js';
+import type { ManagedContributionShape, ManagedRendererContribution, RendererContributionBrand, TaujsRendererContribution } from '@taujs/server/renderer';
 
-const RENDERER_BRAND: RendererContributionBrand = 'taujs.renderer-contribution/v1';
+const RENDERER_BRAND: RendererContributionBrand = 'taujs.renderer-contribution/v2';
 
-/** Options for {@link reactRenderer}: a required tsconfig `project` plus React options (ownership
- * `include`/`exclude` are RESERVED - the host computes them from the project). */
-export type ReactRendererOptions = ReactCompilerOptions;
+export type { ReactRendererOptions } from './rendererOptions.js';
 
 export function reactRenderer(opts: ReactRendererOptions): TaujsRendererContribution {
-  const compiler = buildReactContribution(opts);
-  const contribution: RendererContributionShape = {
+  // Construction-time validation stays SYNCHRONOUS, via the compiler-free shared validator (the lazy
+  // builder consumes the same validated shape), so a bad declaration throws at config evaluation, not at
+  // the first lazy load in build/dev.
+  const validated = validateReactRendererOptions(opts);
+
+  // The loader is invoked once per host prepass; the memo makes the managed contribution's CONSTRUCTION
+  // once per contribution lifetime. The module cache keeps `CompilerImpl` reference identity per
+  // installed copy, so the host's one-impl-per-key assertion behaves exactly as with the eager protocol.
+  let compilerPromise: Promise<ManagedContributionShape> | undefined;
+  const contribution: ManagedRendererContribution = {
     brand: RENDERER_BRAND,
     key: REACT_RENDERER_KEY,
     contractVersion: RENDER_CONTRACT_VERSION,
     managedCompilation: true,
-    compiler,
+    loadCompiler: () => (compilerPromise ??= import('./compiler/reactCompiler.js').then((m) => m.buildReactContribution(validated))),
   };
   return contribution as unknown as TaujsRendererContribution;
 }

--- a/packages/react/src/rendererOptions.ts
+++ b/packages/react/src/rendererOptions.ts
@@ -1,0 +1,25 @@
+/**
+ * Compiler-free option surface + validation for `reactRenderer()` - the ONE definition shared by the
+ * synchronous factory (construction-time errors) and the lazy compiler builder (which receives the same
+ * validated shape), so the two sides cannot drift.
+ *
+ * This module must stay free of compiler VALUE imports: it loads at declaration time in production
+ * processes, and the recorder gate asserts the production graph never resolves the compiler toolchain.
+ * The `@vitejs/plugin-react` reference below is type-only and erases at compile time.
+ */
+import type react from '@vitejs/plugin-react';
+
+type ReactOptions = NonNullable<Parameters<typeof react>[0]>;
+
+/** Options for `reactRenderer()`: a required tsconfig `project` plus React options; the ownership
+ * filters (`include`/`exclude`) are RESERVED - the host computes them from the project. */
+export type ReactRendererOptions = { project: string } & Omit<ReactOptions, 'include' | 'exclude'>;
+
+/** Synchronous validation; returns the options unchanged for the lazy builder to consume. */
+export function validateReactRendererOptions(opts: ReactRendererOptions): ReactRendererOptions {
+  if (!opts?.project) throw new Error('[taujs] reactRenderer requires a `project` tsconfig path.');
+  if ('include' in opts || 'exclude' in opts) {
+    throw new Error('[taujs] reactRenderer does not accept `include`/`exclude` - ownership is computed from the tsconfig `project`.');
+  }
+  return opts;
+}

--- a/packages/react/src/test/reactRenderer.test.ts
+++ b/packages/react/src/test/reactRenderer.test.ts
@@ -15,7 +15,7 @@ import type { ManagedContributionShape, ManagedGroupMember, RendererContribution
 // on @taujs/server. Compile-time equality with the host is enforced by the type-only brand imports; the
 // cross-package literal match is checked in fixtures/renderer-composition.
 const MANAGED_CONTRIBUTION_BRAND = 'taujs.managed-plugin-contribution/v1';
-const RENDERER_CONTRIBUTION_BRAND = 'taujs.renderer-contribution/v1';
+const RENDERER_CONTRIBUTION_BRAND = 'taujs.renderer-contribution/v2';
 
 const fixturesDir = path.dirname(fileURLToPath(new URL('../compiler/test/fixtures/tsconfig.owned.json', import.meta.url)));
 const UNSCOPED = Symbol.for('taujs.unscoped-compiler');
@@ -49,15 +49,35 @@ describe('buildReactContribution (the managed compiler contribution reactRendere
   });
 });
 
-describe('reactRenderer (the public renderer contribution)', () => {
-  it('wraps the React managed compiler contribution with managedCompilation + a render-module contract', () => {
+describe('reactRenderer (the public renderer contribution, v2 lazy protocol)', () => {
+  it('declares the v2 brand, identity and render-module contract synchronously, with a lazy compiler loader', async () => {
     const contribution = reactRenderer({ project: './tsconfig.react.json' }) as unknown as RendererContributionShape;
     expect(contribution.brand).toBe(RENDERER_CONTRIBUTION_BRAND);
     expect(contribution.key).toBe('react');
     expect(contribution.contractVersion).toBe('v1');
     expect(contribution.managedCompilation).toBe(true);
-    expect(contribution.compiler?.brand).toBe(MANAGED_CONTRIBUTION_BRAND);
-    expect(contribution.compiler?.key).toBe('react');
+    expect(typeof contribution.loadCompiler).toBe('function');
+    const compiler = await contribution.loadCompiler!();
+    expect(compiler.brand).toBe(MANAGED_CONTRIBUTION_BRAND);
+    expect(compiler.key).toBe('react');
+  });
+
+  it('validates options synchronously at construction (no lazy-load needed to see the error)', () => {
+    expect(() => reactRenderer({ project: '' })).toThrow(/requires a `project`/);
+    // @ts-expect-error include is reserved - ownership is computed from the project
+    expect(() => reactRenderer({ project: './t.json', include: ['x'] })).toThrow(/does not accept `include`/);
+  });
+
+  it('memoises the compiler load: one promise, one contribution instance per factory call', async () => {
+    const contribution = reactRenderer({ project: './tsconfig.react.json' }) as unknown as RendererContributionShape;
+    const [a, b] = await Promise.all([contribution.loadCompiler!(), contribution.loadCompiler!()]);
+    expect(a).toBe(b);
+  });
+
+  it('shares ONE impl reference across separately declared contributions (safeguard 1 across lazy loads)', async () => {
+    const one = reactRenderer({ project: './a.json' }) as unknown as RendererContributionShape;
+    const two = reactRenderer({ project: './b.json' }) as unknown as RendererContributionShape;
+    expect((await one.loadCompiler!()).impl).toBe((await two.loadCompiler!()).impl);
   });
 });
 

--- a/packages/server/src/Build.ts
+++ b/packages/server/src/Build.ts
@@ -273,7 +273,7 @@ export async function taujsBuild({
     // and was extracted in phase 1) PLUS the fresh framework plugins its renderer supplies for THIS build
     // environment (Vue's pluginVue pack). Managed compilers are constructed below from the global plan and
     // prepended. A raw plugin duplicating a renderer-supplied one is a hard error (appEnvironmentPlugins).
-    const rawAppPlugins = appEnvironmentPlugins(appId, ownership.rawByApp.get(appId) ?? (plugins as PluginOption[]), renderer, 'build');
+    const rawAppPlugins = await appEnvironmentPlugins(appId, ownership.rawByApp.get(appId) ?? (plugins as PluginOption[]), renderer, 'build');
 
     const outDir = path.resolve(projectRoot, isSSRBuild ? `dist/ssr/${entryPoint}` : `dist/client/${entryPoint}`);
     const root = entryPoint ? path.resolve(clientBaseDir, entryPoint) : clientBaseDir;

--- a/packages/server/src/Renderer.ts
+++ b/packages/server/src/Renderer.ts
@@ -11,8 +11,17 @@
  * `@taujs/server/config`.
  */
 
-// The renderer-contribution contract (the config-time declaration half).
-export type { RenderContractVersion, RendererContributionBrand, RendererContributionShape, TaujsRendererContribution } from './utils/RendererContract';
+// The renderer-contribution contract (the config-time declaration half). The shape is a discriminated
+// union on `managedCompilation`; the variant types are exported so a renderer factory can type its
+// contribution against the exact protocol variant it implements.
+export type {
+  EnvironmentRendererContribution,
+  ManagedRendererContribution,
+  RenderContractVersion,
+  RendererContributionBrand,
+  RendererContributionShape,
+  TaujsRendererContribution,
+} from './utils/RendererContract';
 
 // The ESC-1 managed compiler-author contract a JSX renderer (managedCompilation:true) implements.
 export type {

--- a/packages/server/src/test/RuntimeLoggerFallthrough.test.ts
+++ b/packages/server/src/test/RuntimeLoggerFallthrough.test.ts
@@ -6,16 +6,32 @@ import { describe, expect, it } from 'vitest';
 
 const RESULT_PREFIX = 'TAUJS_FALLTHROUGH_LOGGER_RESULT=';
 
+// Layered deadlines from a measured budget (2026-08-03): the child (real dev-server boot: Vite +
+// compiler plugin + one request) completes in ~2.5s alone and ~5.1s worst-observed under the fully
+// parallel suite's worker contention. The CHILD watchdog is the operative deadline at ~2x that
+// worst case; the Vitest cap sits above it only so the child's ETIMEDOUT report - not a worker
+// interrupt - is what a failure shows. spawnSync blocks the worker, so a Vitest cap below the child
+// timeout could not fire reliably anyway.
+const CHILD_TIMEOUT_MS = 10_000;
+const VITEST_TIMEOUT_MS = 12_000;
+
 describe('runtime logger fallthrough (real development server)', () => {
-  it('sends a successful unmatched-page record through the selected request logger', () => {
+  it('sends a successful unmatched-page record through the selected request logger', { timeout: VITEST_TIMEOUT_MS }, () => {
     const fixtureRoot = fileURLToPath(new URL('../../../../fixtures/playground-react/', import.meta.url));
     const childScript = fileURLToPath(new URL('./support/RuntimeLoggerFallthrough.child.ts', import.meta.url));
     const result = spawnSync(process.execPath, ['--import', 'tsx', childScript], {
       cwd: fixtureRoot,
       env: { ...process.env, NODE_ENV: 'development' },
       encoding: 'utf8',
-      timeout: 30_000,
+      timeout: CHILD_TIMEOUT_MS,
     });
+
+    const childTimedOut = (result.error as NodeJS.ErrnoException | undefined)?.code === 'ETIMEDOUT';
+    expect(
+      childTimedOut,
+      `the development child exceeded its ${CHILD_TIMEOUT_MS / 1000}s watchdog (measured budget: ~2.5s alone, ~5.1s under full-suite contention) - ` +
+        `stderr tail: ${result.stderr?.slice(-500) ?? '(none)'}`,
+    ).toBe(false);
 
     expect(
       {

--- a/packages/server/src/test/support/renderer.ts
+++ b/packages/server/src/test/support/renderer.ts
@@ -1,25 +1,28 @@
 import type { ManagedContributionShape } from '../../utils/ManagedPlugins';
 import type { TaujsRendererContribution } from '../../utils/RendererContract';
 
-// A minimal, structurally-valid renderer contribution for tests that just need the required field.
+// A minimal, structurally-valid v2 renderer contribution for tests that just need the required field.
+// `compiler` is delivered through the lazy v2 loader; a plain non-managed contribution carries the
+// lazy environment-plugins loader (empty pack) so the v2 recogniser accepts it.
 export function testRenderer(opts: { key?: string; managedCompilation?: boolean; compiler?: unknown } = {}): TaujsRendererContribution {
+  const managedCompilation = opts.managedCompilation ?? false;
   return {
-    brand: 'taujs.renderer-contribution/v1',
+    brand: 'taujs.renderer-contribution/v2',
     key: opts.key ?? 'test',
     contractVersion: 'v1',
-    managedCompilation: opts.managedCompilation ?? false,
-    ...(opts.compiler ? { compiler: opts.compiler } : {}),
+    managedCompilation,
+    ...(managedCompilation ? { loadCompiler: async () => opts.compiler } : { loadEnvironmentPlugins: async () => [] }),
   } as unknown as TaujsRendererContribution;
 }
 
-// Wrap an ESC-1 managed compiler contribution as a renderer contribution (managedCompilation:true).
+// Wrap an ESC-1 managed compiler contribution as a v2 renderer contribution (managedCompilation:true).
 export function rendererFromManaged(managed: ManagedContributionShape): TaujsRendererContribution {
   return {
-    brand: 'taujs.renderer-contribution/v1',
+    brand: 'taujs.renderer-contribution/v2',
     key: managed.key,
     contractVersion: 'v1',
     managedCompilation: true,
-    compiler: managed,
+    loadCompiler: async () => managed,
   } as unknown as TaujsRendererContribution;
 }
 

--- a/packages/server/src/utils/OwnershipPrepass.ts
+++ b/packages/server/src/utils/OwnershipPrepass.ts
@@ -69,24 +69,26 @@ function extractRawPlugins(appId: string, plugins: ReadonlyArray<unknown> | unde
 /**
  * The single ESC-1 managed compiler contribution an app's renderer carries (a JSX renderer), or none (Vue).
  * `renderer:` is REQUIRED: an absent or invalid contribution is a hard error here (dev boot + build; the
- * prod boot path enforces the same in AssetManager).
+ * prod boot path enforces the same in AssetManager). v2 protocol: the compiler is LOADED here - the one
+ * seam that awaits `loadCompiler()`, called only from `prepareOwnership`. The loader is INVOKED once per
+ * prepass invocation (one dev boot; one `taujsBuild` run); the factory memoises the contribution promise,
+ * so the managed contribution is CONSTRUCTED once per contribution lifetime. The compiler toolchain
+ * therefore resolves in build/dev processes and never in production.
  */
-function managedFromRenderer(appId: string, renderer: unknown): ManagedContributionShape | undefined {
+async function managedFromRenderer(appId: string, renderer: unknown): Promise<ManagedContributionShape | undefined> {
   const contribution = requireRendererContribution(appId, renderer);
   if (!contribution.managedCompilation) return undefined;
-  const compiler = contribution.compiler;
+  const compiler = await contribution.loadCompiler();
   if (!isManagedContribution(compiler)) {
-    throw new Error(`[taujs] app "${appId}": managed renderer "${contribution.key}" is missing its compiler contribution (internal error).`);
+    throw new Error(`[taujs] app "${appId}": managed renderer "${contribution.key}" loaded an invalid compiler contribution (internal error).`);
   }
   return compiler;
 }
 
 /** A non-managed renderer's ordinary framework plugin pack, built FRESH for this Vite environment (Vue). */
-function rendererEnvironmentPlugins(renderer: unknown, lifecycle: 'dev' | 'build'): PluginOption[] {
-  if (!isRendererContribution(renderer)) return [];
-  const make = renderer.createEnvironmentPlugins;
-  if (typeof make !== 'function') return [];
-  const produced = make(lifecycle);
+async function rendererEnvironmentPlugins(renderer: unknown, lifecycle: 'dev' | 'build'): Promise<PluginOption[]> {
+  if (!isRendererContribution(renderer) || renderer.managedCompilation) return [];
+  const produced = await renderer.loadEnvironmentPlugins(lifecycle);
   return (Array.isArray(produced) ? produced : [produced]) as PluginOption[];
 }
 
@@ -95,8 +97,13 @@ function rendererEnvironmentPlugins(renderer: unknown, lifecycle: 'dev' | 'build
  * renderer supplies (Vue). A raw plugin that DUPLICATES a renderer-supplied one (e.g. a raw `pluginVue()`
  * beside `vueRenderer()`) is a hard error - the renderer already provides it (design §2.4).
  */
-export function appEnvironmentPlugins(appId: string, rawPlugins: readonly PluginOption[], renderer: unknown, lifecycle: 'dev' | 'build'): PluginOption[] {
-  const rendererPlugins = rendererEnvironmentPlugins(renderer, lifecycle);
+export async function appEnvironmentPlugins(
+  appId: string,
+  rawPlugins: readonly PluginOption[],
+  renderer: unknown,
+  lifecycle: 'dev' | 'build',
+): Promise<PluginOption[]> {
+  const rendererPlugins = await rendererEnvironmentPlugins(renderer, lifecycle);
   if (rendererPlugins.length > 0) {
     const rendererNames = new Set(collectPluginNames(rendererPlugins));
     for (const name of collectPluginNames(rawPlugins)) {
@@ -133,10 +140,11 @@ export async function prepareOwnership(apps: ReadonlyArray<AppPluginInput>, inpu
   const members: ManagedGroupMember[] = [];
 
   for (const app of apps) {
-    // Renderer v1: `plugins` holds ordinary Vite plugins only (reject a leaked contribution); the managed
-    // compiler contribution is carried by the app's singular `renderer:` (React/Solid) - at most ONE.
+    // `plugins` holds ordinary Vite plugins only (reject a leaked contribution); the managed compiler
+    // contribution is carried by the app's singular `renderer:` (React/Solid) - at most ONE, loaded
+    // lazily here (v2 protocol) so declaration never resolves the compiler toolchain.
     rawByApp.set(app.appId, extractRawPlugins(app.appId, app.plugins));
-    const managed = managedFromRenderer(app.appId, app.renderer);
+    const managed = await managedFromRenderer(app.appId, app.renderer);
     keysByApp.set(app.appId, managed ? [managed.key] : []);
     if (managed) members.push({ contribution: managed, appId: app.appId, appRoot: app.appRoot });
   }
@@ -245,7 +253,12 @@ export async function assembleDevPluginChain(opts: {
   // Each app's plugins for the shared dev environment = its raw plugins + the FRESH framework plugins its
   // renderer supplies (Vue's pluginVue pack). Constructed ONCE here (not per composePlugins pass).
   const pluginsByApp = new Map<string, PluginOption[]>(
-    opts.apps.map((app) => [app.appId, appEnvironmentPlugins(app.appId, rawOf(app.appId), app.renderer, 'dev')]),
+    await Promise.all(
+      opts.apps.map(async (app): Promise<[string, PluginOption[]]> => [
+        app.appId,
+        await appEnvironmentPlugins(app.appId, rawOf(app.appId), app.renderer, 'dev'),
+      ]),
+    ),
   );
   const pluginsFor = (appId: string): PluginOption[] => pluginsByApp.get(appId) ?? [];
 

--- a/packages/server/src/utils/RendererContract.ts
+++ b/packages/server/src/utils/RendererContract.ts
@@ -19,9 +19,18 @@ import type { RenderModule } from '../types';
  * discipline {@link ./ManagedPlugins} keeps.
  */
 
-/** Structural brand for a renderer contribution, versioned so an incompatible shape is a different brand. */
-export const RENDERER_CONTRIBUTION_BRAND = 'taujs.renderer-contribution/v1' as const;
+/**
+ * Structural brand for a renderer contribution, versioned so an incompatible shape is a different brand.
+ * The brand IS the contribution-protocol discriminator: v2 is the LAZY protocol (compiler machinery is
+ * loaded through async loaders by build/dev only; production never invokes them). The eager v1 protocol
+ * is recognised explicitly BY ITS BRAND in {@link requireRendererContribution} and rejected with upgrade
+ * guidance - never inferred from missing properties.
+ */
+export const RENDERER_CONTRIBUTION_BRAND = 'taujs.renderer-contribution/v2' as const;
 export type RendererContributionBrand = typeof RENDERER_CONTRIBUTION_BRAND;
+
+/** The superseded eager protocol brand, recognised only to name the required upgrade. */
+export const EAGER_RENDERER_CONTRIBUTION_BRAND = 'taujs.renderer-contribution/v1' as const;
 
 /**
  * The render-MODULE contract version - the runtime `{ renderSSR, renderStream }` shape a framework's
@@ -40,32 +49,49 @@ export type DeclaredRenderContract = {
   contractVersion: string;
 };
 
-/**
- * The runtime shape a renderer factory produces. NON-public + unstable (versioned by the brand); the public
- * face is the opaque {@link TaujsRendererContribution}. App association is added by the host at grouping
- * time, not carried here.
- */
-export type RendererContributionShape = {
+/** The identity fields every v2 contribution carries, protocol-variant-independent. */
+type RendererContributionBase = {
   readonly brand: RendererContributionBrand;
   /** Framework identity + (when managed) the ESC-1 grouping key. */
   readonly key: string;
   /** The render-module contract version the app's loaded {@link RenderModule} must match. */
   readonly contractVersion: string;
-  /**
-   * True for frameworks whose JSX/TSX compilation COLLIDES and needs scoped ownership (React/Solid) - they
-   * carry {@link RendererContributionShape.compiler}; false for frameworks whose compiler is an ordinary
-   * unscoped Vite plugin (Vue) - they carry {@link RendererContributionShape.createEnvironmentPlugins}.
-   */
-  readonly managedCompilation: boolean;
-  /** The ESC-1 managed compiler contribution - present IFF `managedCompilation` (a JSX renderer). */
-  readonly compiler?: ManagedContributionShape;
-  /**
-   * A non-managed renderer's ordinary framework Vite plugin(s), built FRESH per environment (Vue's
-   * `pluginVue` pack). Typed `unknown` for the same cross-`@types/node` Vite type-identity reason as
-   * `PreparedPlan.createPlugin`; the host casts to its own `PluginOption` at the composition seam.
-   */
-  readonly createEnvironmentPlugins?: (lifecycle: 'dev' | 'build') => unknown;
 };
+
+/**
+ * A managed-compilation renderer (React/Solid): JSX/TSX compilation COLLIDES across frameworks and needs
+ * scoped ownership, carried as a lazy ESC-1 compiler contribution. `loadCompiler` is invoked by the host
+ * prepass (once per prepass invocation: one dev boot, one `taujsBuild` run); the factory memoises the
+ * contribution promise, so the managed contribution is CONSTRUCTED once per contribution lifetime.
+ * Production never invokes it, so the compiler toolchain never resolves in a production process.
+ */
+export type ManagedRendererContribution = RendererContributionBase & {
+  readonly managedCompilation: true;
+  readonly loadCompiler: () => Promise<ManagedContributionShape>;
+  readonly loadEnvironmentPlugins?: never;
+};
+
+/**
+ * A non-managed renderer (Vue): its compiler is an ordinary unscoped Vite plugin, produced lazily and
+ * FRESH once per Vite environment (the ESC-1 lifecycle lesson - plugin objects are never reused across
+ * environments; only the module import behind the loader is cached by ESM). The resolved value is typed
+ * `unknown` for the same cross-`@types/node` Vite type-identity reason as `PreparedPlan.createPlugin`;
+ * the host casts to its own `PluginOption` at the composition seam.
+ */
+export type EnvironmentRendererContribution = RendererContributionBase & {
+  readonly managedCompilation: false;
+  readonly loadCompiler?: never;
+  readonly loadEnvironmentPlugins: (lifecycle: 'dev' | 'build') => Promise<unknown>;
+};
+
+/**
+ * The runtime shape a renderer factory produces - a DISCRIMINATED UNION on `managedCompilation`, so the
+ * protocol's central invariant (exactly one loader, selected by the discriminant) is structural rather
+ * than asserted. NON-public + unstable (versioned by the brand); the public face is the opaque
+ * {@link TaujsRendererContribution}. App association is added by the host at grouping time, not carried
+ * here.
+ */
+export type RendererContributionShape = ManagedRendererContribution | EnvironmentRendererContribution;
 
 declare const RENDERER_OPAQUE: unique symbol;
 /**
@@ -76,13 +102,33 @@ declare const RENDERER_OPAQUE: unique symbol;
  */
 export type TaujsRendererContribution = { readonly [RENDERER_OPAQUE]: true };
 
-/** Structural, forgery-tolerant recogniser for a renderer contribution (host-side). */
+/**
+ * Structural, forgery-tolerant recogniser for a v2 renderer contribution (host-side). Acceptance is
+ * driven by the BRAND (the protocol discriminator); the loader checks are integrity validation of an
+ * already-branded value, not protocol detection. They enforce the union's EXCLUSIVITY: exactly the one
+ * loader the `managedCompilation` discriminant selects, never both.
+ */
 export function isRendererContribution(value: unknown): value is RendererContributionShape {
   if (typeof value !== 'object' || value === null) return false;
   const v = value as Record<string, unknown>;
-  return (
-    v.brand === RENDERER_CONTRIBUTION_BRAND && typeof v.key === 'string' && typeof v.contractVersion === 'string' && typeof v.managedCompilation === 'boolean'
-  );
+  if (
+    v.brand !== RENDERER_CONTRIBUTION_BRAND ||
+    typeof v.key !== 'string' ||
+    typeof v.contractVersion !== 'string' ||
+    typeof v.managedCompilation !== 'boolean'
+  ) {
+    return false;
+  }
+  return v.managedCompilation
+    ? typeof v.loadCompiler === 'function' && v.loadEnvironmentPlugins === undefined
+    : typeof v.loadEnvironmentPlugins === 'function' && v.loadCompiler === undefined;
+}
+
+/** Explicit recogniser for the superseded eager v1 protocol - used ONLY to word the upgrade error. */
+export function isEagerRendererContribution(value: unknown): value is { key: string } {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return v.brand === EAGER_RENDERER_CONTRIBUTION_BRAND && typeof v.key === 'string';
 }
 
 /** The declared render contract a contribution asserts of the app's render module. */
@@ -96,6 +142,11 @@ export function declaredContractOf(contribution: RendererContributionShape): Dec
  * contribution is a hard error here with ONE consistent message (not repeated per call site).
  */
 export function requireRendererContribution(appId: string, renderer: unknown): RendererContributionShape {
+  if (isEagerRendererContribution(renderer)) {
+    throw AppError.internal(
+      `[taujs] app "${appId}" declares renderer "${renderer.key}" using the eager v1 contribution protocol, which this @taujs/server no longer accepts. Upgrade @taujs/${renderer.key} to the release that provides the v2 lazy contribution protocol (see the @taujs/server changelog for the paired versions).`,
+    );
+  }
   if (!isRendererContribution(renderer)) {
     throw AppError.internal(
       `[taujs] app "${appId}" must declare a valid renderer: reactRenderer()/vueRenderer(). \`renderer:\` is required (found ${renderer === undefined ? 'none' : 'an invalid value'}).`,

--- a/packages/server/src/utils/test/OwnershipPrepass.test.ts
+++ b/packages/server/src/utils/test/OwnershipPrepass.test.ts
@@ -51,6 +51,24 @@ describe('prepareOwnership (phase 1)', () => {
     expect(prepared.keysByApp.get('web')).toEqual([]);
   });
 
+  // Unit 1B gate (once-per-ruled-lifecycle): prepareOwnership is the ONE seam that loads a managed
+  // compiler; each contribution's v2 loader resolves exactly once per invocation, including across a
+  // multi-app same-key group.
+  it('loads each v2 compiler contribution exactly once per prepareOwnership, same-key groups included', async () => {
+    const react = makeImpl('react');
+    const loadA = vi.fn(async () => contribution('react', react));
+    const loadB = vi.fn(async () => contribution('react', react));
+    const rendererOf = (load: () => Promise<ManagedContributionShape>) =>
+      ({ brand: 'taujs.renderer-contribution/v2', key: 'react', contractVersion: 'v1', managedCompilation: true, loadCompiler: load }) as unknown;
+
+    const prepared = await prepareOwnership([app('web', [], rendererOf(loadA)), app('admin', [], rendererOf(loadB))], INPUT);
+
+    expect(loadA).toHaveBeenCalledTimes(1);
+    expect(loadB).toHaveBeenCalledTimes(1);
+    expect(prepared.plans.size).toBe(1);
+    expect(react.prepare).toHaveBeenCalledTimes(1);
+  });
+
   it('extracts managed contributions, leaving only raw plugins per app', async () => {
     const solid = makeImpl('solid');
     const rawPlugin = { name: 'y' };
@@ -291,13 +309,13 @@ describe('createOwnershipDiagnostic (safeguard 2, fail-closed)', () => {
 // managed-active gate (a Vue-only project still gets pluginVue). These are the load-bearing renderer-v1
 // hard errors + supply path introduced on top of the ESC-1 baseline.
 describe('renderer v1 guardrails + non-managed (Vue) plugin supply', () => {
-  const RENDERER_BRAND = 'taujs.renderer-contribution/v1';
+  const RENDERER_BRAND = 'taujs.renderer-contribution/v2';
   const vueLikeRenderer = (plugins: unknown[]) => ({
     brand: RENDERER_BRAND,
     key: 'vue',
     contractVersion: 'v1',
     managedCompilation: false,
-    createEnvironmentPlugins: () => plugins,
+    loadEnvironmentPlugins: async () => plugins,
   });
 
   it('rejects a managed compiler contribution placed DIRECTLY in plugins (belongs on renderer:)', async () => {
@@ -314,15 +332,15 @@ describe('renderer v1 guardrails + non-managed (Vue) plugin supply', () => {
     await expect(prepareOwnership([app('web', [], { not: 'a renderer' })], INPUT)).rejects.toThrow(/must declare a valid renderer/);
   });
 
-  it("injects a non-managed renderer's fresh plugin pack even with NO managed ownership (not gated on active)", () => {
+  it("injects a non-managed renderer's fresh plugin pack even with NO managed ownership (not gated on active)", async () => {
     const vuePlugin = { name: 'vite:vue' };
-    const result = appEnvironmentPlugins('shop', [{ name: 'user-plugin' } as never], vueLikeRenderer([vuePlugin]), 'dev');
+    const result = await appEnvironmentPlugins('shop', [{ name: 'user-plugin' } as never], vueLikeRenderer([vuePlugin]), 'dev');
     expect(result).toEqual([{ name: 'user-plugin' }, vuePlugin]);
   });
 
-  it('hard-errors when a raw plugin duplicates a renderer-supplied one (raw pluginVue beside vueRenderer)', () => {
+  it('hard-errors when a raw plugin duplicates a renderer-supplied one (raw pluginVue beside vueRenderer)', async () => {
     const vuePlugin = { name: 'vite:vue' };
-    expect(() => appEnvironmentPlugins('shop', [{ name: 'vite:vue' } as never], vueLikeRenderer([vuePlugin]), 'build')).toThrow(
+    await expect(appEnvironmentPlugins('shop', [{ name: 'vite:vue' } as never], vueLikeRenderer([vuePlugin]), 'build')).rejects.toThrow(
       /duplicates a plugin its renderer supplies/,
     );
   });

--- a/packages/server/src/utils/test/RendererContract.test.ts
+++ b/packages/server/src/utils/test/RendererContract.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { assertRenderContract, declaredContractOf, isRendererContribution, readRenderFnContract } from '../RendererContract';
+import { assertRenderContract, declaredContractOf, isRendererContribution, readRenderFnContract, requireRendererContribution } from '../RendererContract';
 
 import type { RendererContributionShape } from '../RendererContract';
 
@@ -74,10 +74,11 @@ describe('assertRenderContract (generic host identity validation)', () => {
 
 describe('isRendererContribution + declaredContractOf', () => {
   const valid: RendererContributionShape = {
-    brand: 'taujs.renderer-contribution/v1',
+    brand: 'taujs.renderer-contribution/v2',
     key: 'react',
     contractVersion: 'v1',
     managedCompilation: true,
+    loadCompiler: async () => ({}) as never,
   };
 
   it('recognises a structurally valid renderer contribution', () => {
@@ -91,7 +92,47 @@ describe('isRendererContribution + declaredContractOf', () => {
     expect(isRendererContribution({ ...valid, managedCompilation: undefined })).toBe(false);
   });
 
+  it('validates v2 loader integrity behind the brand: managed needs loadCompiler, non-managed needs loadEnvironmentPlugins', () => {
+    expect(isRendererContribution({ ...valid, loadCompiler: undefined })).toBe(false);
+    expect(isRendererContribution({ ...valid, managedCompilation: false })).toBe(false);
+    expect(isRendererContribution({ ...valid, managedCompilation: false, loadCompiler: undefined, loadEnvironmentPlugins: async () => [] })).toBe(true);
+  });
+
+  it('enforces the union exclusivity: a contribution carrying BOTH loaders is rejected', () => {
+    expect(isRendererContribution({ ...valid, loadEnvironmentPlugins: async () => [] })).toBe(false);
+    expect(isRendererContribution({ ...valid, managedCompilation: false, loadEnvironmentPlugins: async () => [] })).toBe(false);
+  });
+
   it('derives the declared render contract from a contribution', () => {
     expect(declaredContractOf(valid)).toEqual({ key: 'react', contractVersion: 'v1' });
+  });
+});
+
+// The contribution-protocol discriminator (Unit 1B gate): the brand names the protocol; an eager v1
+// contribution is recognised EXPLICITLY by its brand and rejected with upgrade guidance naming the
+// renderer package - never inferred from missing properties.
+describe('requireRendererContribution - protocol discrimination', () => {
+  const v2 = {
+    brand: 'taujs.renderer-contribution/v2',
+    key: 'react',
+    contractVersion: 'v1',
+    managedCompilation: true,
+    loadCompiler: async () => ({}) as never,
+  };
+
+  it('accepts a v2 lazy contribution', () => {
+    expect(requireRendererContribution('web', v2)).toBe(v2);
+  });
+
+  it('rejects an eager v1 contribution with the guided upgrade error naming the renderer', () => {
+    const v1 = { brand: 'taujs.renderer-contribution/v1', key: 'solid', contractVersion: 'v1', managedCompilation: true, compiler: {} };
+    expect(() => requireRendererContribution('web', v1)).toThrow(
+      /declares renderer "solid" using the eager v1 contribution protocol.*Upgrade @taujs\/solid to the release that provides the v2 lazy contribution protocol/,
+    );
+  });
+
+  it('keeps the generic required-renderer error for absent and arbitrary values', () => {
+    expect(() => requireRendererContribution('web', undefined)).toThrow(/must declare a valid renderer.*found none/);
+    expect(() => requireRendererContribution('web', { some: 'junk' })).toThrow(/must declare a valid renderer.*an invalid value/);
   });
 });

--- a/packages/solid/src/compiler/solidCompiler.ts
+++ b/packages/solid/src/compiler/solidCompiler.ts
@@ -9,7 +9,10 @@
 import picomatch from 'picomatch';
 import solid from 'vite-plugin-solid';
 
+import { validateSolidRendererOptions } from '../rendererOptions.js';
+
 import type { PluginOption } from 'vite';
+import type { SolidRendererOptions } from '../rendererOptions.js';
 import type { CompilerImpl, EffectiveScope, ManagedContributionBrand, ManagedContributionShape, PreparedPlan } from '@taujs/server/renderer';
 
 // vite-plugin-solid filters the RAW module id (query included) with a createFilter captured at
@@ -63,7 +66,7 @@ export function tagUnscopedCompiler<T>(value: T, key: string): T {
  * is forced is exactly the shape that hides defects. Raw `pluginSolid()` at `@taujs/solid/plugin`
  * retains the full portable Vite option surface for anyone who needs it.
  */
-export type SolidCompilerOptions = { project: string };
+export type SolidCompilerOptions = SolidRendererOptions;
 
 // Module-local object => REFERENCE identity (safeguard 1): every contribution from THIS installed
 // @taujs/solid copy shares it; a second installed copy yields a distinct object, so the host detects
@@ -107,17 +110,7 @@ const solidCompilerImpl: CompilerImpl = {
 
 /** Build the Solid managed compiler contribution `solidRenderer()` carries (ESC-1 shape). */
 export function buildSolidContribution(opts: SolidCompilerOptions): ManagedContributionShape {
-  const { project, ...rest } = opts;
-  if (!project) throw new Error('[taujs] solidRenderer requires a `project` tsconfig path.');
-  // `{ project }` is the entire surface. Anything else - including the previously-tolerated
-  // `include`/`exclude` and any vite-plugin-solid option - is rejected rather than silently
-  // dropped, so a caller is told their intent is not supported instead of it vanishing.
-  const unsupported = Object.keys(rest);
-  if (unsupported.length > 0) {
-    throw new Error(
-      `[taujs] solidRenderer accepts only \`project\` (received: ${unsupported.join(', ')}). Ownership is computed from the tsconfig project, and the transform mode is fixed. Use pluginSolid() from '@taujs/solid/plugin' for raw Vite options.`,
-    );
-  }
+  const { project } = validateSolidRendererOptions(opts);
 
   return {
     brand: MANAGED_BRAND,

--- a/packages/solid/src/renderer.ts
+++ b/packages/solid/src/renderer.ts
@@ -2,10 +2,11 @@
  * `@taujs/solid/renderer` - the application-facing renderer contribution.
  *
  * This subpath exposes EXACTLY `solidRenderer({ project })` and nothing else. It is separate from
- * the root entry on purpose: it reaches the managed compiler, which pulls the OPTIONAL
- * `vite`/`vite-plugin-solid`/`typescript` peers, and a client bundle that imports `@taujs/solid`
- * must never drag those into its graph. Do not re-export it from the root for convenience - that
- * decision is frozen and any change returns for a DX ruling with packed-consumer evidence.
+ * the root entry on purpose: it carries the managed compiler CONTRIBUTION, which pulls the OPTIONAL
+ * `vite`/`vite-plugin-solid`/`typescript` peers when build or development lazily loads it (v2
+ * protocol - declaration itself is peer-free), and a client bundle that imports `@taujs/solid`
+ * must never drag the factory into its graph. Do not re-export it from the root for convenience -
+ * that decision is frozen and any change returns for a DX ruling with packed-consumer evidence.
  *
  * Managed compilation ALWAYS forces `vite-plugin-solid`'s `ssr: true` internally (verified against
  * the pinned plugin: `ssr:true` enables hydratable transforms, and false/absent produces
@@ -13,33 +14,36 @@
  * `exclude` and every other advanced plugin option are NOT renderer-v1 DX; raw `pluginSolid()` at
  * `@taujs/solid/plugin` remains the portable escape hatch for plain Vite.
  */
-import { buildSolidContribution } from './compiler/solidCompiler.js';
-
 import { RENDER_CONTRACT_VERSION, SOLID_RENDERER_KEY } from './renderContract.js';
+import { validateSolidRendererOptions } from './rendererOptions.js';
 
-import type { SolidCompilerOptions } from './compiler/solidCompiler.js';
-import type { RendererContributionBrand, RendererContributionShape, TaujsRendererContribution } from '@taujs/server/renderer';
+import type { SolidRendererOptions } from './rendererOptions.js';
+import type { ManagedContributionShape, ManagedRendererContribution, RendererContributionBrand, TaujsRendererContribution } from '@taujs/server/renderer';
 
 // Single source of truth for the key + contract version: `renderContract.ts`, which the render
 // module's brand also uses. Two copies could disagree and the host would reject the module.
-const RENDERER_BRAND: RendererContributionBrand = 'taujs.renderer-contribution/v1';
+// v2 = the LAZY contribution protocol: the compiler module (and its vite-plugin-solid/Babel graph)
+// is imported only when build or development loads it, never at declaration time.
+const RENDERER_BRAND: RendererContributionBrand = 'taujs.renderer-contribution/v2';
 
-/**
- * The renderer's ENTIRE option surface (design 1.5, frozen): a single required tsconfig `project`
- * that defines the app's ownership boundary. Ownership `include`/`exclude` are RESERVED - the host
- * computes them from the project - and no transform-mode option is offered.
- */
-export type SolidRendererOptions = { project: string };
+export type { SolidRendererOptions } from './rendererOptions.js';
 
 /** Declare an app as a Solid app. Pass it to `renderer:` in the τjs config. */
 export function solidRenderer(opts: SolidRendererOptions): TaujsRendererContribution {
-  const compiler = buildSolidContribution(opts);
-  const contribution: RendererContributionShape = {
+  // Construction-time validation stays SYNCHRONOUS, via the compiler-free shared validator (the lazy
+  // builder consumes the same validated shape), so a bad declaration throws at config evaluation.
+  const validated = validateSolidRendererOptions(opts);
+
+  // The loader is invoked once per host prepass; the memo makes the managed contribution's CONSTRUCTION
+  // once per contribution lifetime. Module-cache reference identity preserves the host's
+  // one-impl-per-key assertion exactly as with the eager protocol.
+  let compilerPromise: Promise<ManagedContributionShape> | undefined;
+  const contribution: ManagedRendererContribution = {
     brand: RENDERER_BRAND,
     key: SOLID_RENDERER_KEY,
     contractVersion: RENDER_CONTRACT_VERSION,
     managedCompilation: true,
-    compiler,
+    loadCompiler: () => (compilerPromise ??= import('./compiler/solidCompiler.js').then((m) => m.buildSolidContribution(validated))),
   };
   return contribution as unknown as TaujsRendererContribution;
 }

--- a/packages/solid/src/rendererOptions.ts
+++ b/packages/solid/src/rendererOptions.ts
@@ -1,0 +1,31 @@
+/**
+ * Compiler-free option surface + validation for `solidRenderer()` - the ONE definition shared by the
+ * synchronous factory (construction-time errors) and the lazy compiler builder (which receives the same
+ * validated shape), so the two sides cannot drift.
+ *
+ * This module must stay free of compiler imports: it loads at declaration time in production processes,
+ * and the recorder gate asserts the production graph never resolves the compiler toolchain.
+ */
+
+/**
+ * The renderer's ENTIRE option surface (design 1.5, frozen): a single required tsconfig `project` that
+ * defines the app's ownership boundary. Ownership `include`/`exclude` are RESERVED - the host computes
+ * them from the project - and no transform-mode option is offered.
+ */
+export type SolidRendererOptions = { project: string };
+
+/** Synchronous validation; returns the options unchanged for the lazy builder to consume. */
+export function validateSolidRendererOptions(opts: SolidRendererOptions): SolidRendererOptions {
+  const { project, ...rest } = opts ?? ({} as SolidRendererOptions);
+  if (!project) throw new Error('[taujs] solidRenderer requires a `project` tsconfig path.');
+  // `{ project }` is the entire surface. Anything else - including the previously-tolerated
+  // `include`/`exclude` and any vite-plugin-solid option - is rejected rather than silently dropped,
+  // so a caller is told their intent is not supported instead of it vanishing.
+  const unsupported = Object.keys(rest);
+  if (unsupported.length > 0) {
+    throw new Error(
+      `[taujs] solidRenderer accepts only \`project\` (received: ${unsupported.join(', ')}). Ownership is computed from the tsconfig project, and the transform mode is fixed. Use pluginSolid() from '@taujs/solid/plugin' for raw Vite options.`,
+    );
+  }
+  return opts;
+}

--- a/packages/solid/src/test/BuiltOutput.test.ts
+++ b/packages/solid/src/test/BuiltOutput.test.ts
@@ -155,21 +155,29 @@ describe('built-output import smoke (packed artefact, real consumers)', () => {
     expect(JSON.parse(out)).toContain('pluginSolid');
   });
 
-  it('ROOT-EXPORT KILL TEST: a client-only consumer works WITHOUT the optional compiler peers', { timeout: 300_000 }, () => {
-    // This is the property the frozen root-vs-subpath split exists to deliver, verified against
-    // the packed artefact in a consumer that has installed NO compiler peers at all:
+  it('ROOT-EXPORT KILL TEST: a peer-free consumer declares solidRenderer; the compiler peers are demanded only at lazy load', { timeout: 300_000 }, () => {
+    // The v2 lazy contribution protocol changes the frozen property DELIBERATELY: in a consumer with NO
+    // compiler peers installed,
     //   - the root entry loads and renders (proven by the tests above, same consumer);
-    //   - `/renderer` legitimately does NOT, because it needs `vite-plugin-solid`.
-    // If the root ever re-exported `solidRenderer` "for convenience", the root tests above would
-    // start failing here with exactly this error - which is why the split is not merely tidiness.
-    let error = '';
-    try {
-      runInConsumer(`await import('@taujs/solid/renderer'); console.log('loaded');`);
-    } catch (e) {
-      error = String((e as { stderr?: string; message?: string }).stderr ?? (e as Error).message);
-    }
+    //   - `/renderer` now ALSO loads and declares (identity is synchronous and peer-free - this is what
+    //     keeps production processes free of the compiler toolchain);
+    //   - the OPTIONAL `vite-plugin-solid` peer is demanded exactly at `loadCompiler()` - the build/dev
+    //     seam - with the package named in the failure.
+    // If renderer.ts ever regains an eager compiler import, the declaration leg fails here; if the lazy
+    // load stops naming the missing peer, the load leg fails.
+    const out = runInConsumer(`
+      const { solidRenderer } = await import('@taujs/solid/renderer');
+      const c = solidRenderer({ project: './tsconfig.solid.json' });
+      let loadError = '';
+      try {
+        await c.loadCompiler();
+      } catch (e) {
+        loadError = String((e && e.message) || e);
+      }
+      console.log(JSON.stringify({ key: c.key, managedCompilation: c.managedCompilation, loadErrorNamesPeer: loadError.includes('vite-plugin-solid') }));
+    `);
 
-    expect(error).toMatch(/vite-plugin-solid/);
+    expect(JSON.parse(out)).toEqual({ key: 'solid', managedCompilation: true, loadErrorNamesPeer: true });
   });
 
   it('INTERNALS stay unreachable from the packed package', { timeout: 300_000 }, () => {

--- a/packages/solid/src/test/solidRenderer.test.ts
+++ b/packages/solid/src/test/solidRenderer.test.ts
@@ -13,7 +13,7 @@ import type { ManagedContributionShape, ManagedGroupMember, RendererContribution
 // on @taujs/server. Compile-time equality with the host is enforced by the type-only brand imports; the
 // cross-package literal match is checked in fixtures/renderer-composition.
 const MANAGED_CONTRIBUTION_BRAND = 'taujs.managed-plugin-contribution/v1';
-const RENDERER_CONTRIBUTION_BRAND = 'taujs.renderer-contribution/v1';
+const RENDERER_CONTRIBUTION_BRAND = 'taujs.renderer-contribution/v2';
 
 const fixturesDir = path.dirname(fileURLToPath(new URL('../compiler/test/fixtures/tsconfig.owned.json', import.meta.url)));
 const UNSCOPED = Symbol.for('taujs.unscoped-compiler');
@@ -54,15 +54,30 @@ describe('buildSolidContribution (the managed compiler contribution solidRendere
   });
 });
 
-describe('solidRenderer (PUBLIC as of renderer v1 - `@taujs/solid/renderer`)', () => {
-  it('wraps the Solid managed compiler contribution with managedCompilation', () => {
+describe('solidRenderer (PUBLIC as of renderer v1 - `@taujs/solid/renderer`, v2 lazy protocol)', () => {
+  it('declares the v2 brand and identity synchronously, with a lazy compiler loader', async () => {
     const contribution = solidRenderer({ project: './tsconfig.solid.json' }) as unknown as RendererContributionShape;
     expect(contribution.brand).toBe(RENDERER_CONTRIBUTION_BRAND);
     expect(contribution.key).toBe('solid');
     expect(contribution.contractVersion).toBe('v1');
     expect(contribution.managedCompilation).toBe(true);
-    expect(contribution.compiler?.brand).toBe(MANAGED_CONTRIBUTION_BRAND);
-    expect(contribution.compiler?.key).toBe('solid');
+    expect(typeof contribution.loadCompiler).toBe('function');
+    const compiler = await contribution.loadCompiler!();
+    expect(compiler.brand).toBe(MANAGED_CONTRIBUTION_BRAND);
+    expect(compiler.key).toBe('solid');
+  });
+
+  it('validates options synchronously at construction (no lazy-load needed to see the error)', () => {
+    expect(() => solidRenderer({ project: '' })).toThrow(/requires a `project`/);
+    expect(() => solidRenderer({ project: './t.json', ssr: true } as never)).toThrow(/accepts only `project`/);
+  });
+
+  it('memoises the compiler load and keeps impl reference identity across contributions', async () => {
+    const one = solidRenderer({ project: './a.json' }) as unknown as RendererContributionShape;
+    const two = solidRenderer({ project: './b.json' }) as unknown as RendererContributionShape;
+    const [a, b] = await Promise.all([one.loadCompiler!(), one.loadCompiler!()]);
+    expect(a).toBe(b);
+    expect((await one.loadCompiler!()).impl).toBe((await two.loadCompiler!()).impl);
   });
 });
 

--- a/packages/vue/src/renderer.ts
+++ b/packages/vue/src/renderer.ts
@@ -1,5 +1,5 @@
 /**
- * `@taujs/vue/renderer` - the `vueRenderer()` factory (renderer v1, RFC 0006 / renderer design v5).
+ * `@taujs/vue/renderer` - the `vueRenderer()` factory (contribution protocol v2, RFC 0006 / renderer design v5).
  *
  * Declared on an app's REQUIRED singular `renderer:`. Vue's `.vue` compiler does NOT collide with other
  * frameworks' files, so vueRenderer carries NO ownership machinery (`managedCompilation: false`): instead it
@@ -10,23 +10,29 @@
  * A raw `pluginVue()` in `plugins:` alongside `vueRenderer()` in the same resolved environment is a hard
  * host error (the renderer already supplies it).
  */
-import { pluginVue } from './plugin.js';
 import { RENDER_CONTRACT_VERSION, VUE_RENDERER_KEY } from './renderContract.js';
 
-import type { RendererContributionBrand, RendererContributionShape, TaujsRendererContribution } from '@taujs/server/renderer';
+import type { pluginVue } from './plugin.js';
+import type { EnvironmentRendererContribution, RendererContributionBrand, TaujsRendererContribution } from '@taujs/server/renderer';
 
-const RENDERER_BRAND: RendererContributionBrand = 'taujs.renderer-contribution/v1';
+// v2 = the LAZY contribution protocol: `pluginVue` (and `@vitejs/plugin-vue` behind it) is imported
+// only when a Vite environment is actually assembled in build or development - never at declaration
+// time, so a production process importing this factory via its config stays compiler-free.
+const RENDERER_BRAND: RendererContributionBrand = 'taujs.renderer-contribution/v2';
 
 /** Options for {@link vueRenderer}: the ordinary `@vitejs/plugin-vue` options (supplied fresh per env). */
 export type VueRendererOptions = Parameters<typeof pluginVue>[0];
 
 export function vueRenderer(opts?: VueRendererOptions): TaujsRendererContribution {
-  const contribution: RendererContributionShape = {
+  const contribution: EnvironmentRendererContribution = {
     brand: RENDERER_BRAND,
     key: VUE_RENDERER_KEY,
     contractVersion: RENDER_CONTRACT_VERSION,
     managedCompilation: false,
-    createEnvironmentPlugins: () => pluginVue(opts),
+    // A FRESH pluginVue pack per invocation - the host calls this once per Vite environment (the ESC-1
+    // lifecycle lesson: plugin objects are never reused across environments). Only the module import
+    // behind it is cached, by ESM itself.
+    loadEnvironmentPlugins: async () => (await import('./plugin.js')).pluginVue(opts),
   };
   return contribution as unknown as TaujsRendererContribution;
 }


### PR DESCRIPTION
## What

Unit 1B of the production Vite isolation work (host-neutrality programme, stream 1).
One coordinated pre-v1 breaking minor train: server + all three renderers, upgraded together. No application source changes - `reactRenderer()`, `vueRenderer()` and `solidRenderer()` keep their exact synchronous signatures, and the render-module contract does not move.

- the renderer-contribution brand is the explicit protocol discriminator:
  `taujs.renderer-contribution/v2` (lazy) is the only protocol the server accepts; an eager v1 contribution fails at boot and build with an error naming the renderer package and the required upgrade
- the contribution type is a discriminated union on `managedCompilation` - React/Solid carry a memoised `loadCompiler()`, Vue carries `loadEnvironmentPlugins()` producing a fresh pack per Vite environment; exactly one loader, enforced structurally and at runtime
- renderer factories no longer import compiler machinery at declaration time; a production process never resolves the compiler toolchain
- one compiler-free `rendererOptions` module per JSX renderer is the single   validation surface for both the synchronous factory and the lazy builder
- no `@taujs/server` peer metadata: measurement showed npm's optional-peer   mismatch handling is topology-dependent (warning on a two-step add, hard `ETARGET` on a fresh install while the range is unsatisfiable) - the runtime brand check is the sole authoritative failure; portable plain-Vite use stays clean

A separate test-infrastructure commit gives the real-dev-server logger test layered, measured deadlines (child watchdog 10s operative, Vitest cap 12s above it, `ETIMEDOUT` asserted with measured context).

## Evidence

Packed artefacts of all four packages in scratch consumers (full record in `docs/vite-isolation/00-1B-PROTOCOL-PROOF.md`):

- production boots for React, Vue and Solid serve SSR, streaming and static assets with the forbidden set EMPTY by package identity (Solid drops from 1,406 to 690 resolutions - the Babel stack leaves the production graph)
- development boots and per-renderer builds run through the lazy path
- the old published eager renderer against the new server fails at build and dev with the guided upgrade error
- the Platformatic Watt spike serves in BOTH ownership modes with the forbidden set empty (mode A 429, mode B 432) - the originally failing P1 import-isolation gate now passes in both modes
- full-workspace `pnpm run check` green (build, typecheck, format, check-exports, all suites including the fixture browser runs)

## Migration

Upgrade the paired packages together (`@taujs/server` + your renderer). No source changes.
