### PR TITLE
fix(server): single runtime-mode derivation - explicit development, coherent production

### DIFF
--- a/.changeset/scaffolder-runtime-mode-alignment.md
+++ b/.changeset/scaffolder-runtime-mode-alignment.md
@@ -1,0 +1,11 @@
+---
+'@taujs/create-taujs': patch
+---
+
+Generated applications ask the runtime-mode question the way τjs answers it. The server template
+derived its debug setting from `process.env.NODE_ENV !== "production"`, which treats `test`,
+`staging` and an unset variable as development while the server runs them as production. It now
+reads `process.env.NODE_ENV === "development"`, with a comment stating the rule.
+
+No behaviour change for `npm run dev` or `npm start`, which set `NODE_ENV` explicitly; the
+difference appears when a supervisor, CI runner or container leaves it at some other value.

--- a/.changeset/single-runtime-mode-derivation.md
+++ b/.changeset/single-runtime-mode-derivation.md
@@ -1,0 +1,35 @@
+---
+'@taujs/server': minor
+---
+
+One runtime-mode derivation replaces the scattered `NODE_ENV` comparisons. Development must be
+requested explicitly; `production`, `test`, unset and any other value (`staging`, `ci`, a typo)
+are one production mode, resolved once and snapshotted at module evaluation.
+
+This fixes a real boot failure. Two derivations disagreed about every value that was neither
+literal: the client root partitioned on `=== 'production'` (so `test` and unset selected
+`src/client`) while asset loading partitioned on `=== 'development'` (so the same values took the
+production branch). The result was a development client root with production asset loading, i.e. a
+guaranteed `src/client/.vite/manifest.json` ENOENT at boot - an infinite crash-loop under a
+supervisor that restarts failed workers, and the reason `NODE_ENV`-unset hosts such as
+Platformatic Watt workers could not boot a τjs application at all.
+
+An unset `NODE_ENV` now selects production mode consistently. With built assets present, the
+application boots from `dist/client` instead of incorrectly reading production manifests from
+`src/client`. An explicitly supplied `clientRoot` remains authoritative in every mode.
+
+Intentional behaviour changes when `NODE_ENV` is `test`, unset, or any value other than
+`development` and `production`. Each was previously treated as non-production:
+
+- the client root is `dist/client`, not `src/client`
+- the runtime logger minimum level is `info`, not `debug`, in both fallback constructions. Debug
+  records are a development facility, so `debug` options no longer produce debug output in these
+  environments
+- log timestamps are ISO, not `HH:mm:ss.SSS`
+- warning records strip stacks by default
+- a missing global CSP raises the production advisory, in the boot summary and in the security
+  contract report (status `warning` with the production tail note)
+
+Set `NODE_ENV=development` for the development loop, as the scaffolded scripts already do. No
+public API changes: the derivation is internal, and `resolveRuntimeMode` is not exported from the
+package.

--- a/fixtures/playground-react/src/server/index.ts
+++ b/fixtures/playground-react/src/server/index.ts
@@ -18,7 +18,9 @@ const { net } = await createServer({
   config,
   serviceRegistry,
   fastify: app,
-  debug: process.env.NODE_ENV !== 'production' ? { ssr: true } : false,
+  // Development is requested explicitly, the same question τjs asks itself: test, staging and an
+  // unset variable are production, and debug records are a development facility.
+  debug: process.env.NODE_ENV === 'development' ? { ssr: true } : false,
 });
 
 await app.listen({ host: net.host, port: net.port });

--- a/fixtures/playground-solid/src/server/index.ts
+++ b/fixtures/playground-solid/src/server/index.ts
@@ -10,7 +10,9 @@ const { net } = await createServer({
   config,
   serviceRegistry,
   fastify: app,
-  debug: process.env.NODE_ENV !== 'production' ? { ssr: true } : false,
+  // Development is requested explicitly, the same question τjs asks itself: test, staging and an
+  // unset variable are production, and debug records are a development facility.
+  debug: process.env.NODE_ENV === 'development' ? { ssr: true } : false,
 });
 
 await app.listen({ host: net.host, port: net.port });

--- a/fixtures/playground-vue/src/server/index.ts
+++ b/fixtures/playground-vue/src/server/index.ts
@@ -10,7 +10,9 @@ const { net } = await createServer({
   config,
   serviceRegistry,
   fastify: app,
-  debug: process.env.NODE_ENV !== 'production' ? { ssr: true } : false,
+  // Development is requested explicitly, the same question τjs asks itself: test, staging and an
+  // unset variable are production, and debug records are a development facility.
+  debug: process.env.NODE_ENV === 'development' ? { ssr: true } : false,
 });
 
 await app.listen({ host: net.host, port: net.port });

--- a/packages/create-taujs/src/index.ts
+++ b/packages/create-taujs/src/index.ts
@@ -1388,7 +1388,9 @@ function generateServerIndex() {
 import config from '../../taujs.config.ts';
 import { serviceRegistry } from './services/registry.ts';
 
-const isDev = process.env.NODE_ENV !== "production";
+// Development is requested explicitly, exactly as τjs derives its own runtime mode: every other
+// value - production, test, staging, unset - is production. Do not invert this check.
+const isDev = process.env.NODE_ENV === "development";
 
 const { app, net } = await createServer({
   config,

--- a/packages/create-taujs/src/test/__snapshots__/generate.test.ts.snap
+++ b/packages/create-taujs/src/test/__snapshots__/generate.test.ts.snap
@@ -564,7 +564,9 @@ code {
 import config from '../../taujs.config.ts';
 import { serviceRegistry } from './services/registry.ts';
 
-const isDev = process.env.NODE_ENV !== "production";
+// Development is requested explicitly, exactly as τjs derives its own runtime mode: every other
+// value - production, test, staging, unset - is production. Do not invert this check.
+const isDev = process.env.NODE_ENV === "development";
 
 const { app, net } = await createServer({
   config,

--- a/packages/create-taujs/src/test/cli-solid.test.ts
+++ b/packages/create-taujs/src/test/cli-solid.test.ts
@@ -348,3 +348,20 @@ describe('scaffolder baseline - the Vite builds pin NODE_ENV', () => {
     });
   }
 });
+
+describe('scaffolder baseline - generated code asks the runtime-mode question the way τjs does', () => {
+  for (const framework of ['react', 'vue', 'solid'] as Framework[]) {
+    it(`${framework}: development is explicit, never "not production"`, () => {
+      const { read } = generate(framework);
+      const server = read('src/server/index.ts');
+
+      // τjs resolves ONE runtime mode: development is requested explicitly and every other value -
+      // production, test, staging, unset - is production. A generated `!== "production"` taught the
+      // opposite partition, which is the mixture that made an unset NODE_ENV read production
+      // manifests from src/client and crash-loop under a supervisor.
+      expect(server).toContain('process.env.NODE_ENV === "development"');
+      expect(server).not.toContain('!== "production"');
+      expect(server).not.toContain("!== 'production'");
+    });
+  }
+});

--- a/packages/server/src/CreateServer.ts
+++ b/packages/server/src/CreateServer.ts
@@ -16,7 +16,7 @@ import { bannerPlugin } from './network/Network';
 import { verifyContracts, isAuthRequired, hasAuthenticate } from './security/VerifyMiddleware';
 import { printConfigSummary, printContractReport, printSecuritySummary } from './Setup';
 import { ssrServerPlugin } from './SSRServer';
-import { isDevelopment } from './System';
+import { isDevelopment, runtimeMode } from './System';
 
 import type { FastifyInstance } from 'fastify';
 import type { ServiceRegistry } from './core/services/DataServices';
@@ -58,7 +58,7 @@ const resolveClientRoot = (userClientRoot?: string): string => {
 
   const cwd = process.cwd();
 
-  if (process.env.NODE_ENV === 'production') return path.resolve(cwd, 'dist/client');
+  if (runtimeMode === 'production') return path.resolve(cwd, 'dist/client');
 
   return path.resolve(cwd, 'src/client');
 };
@@ -95,7 +95,7 @@ export const createServer = async (opts: CreateServerOptions): Promise<CreateSer
     source: opts.logger ? 'explicit' : fastifyLogger ? 'fastify' : 'fallback',
     debug: opts.debug,
     custom: opts.logger ?? fastifyLogger,
-    minLevel: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
+    minLevel: runtimeMode === 'production' ? 'info' : 'debug',
   };
   const logger = createRuntimeLogger(runtimeLogger, {
     includeContext: true,

--- a/packages/server/src/SSRServer.ts
+++ b/packages/server/src/SSRServer.ts
@@ -14,7 +14,7 @@ import { TEMPLATE } from './constants';
 import { AppError } from './core/errors/AppError';
 import { logResponseFailure } from './core/errors/ResponseFailureLog';
 import { fastifyConfigForRoute, selectedRouteFrom } from './core/routes/FastifyRoutes';
-import { isDevelopment } from './System';
+import { isDevelopment, runtimeMode } from './System';
 
 import { printVitePluginSummary } from './Setup';
 import { createLogger } from './logging/Logger';
@@ -56,7 +56,7 @@ const installOwnedScope = async (scope: FastifyInstance, opts: SSRServerOptions,
     : createLogger({
         debug: opts.debug,
         context: { component: 'ssr-server' },
-        minLevel: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
+        minLevel: runtimeMode === 'production' ? 'info' : 'debug',
         includeContext: true,
         singleLine: true,
       });

--- a/packages/server/src/Setup.ts
+++ b/packages/server/src/Setup.ts
@@ -1,4 +1,5 @@
 import { CONTENT } from './constants';
+import { runtimeMode } from './System';
 
 import type { Plugin } from 'vite';
 import type { CoreSecurityConfig } from './core/config/types';
@@ -38,7 +39,7 @@ export function printSecuritySummary(logger: Logger, routes: Route[], security: 
     if (hasReporting) detail += ', reporting';
     if (custom > 0) detail += `, ${custom} route override(s)`;
   } else {
-    if (process.env.NODE_ENV === 'production') {
+    if (runtimeMode === 'production') {
       logger.warn({}, '(consider explicit config for production)');
     }
   }

--- a/packages/server/src/System.ts
+++ b/packages/server/src/System.ts
@@ -2,7 +2,29 @@ import { dirname, join } from 'node:path';
 import path from 'node:path'; /* separated import due to Istanbul coverage bug */
 import { fileURLToPath } from 'node:url';
 
-export const isDevelopment = process.env.NODE_ENV === 'development';
+export type RuntimeMode = 'development' | 'production';
+
+/**
+ * The ONE runtime-mode derivation. Development must be requested explicitly; `production`,
+ * `test`, unset and any other value (`staging`, `ci`, ...) all take production runtime
+ * behaviour. Previously the mode was inferred independently at each site with two different
+ * partitions (`=== 'development'` vs `=== 'production'`), so every value that was neither
+ * literal produced an incoherent mixture - a development client root with production asset
+ * loading, i.e. a guaranteed `src/client/.vite/manifest.json` ENOENT at boot.
+ *
+ * Internal source export for direct tests only - deliberately NOT part of the package exports.
+ */
+export function resolveRuntimeMode(nodeEnv: string | undefined): RuntimeMode {
+  return nodeEnv === 'development' ? 'development' : 'production';
+}
+
+/**
+ * Snapshotted once at module evaluation. Mutating `process.env.NODE_ENV` after importing
+ * `@taujs/server` is unsupported and must never change part of a running process.
+ */
+export const runtimeMode: RuntimeMode = resolveRuntimeMode(process.env.NODE_ENV);
+export const isDevelopment = runtimeMode === 'development';
+
 export const __filename = fileURLToPath(import.meta.url);
 
 const DIR_SUFFIX = isDevelopment ? '..' : './';

--- a/packages/server/src/logging/Logger.ts
+++ b/packages/server/src/logging/Logger.ts
@@ -1,6 +1,7 @@
 import pc from 'picocolors';
 
 import { parseDebugInput } from './Parser';
+import { runtimeMode } from '../System';
 import { DEBUG_CATEGORIES, type BaseLogger, type DebugCategory, type DebugConfig, type Logs, type LogLevel } from '../core/logging/types';
 
 export { DEBUG_CATEGORIES };
@@ -68,7 +69,7 @@ export class Logger implements Logs {
   private shouldIncludeStack(level: LogLevel): boolean {
     const include = this.config.includeStack;
 
-    if (include === undefined) return level === 'error' || (level === 'warn' && process.env.NODE_ENV !== 'production');
+    if (include === undefined) return level === 'error' || (level === 'warn' && runtimeMode !== 'production');
 
     if (typeof include === 'boolean') return include;
 
@@ -96,7 +97,7 @@ export class Logger implements Logs {
 
   private formatTimestamp(): string {
     const now = new Date();
-    if (process.env.NODE_ENV === 'production') return now.toISOString();
+    if (runtimeMode === 'production') return now.toISOString();
 
     const hours = String(now.getHours()).padStart(2, '0');
     const minutes = String(now.getMinutes()).padStart(2, '0');

--- a/packages/server/src/logging/test/Logger.test.ts
+++ b/packages/server/src/logging/test/Logger.test.ts
@@ -24,6 +24,24 @@ const parseDebugInputMock = parseDebugInput as unknown as Mock;
 
 const originalEnv = { ...process.env };
 
+// The runtime mode is snapshotted at module evaluation, so a Logger test that needs a specific
+// mode selects the environment and then imports Logger - it never mutates NODE_ENV mid-test and
+// never substitutes an assertion on the resolver for one on Logger's own behaviour.
+async function importLoggerWithEnv(nodeEnv: string | undefined) {
+  const previous = process.env.NODE_ENV;
+
+  if (nodeEnv === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = nodeEnv;
+
+  vi.resetModules();
+
+  try {
+    return await import('../Logger');
+  } finally {
+    process.env.NODE_ENV = previous;
+  }
+}
+
 describe('Logger', () => {
   let logSpy: ReturnType<typeof vi.spyOn>;
   let warnSpy: ReturnType<typeof vi.spyOn>;
@@ -46,18 +64,24 @@ describe('Logger', () => {
     process.env = { ...originalEnv };
   });
 
-  it('formatTimestamp uses HH:mm:ss.SSS in non-production and ISO in production', () => {
-    const logger = createLogger();
-    logger.info({}, 'hello');
+  it('formatTimestamp uses HH:mm:ss.SSS in development and ISO in every production-mode environment', async () => {
+    const development = await importLoggerWithEnv('development');
+    development.createLogger().info({}, 'hello');
 
     const firstArg = (console.log as any).mock.calls[0][0] as string;
     expect(firstArg).toMatch(/^03:04:05\.006 \[info\] hello$/);
 
-    (console.log as any).mockClear();
-    process.env.NODE_ENV = 'production';
-    logger.info({}, 'prod');
-    const prodArg = (console.log as any).mock.calls[0][0] as string;
-    expect(prodArg).toMatch(/^\d{4}-\d{2}-\d{2}T03:04:05\.006Z \[info\] prod$/);
+    // `production`, `test`, unset and any other value are ONE mode, so the production timestamp
+    // is pinned across all four rather than only the literal `production`.
+    for (const nodeEnv of ['production', 'test', undefined, 'staging']) {
+      (console.log as any).mockClear();
+
+      const productionMode = await importLoggerWithEnv(nodeEnv);
+      productionMode.createLogger().info({}, 'prod');
+
+      const prodArg = (console.log as any).mock.calls[0][0] as string;
+      expect(prodArg, `NODE_ENV=${String(nodeEnv)}`).toMatch(/^\d{4}-\d{2}-\d{2}T03:04:05\.006Z \[info\] prod$/);
+    }
   });
 
   it('minLevel gating: info suppressed when minLevel=warn, warn+error allowed; debug suppressed unless enabled', () => {
@@ -110,8 +134,9 @@ describe('Logger', () => {
     expect(msg).toContain('[debug:routes] enabled');
   });
 
-  it('includeStack: default includes warn (in non-prod) and error, strips stack otherwise; boolean and fn work', () => {
-    const loggerA = createLogger({ minLevel: 'debug' });
+  it('includeStack: default includes warn (in development) and error, strips stack otherwise; boolean and fn work', async () => {
+    const development = await importLoggerWithEnv('development');
+    const loggerA = development.createLogger({ minLevel: 'debug' });
 
     const circular: any = { a: 1, stack: 'S', inner: { someStack: 'X' } };
     circular.self = circular;
@@ -128,11 +153,17 @@ describe('Logger', () => {
     const warnMeta = warnArgs[1];
     expect(warnMeta.stack).toBe('S2');
 
-    process.env.NODE_ENV = 'production';
-    const loggerB = createLogger({ minLevel: 'debug' });
-    loggerB.warn({ stack: 'S3' }, 'prod warn');
-    const prodWarn = (console.warn as any).mock.calls.pop()!;
-    expect(prodWarn.length).toBe(1);
+    // Every non-development environment is production mode, so `test` strips warn stacks exactly
+    // as `production` does - the delta this unit deliberately introduced.
+    for (const nodeEnv of ['production', 'test']) {
+      const productionMode = await importLoggerWithEnv(nodeEnv);
+      const loggerB = productionMode.createLogger({ minLevel: 'debug' });
+
+      loggerB.warn({ stack: 'S3' }, 'prod warn');
+
+      const prodWarn = (console.warn as any).mock.calls.pop()!;
+      expect(prodWarn.length, `NODE_ENV=${nodeEnv}`).toBe(1);
+    }
 
     const loggerC = createLogger({ includeStack: true, minLevel: 'debug' });
     loggerC.info({ stack: 'S4' }, 'boolean true');

--- a/packages/server/src/security/VerifyMiddleware.ts
+++ b/packages/server/src/security/VerifyMiddleware.ts
@@ -1,3 +1,5 @@
+import { runtimeMode } from '../System';
+
 import type { FastifyInstance } from 'fastify';
 import type { CoreSecurityConfig, Route } from '../core/config/types';
 
@@ -65,7 +67,7 @@ export const verifyContracts = (app: FastifyInstance, routes: Route[], contracts
       const enabled = total - disabled;
       const hasGlobal = !!security?.csp;
 
-      const prodNoGlobal = !hasGlobal && process.env.NODE_ENV === 'production';
+      const prodNoGlobal = !hasGlobal && runtimeMode === 'production';
 
       let status: ContractItem['status'] = 'verified';
       let tail = '';

--- a/packages/server/src/security/test/CSP.test.ts
+++ b/packages/server/src/security/test/CSP.test.ts
@@ -57,6 +57,7 @@ async function importer(isDev = true) {
 
   vi.doMock('../../System', () => ({
     isDevelopment: isDev,
+    runtimeMode: isDev ? 'development' : 'production',
   }));
 
   return await import('../CSP');

--- a/packages/server/src/security/test/VerifyMiddleware.test.ts
+++ b/packages/server/src/security/test/VerifyMiddleware.test.ts
@@ -1,9 +1,27 @@
 // @vitest-environment node
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 
 import { isAuthRequired, hasAuthenticate, verifyContracts, formatCspLoadedMsg } from '../VerifyMiddleware';
 
 import type { ContractReport } from '../VerifyMiddleware';
+
+// The runtime mode is snapshotted at module evaluation, so the CSP advisory follows the mode this
+// module was imported under - not whatever NODE_ENV holds when `verifyContracts` is called. The
+// statically imported module above runs under the suite's ambient `NODE_ENV=test`, which the single
+// runtime-mode derivation treats as PRODUCTION; a development expectation selects the environment
+// and then imports.
+async function importVerifyMiddlewareWithEnv(nodeEnv: string) {
+  const previous = process.env.NODE_ENV;
+  process.env.NODE_ENV = nodeEnv;
+
+  vi.resetModules();
+
+  try {
+    return await import('../VerifyMiddleware');
+  } finally {
+    process.env.NODE_ENV = previous;
+  }
+}
 
 type Route = {
   path?: string;
@@ -44,10 +62,6 @@ describe('VerifyMiddleware helpers', () => {
 });
 
 describe('verifyContracts', () => {
-  beforeEach(() => {
-    process.env.NODE_ENV = 'test';
-  });
-
   afterEach(() => {
     process.env = { ...ORIG_ENV };
   });
@@ -171,8 +185,10 @@ describe('verifyContracts', () => {
     ]);
   });
 
-  it('CSP: no global, development; overrides present and disabled routes counted', () => {
-    process.env.NODE_ENV = 'development';
+  it('CSP: no global, development; overrides present and disabled routes counted', async () => {
+    // Development is the ONLY mode without the production advisory, and it must be requested
+    // explicitly - hence the environment-selected import rather than a mid-test NODE_ENV write.
+    const { verifyContracts } = await importVerifyMiddlewareWithEnv('development');
 
     const app = {} as any;
     const routes: Route[] = [
@@ -211,8 +227,6 @@ describe('verifyContracts', () => {
   });
 
   it('CSP: no global, PRODUCTION -> status warning with tail note on the summary line', () => {
-    process.env.NODE_ENV = 'production';
-
     const app = {} as any;
     const routes: Route[] = [
       { path: '/a' }, // default
@@ -250,8 +264,9 @@ describe('verifyContracts', () => {
   });
 
   it('Multiple contracts: mix CSP and other verified counts together', () => {
-    process.env.NODE_ENV = 'test';
-
+    // RECORDED DELTA: this ran under `NODE_ENV=test` and expected the development defaults
+    // message with `verified` status. `test` is production mode now, so a missing global CSP is
+    // the production advisory here exactly as it is under `NODE_ENV=production`.
     const app = { authenticate: () => {} } as any;
     const routes: Route[] = [
       { path: '/a', attr: { middleware: { auth: true } } },
@@ -290,20 +305,19 @@ describe('verifyContracts', () => {
       },
       {
         key: 'csp',
-        status: 'verified',
-        message: 'Loaded development defaults with 1 route override(s)',
+        status: 'warning',
+        message: 'No global CSP configured; 1 route override(s) only (no global CSP header is sent in production without security.csp)',
       },
       {
         key: 'csp',
-        status: 'verified',
+        status: 'warning',
         message: '✓ Verified (3 enabled, 1 disabled, 4 total).',
       },
     ]);
   });
 
   it('CSP: has global config WITH overrides -> "Loaded global config with N route override(s)" (no tail)', () => {
-    process.env.NODE_ENV = 'test'; // non-production: no tail anyway
-
+    // A global config short-circuits the advisory, so this holds in every mode.
     const app = {} as any;
     const routes: Route[] = [
       { path: '/a', attr: { middleware: { csp: { mode: 'merge' } } } }, // override #1
@@ -343,8 +357,6 @@ describe('verifyContracts', () => {
   });
 
   it('CSP: has global config WITH overrides in PRODUCTION → still no warning tail', () => {
-    process.env.NODE_ENV = 'production';
-
     const app = {} as any;
     const routes: Route[] = [
       { path: '/a', attr: { middleware: { csp: { mode: 'replace' } } } }, // override

--- a/packages/server/src/test/CanonicalRequestIdentity.test.ts
+++ b/packages/server/src/test/CanonicalRequestIdentity.test.ts
@@ -215,6 +215,15 @@ describe('SC-09 identity matrix - supplied host (caller policy)', () => {
     const page = observe(await host.app.inject(PATHS.taujsPage));
 
     expect(expectOneIdentity(page, captured)).toBe(CALLER_REQUEST_ID);
+
+    // The binding is proven on a record that exists in EVERY runtime mode. A successful render
+    // emits only request-scoped debug records, and debug is a development facility: since the
+    // single runtime-mode derivation, `NODE_ENV=test` runs as production, so the runtime logger
+    // sits at minLevel `info`. The failure leg emits at error level through the same
+    // request-scoped logger, which is where correlation actually earns its keep - and it matches
+    // the numeric leg below, which has always proven the binding this way.
+    observe(await host.app.inject(PATHS.taujsFailure));
+
     expect(host.logs.some((record) => (record.meta as Record<string, unknown>).reqId === CALLER_REQUEST_ID)).toBe(true);
   });
 

--- a/packages/server/src/test/CreateServer.test.ts
+++ b/packages/server/src/test/CreateServer.test.ts
@@ -176,7 +176,9 @@ describe('createServer', () => {
       }),
     );
 
-    expect(createLoggerSpy).toHaveBeenCalledWith(expect.objectContaining({ minLevel: 'debug', includeContext: true }));
+    // RECORDED DELTA: this suite boots under `NODE_ENV=test` and expected `debug`. Development is
+    // requested explicitly now, so `test` takes the production minimum level.
+    expect(createLoggerSpy).toHaveBeenCalledWith(expect.objectContaining({ minLevel: 'info', includeContext: true }));
 
     expect(registerMock).toHaveBeenNthCalledWith(
       2,
@@ -520,5 +522,87 @@ describe('createServer', () => {
     });
 
     expect(createLoggerSpy).toHaveBeenCalledWith(expect.objectContaining({ custom: customLogger }));
+  });
+});
+
+// The evidence matrix for the single runtime-mode derivation, driven through the real public
+// `createServer` rather than the resolver alone. Before this unit, `resolveClientRoot` partitioned
+// on `=== 'production'` while the asset loader partitioned on `=== 'development'`, so `test`, unset
+// and any arbitrary value selected a DEVELOPMENT client root and then loaded assets the PRODUCTION
+// way - a guaranteed `src/client/.vite/manifest.json` ENOENT at boot, and an infinite crash-loop
+// under a supervisor that restarts failed workers.
+describe('createServer runtime-mode matrix', () => {
+  const bootWith = async (nodeEnv: string | undefined, opts: { clientRoot?: string } = {}) => {
+    const previous = process.env.NODE_ENV;
+
+    if (nodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = nodeEnv;
+
+    try {
+      const { createServer } = await importer();
+
+      await createServer({
+        config: minimalConfig,
+        serviceRegistry: dummyRegistry,
+        ...opts,
+      });
+    } finally {
+      if (previous === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previous;
+    }
+
+    const ssrCall = registerMock.mock.calls.find(([plugin]) => plugin === SSRServerPlugin);
+
+    return {
+      clientRoot: (ssrCall?.[1] as any).clientRoot as string,
+      minLevel: firstLoggerArgs().minLevel,
+    };
+  };
+
+  // `createLoggerSpy` is declared with no parameters, so its recorded call tuple is typed empty.
+  const firstLoggerArgs = () => (createLoggerSpy.mock.calls[0] as unknown as [{ minLevel: string }])[0];
+
+  it('development: the development client root and debug logging', async () => {
+    const boot = await bootWith('development');
+
+    expect(boot.clientRoot).toBe(path.resolve(process.cwd(), 'src/client'));
+    expect(boot.minLevel).toBe('debug');
+  });
+
+  // One row per production-mode class. `test` and unset are the states that used to produce the
+  // mixed boot; `staging` stands for the arbitrary-value class the ruling covers explicitly.
+  it.each([['production'], ['test'], [undefined], ['staging']])('NODE_ENV=%s: the production client root and info logging', async (nodeEnv) => {
+    const boot = await bootWith(nodeEnv as string | undefined);
+
+    expect(boot.clientRoot).toBe(path.resolve(process.cwd(), 'dist/client'));
+    expect(boot.clientRoot).not.toContain(`${path.sep}src${path.sep}client`);
+    expect(boot.minLevel).toBe('info');
+  });
+
+  it('unset with an explicit clientRoot: the caller wins, which is why fail-fast was rejected', async () => {
+    const explicitRoot = path.resolve(process.cwd(), 'somewhere/else/client');
+    const boot = await bootWith(undefined, { clientRoot: explicitRoot });
+
+    expect(boot.clientRoot).toBe(explicitRoot);
+  });
+
+  it('the mode is a process-lifetime snapshot: changing NODE_ENV after import does not move it', async () => {
+    const previous = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+
+    try {
+      const { createServer } = await importer();
+
+      process.env.NODE_ENV = 'production';
+
+      await createServer({ config: minimalConfig, serviceRegistry: dummyRegistry });
+
+      const ssrCall = registerMock.mock.calls.find(([plugin]) => plugin === SSRServerPlugin);
+
+      expect((ssrCall?.[1] as any).clientRoot).toBe(path.resolve(process.cwd(), 'src/client'));
+      expect(firstLoggerArgs().minLevel).toBe('debug');
+    } finally {
+      process.env.NODE_ENV = previous;
+    }
   });
 });

--- a/packages/server/src/test/HostOwnership.test.ts
+++ b/packages/server/src/test/HostOwnership.test.ts
@@ -222,6 +222,12 @@ describe('RFC 0010 - caller-owned host', () => {
 
     const page = observe(await host.app.inject(PATHS.taujsPage));
 
+    // Correlation is asserted after the failure leg because that record exists in every runtime
+    // mode: a successful render only emits request-scoped DEBUG records, and since the single
+    // runtime-mode derivation `NODE_ENV=test` runs as production, where the runtime logger sits at
+    // minLevel `info`.
+    observe(await host.app.inject(PATHS.taujsFailure));
+
     expect(page.requestId).toBe(String(NUMERIC_REQUEST_ID));
     expect(page.requestId).not.toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-/);
     expect(JSON.stringify(host.logs)).toContain(String(NUMERIC_REQUEST_ID));

--- a/packages/server/src/test/SSRServer.test.ts
+++ b/packages/server/src/test/SSRServer.test.ts
@@ -123,9 +123,14 @@ vi.mock('../security/CSP', () => ({ cspPlugin: cspPluginMock }));
 
 vi.mock('../security/CSPReporting', () => ({ cspReportPlugin: cspReportPluginMock }));
 
+// The controlled System mock mirrors the real module's single derivation: one mode drives both
+// exports, so the mock cannot express the mixed state this unit removed.
 vi.mock('../System', () => ({
   get isDevelopment() {
     return devRef.value;
+  },
+  get runtimeMode() {
+    return devRef.value ? 'development' : 'production';
   },
 }));
 
@@ -666,9 +671,11 @@ describe('SSRServer', () => {
     expect(mockReply.send).not.toHaveBeenCalled();
   });
 
-  it('uses minLevel "debug" when not in production', async () => {
-    const orig = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'test';
+  // RECORDED DELTA: these two selected the level by writing NODE_ENV mid-test, and `test` used to
+  // mean debug. The level follows the one runtime mode now, so they select the mode instead -
+  // `test`, unset and any other value all resolve to the production branch.
+  it('uses minLevel "debug" in development', async () => {
+    devRef.value = true;
 
     await app.register(SSRServer, {
       alias: {},
@@ -682,12 +689,11 @@ describe('SSRServer', () => {
     const args = (createLogger as unknown as Mock).mock.calls[0]![0];
     expect(args.minLevel).toBe('debug');
 
-    process.env.NODE_ENV = orig;
+    devRef.value = false;
   });
 
-  it('uses minLevel "info" when NODE_ENV=production', async () => {
-    const orig = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'production';
+  it('uses minLevel "info" in production mode', async () => {
+    devRef.value = false;
 
     await app.register(SSRServer, {
       alias: {},
@@ -700,8 +706,6 @@ describe('SSRServer', () => {
 
     const args = (createLogger as unknown as Mock).mock.calls[0]![0];
     expect(args.minLevel).toBe('info');
-
-    process.env.NODE_ENV = orig;
   });
 
   it('registers static assets with default empty options when options is undefined', async () => {

--- a/packages/server/src/test/System.test.ts
+++ b/packages/server/src/test/System.test.ts
@@ -6,14 +6,19 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 const ORIGINAL_ENV = process.env.NODE_ENV;
 
 async function importSystemWithEnv(env: string | undefined) {
-  process.env.NODE_ENV = env as any;
+  // `process.env.NODE_ENV = undefined` stores the STRING "undefined", which is a different class
+  // from a genuinely unset variable - the state real supervisors produce. Delete it instead.
+  if (env === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = env;
+
   vi.resetModules();
 
   return await import('../System');
 }
 
 afterEach(() => {
-  process.env.NODE_ENV = ORIGINAL_ENV;
+  if (ORIGINAL_ENV === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = ORIGINAL_ENV;
 });
 
 describe('System constants', () => {
@@ -50,12 +55,63 @@ describe('System constants', () => {
     expect(nodePath.normalize(sys.__dirname)).toBe(nodePath.normalize(expectedDir));
   });
 
-  it('undefined NODE_ENV behaves as production (isDevelopment=false)', async () => {
+  it('unset NODE_ENV behaves as production (isDevelopment=false)', async () => {
     const sys = await importSystemWithEnv(undefined);
 
     expect(sys.isDevelopment).toBe(false);
 
     const expectedDir = nodePath.join(nodePath.dirname(sys.__filename), './');
     expect(nodePath.normalize(sys.__dirname)).toBe(nodePath.normalize(expectedDir));
+  });
+});
+
+// The frozen mapping. Development must be requested explicitly; production, test, unset and ANY
+// other value (staging, ci, a typo) are one production mode. The fifth class is the point: the two
+// derivations this replaced partitioned on different literals, so everything outside them produced
+// a development client root with production asset loading.
+const MODE_CLASSES: ReadonlyArray<readonly [label: string, nodeEnv: string | undefined, mode: 'development' | 'production']> = [
+  ['development', 'development', 'development'],
+  ['production', 'production', 'production'],
+  ['test', 'test', 'production'],
+  ['unset', undefined, 'production'],
+  ['an arbitrary value', 'staging', 'production'],
+];
+
+describe('resolveRuntimeMode (pure)', () => {
+  // Direct resolver coverage ADDS to the consuming-site tests; it never stands in for them.
+  it.each(MODE_CLASSES)('%s resolves to %s', async (_label, nodeEnv, mode) => {
+    const { resolveRuntimeMode } = await import('../System');
+
+    expect(resolveRuntimeMode(nodeEnv)).toBe(mode);
+  });
+
+  it('is pure: the argument decides, not the ambient environment', async () => {
+    const { resolveRuntimeMode } = await importSystemWithEnv('production');
+
+    expect(resolveRuntimeMode('development')).toBe('development');
+    expect(resolveRuntimeMode(undefined)).toBe('production');
+  });
+});
+
+describe('runtimeMode snapshot', () => {
+  it.each(MODE_CLASSES)('%s snapshots runtimeMode=%s with isDevelopment agreeing', async (_label, nodeEnv, mode) => {
+    const sys = await importSystemWithEnv(nodeEnv);
+
+    expect(sys.runtimeMode).toBe(mode);
+    expect(sys.isDevelopment).toBe(mode === 'development');
+  });
+
+  it('is taken once at module evaluation: a later NODE_ENV change does not move it', async () => {
+    const sys = await importSystemWithEnv('development');
+
+    expect(sys.runtimeMode).toBe('development');
+
+    process.env.NODE_ENV = 'production';
+    expect(sys.runtimeMode).toBe('development');
+    expect(sys.isDevelopment).toBe(true);
+
+    delete process.env.NODE_ENV;
+    expect(sys.runtimeMode).toBe('development');
+    expect(sys.isDevelopment).toBe(true);
   });
 });

--- a/packages/server/src/utils/test/AssetManager.test.ts
+++ b/packages/server/src/utils/test/AssetManager.test.ts
@@ -83,6 +83,7 @@ async function importer(isDev: boolean) {
 
   vi.doMock('../../System', () => ({
     isDevelopment: isDev,
+    runtimeMode: isDev ? 'development' : 'production',
   }));
 
   const mod = await import('../AssetManager');

--- a/website/src/content/docs/guides/authentication.md
+++ b/website/src/content/docs/guides/authentication.md
@@ -201,12 +201,18 @@ fastify.decorate("authenticate", async function (req, reply) {
 import fastifySession from "@fastify/session";
 import fastifyCookie from "@fastify/cookie";
 
+// A secure cookie describes the TRANSPORT this process is served over, not the build mode.
+// Keying it to `NODE_ENV === "production"` sends session cookies in clear whenever the variable
+// is `staging`, `test` or unset - all of which τjs runs as production. Declare the transport and
+// default to secure, so a missing value fails closed.
+const secureCookies = process.env.COOKIE_SECURE !== "false";
+
 // Register session plugins
 await fastify.register(fastifyCookie);
 await fastify.register(fastifySession, {
   secret: process.env.SESSION_SECRET,
   cookie: {
-    secure: process.env.NODE_ENV === "production",
+    secure: secureCookies,
   },
 });
 
@@ -335,10 +341,15 @@ needs, and never expose session tokens through critical or deferred route data.
 ### 1. Use Secure Session Configuration
 
 ```typescript
+// Default secure; set COOKIE_SECURE=false only where the application is served over plain HTTP,
+// such as local development. Never derive this from NODE_ENV: `staging`, `test` and an unset
+// variable are all production to τjs, and would silently drop the flag.
+const secureCookies = process.env.COOKIE_SECURE !== "false";
+
 await fastify.register(fastifySession, {
   secret: process.env.SESSION_SECRET,
   cookie: {
-    secure: process.env.NODE_ENV === "production", // HTTPS only
+    secure: secureCookies, // HTTPS only
     httpOnly: true, // Prevent XSS
     sameSite: "lax", // CSRF protection
     maxAge: 24 * 60 * 60 * 1000, // 24 hours

--- a/website/src/content/docs/guides/build-deployment.md
+++ b/website/src/content/docs/guides/build-deployment.md
@@ -18,6 +18,36 @@ The deployment strategies below cover the most common patterns, but the underlyi
 
 The build process is designed for multi-app architectures with separate bundles per application.
 
+## Runtime Mode
+
+τjs derives ONE runtime mode from `NODE_ENV`, once, when `@taujs/server` is imported:
+
+| `NODE_ENV`                           | Runtime mode |
+| ------------------------------------ | ------------ |
+| `development`                        | development  |
+| `production`                         | production   |
+| `test`                               | production   |
+| unset                                | production   |
+| any other value, including `staging` | production   |
+
+Development is requested explicitly. Every other value - including an unset variable, which is what
+many process supervisors leave behind - takes the production paths: assets resolve under
+`dist/client`, no Vite development server starts, and logging uses the production minimum level and
+ISO timestamps. Changing `process.env.NODE_ENV` after import does not move part of a running
+process.
+
+Two consequences worth internalising when writing your own conditionals:
+
+- Ask `NODE_ENV === "development"`, never `!== "production"`. The second form sends `test`,
+  `staging` and an unset variable down the development branch while τjs runs them as production -
+  which is how an application ends up looking for production manifests under `src/client`.
+- Do not key security or transport decisions to `NODE_ENV` at all. A secure-cookie flag describes
+  how the process is served, not how it was built. See
+  [Authentication](/guides/authentication/#1-use-secure-session-configuration).
+
+The scaffolded scripts set `NODE_ENV` explicitly for every command, so a generated application
+already satisfies this. Set it explicitly in your own process manager, container or supervisor too.
+
 ## Build Process
 
 ### Build Steps

--- a/website/src/content/docs/guides/logging-telemetry.md
+++ b/website/src/content/docs/guides/logging-telemetry.md
@@ -34,22 +34,26 @@ For a caller-owned host, configure logging directly on Fastify:
 ```ts
 import Fastify from "fastify";
 
+// Development is requested explicitly; `production`, `test`, `staging` and an unset variable all
+// take the production branch. This matches how τjs derives its own runtime mode, so the host
+// logger and τjs records never disagree about which mode the process is in.
+const isDevelopment = process.env.NODE_ENV === "development";
+
 const fastify = Fastify({
   logger: {
-    level: process.env.NODE_ENV === "production" ? "info" : "debug",
+    level: isDevelopment ? "debug" : "info",
     redact: [
       "req.headers.authorization",
       "req.headers.cookie",
       "params.password",
       "params.token",
     ],
-    transport:
-      process.env.NODE_ENV === "production"
-        ? undefined
-        : {
-            target: "pino-pretty",
-            options: { colorize: true },
-          },
+    transport: isDevelopment
+      ? {
+          target: "pino-pretty",
+          options: { colorize: true },
+        }
+      : undefined,
   },
 });
 

--- a/website/src/content/docs/guides/static-assets.md
+++ b/website/src/content/docs/guides/static-assets.md
@@ -54,9 +54,12 @@ Pass a plugin and options when the defaults do not fit:
 import fastifyStatic from "@fastify/static";
 import path from "node:path";
 
+// Ask the same question τjs asks: development is explicit, everything else is production.
+// Testing for `!== "production"` would send `NODE_ENV=test`, `staging` or an unset variable
+// down the development branch while τjs itself loads production assets.
 const clientRoot = path.resolve(
   process.cwd(),
-  process.env.NODE_ENV === "production" ? "dist/client" : "src/client",
+  process.env.NODE_ENV === "development" ? "src/client" : "dist/client",
 );
 
 await createServer({

--- a/website/src/content/docs/reference/taujs-config.md
+++ b/website/src/content/docs/reference/taujs-config.md
@@ -1123,7 +1123,9 @@ export default defineConfig({
 ### Conditional Configuration
 
 ```typescript
-const isDev = process.env.NODE_ENV !== "production";
+// Development is requested explicitly. Every other value - `production`, `test`, `staging`,
+// unset - is production, which is how τjs derives its own runtime mode.
+const isDev = process.env.NODE_ENV === "development";
 
 export default defineConfig({
   server: {


### PR DESCRIPTION
One runtime-mode derivation, and everything τjs publishes or generates aligned to it.

## The defect

The mode was inferred independently at each site with two different partitions: the client root
split on `=== 'production'` while `isDevelopment` split on `=== 'development'`. Every value that
was neither literal - `test`, unset, `staging`, a typo - selected a **development** client root
and then loaded assets the **production** way: a guaranteed `src/client/.vite/manifest.json`
ENOENT at boot, and an infinite crash-loop under a supervisor that restarts failed workers.
Platformatic Watt workers leave `NODE_ENV` unset, which is how it was found; `NODE_ENV=test` on a
built application reproduces it with no supervisor at all.

## The ruling

Development must be requested explicitly. `production`, `test`, unset and any other value are one
production mode, resolved once by a pure `resolveRuntimeMode(nodeEnv)` and snapshotted at module
evaluation.

| `NODE_ENV` | Runtime mode |
| --- | --- |
| `development` | development |
| `production` | production |
| `test` | production |
| unset | production |
| any other value, including `staging` | production |

Fail-fast on unset was rejected: it would break applications that boot today by passing an
explicit `clientRoot`, and would make τjs depend on a variable Node does not require. The
derivation stays internal to `System.ts` - no index re-export, no package entry point, absent
from `dist/*.d.ts`.

## Commits

1. **`8689e32` - the runtime contract.** Seven sites now consume the snapshot: the client root,
   both runtime-logger constructions, the CSP boot advisory, the security contract report, and
   the logger's timestamp and warn-stack defaults.
2. **`b2e7c93` - everything τjs publishes and generates aligned to it.** The documented
   `clientRoot` recipe could recreate the very defect commit 1 removes, so this is part of
   completing the change rather than a follow-up.

## Intentional behaviour changes

For `test`, unset and arbitrary values - each recorded at the test that pinned the old behaviour:

- client root is `dist/client`, not `src/client`
- runtime logger minimum level is `info`, not `debug`, so debug records are a development facility
- ISO timestamps; warn records strip stacks by default
- a missing global CSP raises the production advisory

## Docs, scaffolder and playgrounds

- `guides/build-deployment.md` gains a **Runtime Mode** section: the frozen mapping, the snapshot
  rule, and the two consequences (ask `=== "development"`, never `!== "production"`; never key
  security or transport decisions to `NODE_ENV`)
- `guides/static-assets.md`, `reference/taujs-config.md`, `guides/logging-telemetry.md` corrected
- `guides/authentication.md` - both secure-cookie examples stop deriving a transport fact from a
  build mode; they read an explicit `COOKIE_SECURE` and default to secure, failing closed on a
  missing value
- the generated server template asks for development explicitly, with a snapshot update and a new
  baseline test across all three frameworks
- the three maintained playground entries take the same form

## Evidence

- Unit: the frozen mapping and the snapshot pinned across all five `NODE_ENV` classes, plus a
  seven-row public-entry matrix (the genuine `createServer` with controlled Fastify and SSR
  registration seams) covering development, production, test, unset, `staging`,
  unset-with-explicit-`clientRoot`, and the snapshot.
- Runtime, playground: production, test, unset and `staging` serve the hashed built asset with no
  `@vite/client` and ISO logs; development serves `/@vite/client`; unset with an explicit
  `clientRoot` returns 200; with the build removed, the unset boot fails naming `dist/client`,
  never `src/client`.
- Runtime, Watt: P4(a) rerun on a disposable copy of the spike (the retained archive was
  fingerprinted before and after and is byte-identical). Development renders SSR from source; an
  unset worker (`nodeEnv: null`) serves the built asset with no development Vite runtime and no
  ENOENT.
- Gate: the only `process.env.NODE_ENV` read in `packages/server/src` product code is the single
  resolver call, and the repository sweep leaves no inverted or production-literal mode test
  outside the prose naming the anti-pattern.
- Full workspace typecheck, tests (server 984, create-taujs 44 including the real three-framework
  lifecycle), `check-format`, `check-exports`, and a clean 25-page website build.

Changesets: `@taujs/server` minor, `@taujs/create-taujs` patch.
