### PR TITLE
fix(server): stop streaming duplicating pre-handoff headers under a second casing

### DIFF
--- a/.changeset/streaming-head-normalisation.md
+++ b/.changeset/streaming-head-normalisation.md
@@ -1,0 +1,9 @@
+---
+'@taujs/server': patch
+---
+
+Streaming no longer duplicates pre-handoff headers by re-adding them under different casing.
+
+`reply.getHeaders()` returns lowercase keys, and the head write added `Content-Security-Policy` back under its canonical casing, which Node serialises as a separate header line. Any CSP set before the raw handoff was therefore emitted twice on a streamed response, including the one τjs's own CSP plugin sets in `onRequest`. Both lines always carried the same value, so the policy in force was unchanged, but the duplicate is invalid hygiene in a security header and hosts and proxies may flag or reject it.
+
+The 200 and pre-head 500 paths now commit one normalised, lowercase-keyed object, so every header the reply already carried is preserved under its canonical lowercase name. Hijacking, stream timing, failure handling, deferred settlement and telemetry are untouched.

--- a/packages/server/src/test/StreamingHeadNormalisation.test.ts
+++ b/packages/server/src/test/StreamingHeadNormalisation.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment node
+//
+// Unit 1 of `followups/streaming-response-host-policy.md`: the streamed head is written from ONE
+// normalised, lowercase-keyed object, so a header established before the raw handoff is not
+// re-added under a second casing and emitted twice.
+//
+// Scope note: repeated header LINES are legitimate on the wire (`set-cookie` is the obvious case).
+// The defect is case-variant duplication of a single-valued header caused by two object keys, so
+// the assertions below pin the single-valued headers under test rather than global uniqueness.
+//
+// This has to be a real listener. `inject()` cannot observe the defect - light-my-request reports
+// a single folded header value, while the duplication exists only in Node's raw header
+// serialisation, so an inject-based assertion would pass vacuously. `IncomingMessage.rawHeaders`
+// preserves repeated header lines, which is real wire evidence without hand-parsing TCP chunks.
+//
+// The pre-head 500 head is exercised separately through the captured `writeHead` assertions in
+// `utils/test/HandleRender.test.ts`: reaching it here would need a renderer failure mid-boot, and
+// the captured-object assertions pin the same normalised object.
+
+import http from 'node:http';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import fastify from 'fastify';
+import { describe, expect, it } from 'vitest';
+
+import { createServer } from '../CreateServer';
+import { testRenderer } from './support/renderer';
+
+import type { TaujsConfig } from '../Config';
+
+const TAUJS_CSP_DIRECTIVE = "'taujs-streaming-head'";
+const HOST_POLICY_HEADER = 'X-Host-Policy';
+const HOST_POLICY_VALUE = 'streaming-head-host-policy';
+const STREAM_PATH = '/streamed';
+
+/**
+ * A real streaming render module: it calls `onHead` (which commits the head and pipes), writes app
+ * bytes, then ends the writable so the host's `finish` terminal emits the data script and closes
+ * the response. A stub that never reaches `onHead` would leave the head uncommitted and the wire
+ * assertions vacuous.
+ */
+const RENDER_MODULE = [
+  "const tag = Symbol.for('taujs.render-contract/v1');",
+  "const brand = (fn) => Object.defineProperty(fn, tag, { value: { key: 'test', contractVersion: 'v1' } });",
+  "export const renderSSR = brand(async () => ({ headContent: '', appHtml: '<main>ssr</main>' }));",
+  'export const renderStream = brand((writable, callbacks) => {',
+  '  callbacks.onHead(\'<meta name="streaming-head" content="taujs">\');',
+  "  writable.write('<main>streamed</main>');",
+  '  callbacks.onShellReady?.();',
+  "  callbacks.onAllReady?.({ marker: 'streamed-data' });",
+  '  writable.end();',
+  '  return { abort() {}, done: Promise.resolve() };',
+  '});',
+].join('\n');
+
+/** A built production application whose SSR entry really streams. */
+const streamingFixture = async (): Promise<{ root: string; clientRoot: string }> => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'taujs-streaming-head-'));
+  const clientRoot = path.join(root, 'client');
+  const appRoot = path.join(clientRoot, 'app');
+  const ssrRoot = path.join(root, 'ssr', 'app');
+
+  await mkdir(path.join(appRoot, '.vite'), { recursive: true });
+  await mkdir(path.join(appRoot, 'assets'), { recursive: true });
+  await mkdir(path.join(ssrRoot, '.vite'), { recursive: true });
+  await writeFile(path.join(root, 'package.json'), '{"type":"module"}\n');
+  await writeFile(path.join(appRoot, 'index.html'), '<!doctype html><html><head><!--ssr-head--></head><body><div id="app"><!--ssr-html--></div></body></html>');
+  await writeFile(path.join(appRoot, '.vite', 'manifest.json'), JSON.stringify({ 'entry-client.ts': { file: 'assets/streaming-client.js' } }));
+  await writeFile(path.join(appRoot, 'assets', 'streaming-client.js'), 'export const marker = "streaming";\n');
+  await writeFile(path.join(ssrRoot, '.vite', 'ssr-manifest.json'), '{}');
+  await writeFile(path.join(ssrRoot, 'entry-server.js'), RENDER_MODULE);
+
+  return { root, clientRoot };
+};
+
+const config: TaujsConfig = {
+  apps: [
+    {
+      appId: 'streaming-head-app',
+      entryPoint: 'app',
+      renderer: testRenderer(),
+      routes: [{ path: STREAM_PATH, attr: { render: 'streaming', meta: {} } }],
+    },
+  ],
+  security: { csp: { directives: { 'default-src': [TAUJS_CSP_DIRECTIVE], 'script-src': ["'self'"] } } },
+};
+
+type Wire = { status: number; names: string[]; values: Map<string, string[]>; body: string };
+
+/** Reads the response off a real socket, keeping repeated header lines distinct. */
+const readWire = (port: number, url: string): Promise<Wire> =>
+  new Promise((resolve, reject) => {
+    const request = http.get({ host: '127.0.0.1', port, path: url }, (response) => {
+      let body = '';
+      response.setEncoding('utf8');
+      response.on('data', (chunk) => (body += chunk));
+      response.on('error', reject);
+      response.on('end', () => {
+        const names: string[] = [];
+        const values = new Map<string, string[]>();
+
+        // rawHeaders is a flat [name, value, name, value, ...] list: one entry per line ON THE
+        // WIRE, so a duplicated header survives here where a folded headers object hides it.
+        for (let i = 0; i < response.rawHeaders.length; i += 2) {
+          const name = response.rawHeaders[i]!.toLowerCase();
+          names.push(name);
+          values.set(name, [...(values.get(name) ?? []), response.rawHeaders[i + 1]!]);
+        }
+
+        resolve({ status: response.statusCode ?? 0, names, values, body });
+      });
+    });
+
+    request.on('error', reject);
+  });
+
+describe('streaming head normalisation (real listener)', () => {
+  it('does not introduce case-variant duplicates of pre-handoff headers on the wire', async () => {
+    const { root, clientRoot } = await streamingFixture();
+    const app = fastify({ logger: false });
+
+    try {
+      // An ordinary host policy header, established before the raw handoff exactly as the
+      // documented recipe requires. τjs's own CSP plugin sets its header the same way.
+      app.addHook('onRequest', (_request, reply, done) => {
+        reply.header(HOST_POLICY_HEADER, HOST_POLICY_VALUE);
+        done();
+      });
+
+      await createServer({ config, fastify: app, clientRoot });
+      // Ephemeral port: a fixed one would collide with anything else on the machine.
+      await app.listen({ port: 0, host: '127.0.0.1' });
+
+      const address = app.server.address();
+      const port = typeof address === 'object' && address !== null ? address.port : 0;
+
+      const wire = await readWire(port, STREAM_PATH);
+
+      expect(wire.status).toBe(200);
+
+      // The renderer really streamed and the response terminal really ran.
+      expect(wire.body).toContain('<main>streamed</main>');
+      expect(wire.body).toContain('__INITIAL_DATA__');
+      expect(wire.body).toContain('taujs:data-ready');
+
+      // The defect: a CSP established before the handoff was emitted under two casings.
+      expect(wire.values.get('content-security-policy')).toHaveLength(1);
+      expect(wire.values.get('content-security-policy')?.[0]).toContain(TAUJS_CSP_DIRECTIVE);
+
+      // Each single-valued header the head carries appears once, and its value survives the
+      // normalisation. `content-type` is the head-write's own key; `x-host-policy` is the caller's
+      // pre-handoff policy; `x-request-id` is τjs's request identity from the request context.
+      expect(wire.values.get('content-type')).toHaveLength(1);
+      expect(wire.values.get('content-type')?.[0]).toContain('text/html');
+      expect(wire.values.get('x-host-policy')).toEqual([HOST_POLICY_VALUE]);
+      expect(wire.values.get('x-request-id')).toHaveLength(1);
+    } finally {
+      await app.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/server/src/utils/HandleRender.ts
+++ b/packages/server/src/utils/HandleRender.ts
@@ -463,10 +463,12 @@ export const handleRender = async (
         });
       }
 
-      const headers = reply.getHeaders(); // includes x-request-id from createRequestContext
-      headers['Content-Type'] = 'text/html; charset=utf-8';
-      const cspHeader = reply.getHeader('Content-Security-Policy');
-      if (cspHeader) headers['Content-Security-Policy'] = cspHeader as any;
+      // ONE normalised head object for both commit paths. `reply.getHeaders()` returns LOWERCASE
+      // keys (Fastify lowercases on set), and `writeHead` serialises whatever keys the object
+      // carries, so a mixed-case key added here becomes a SECOND header line on the wire. That is
+      // how any CSP established before the handoff - including τjs's own, set by the CSP plugin in
+      // `onRequest` - was being emitted twice. Every key added here must be lowercase.
+      const headers = { ...reply.getHeaders(), 'content-type': 'text/html; charset=utf-8' }; // includes x-request-id from createRequestContext
 
       // The raw socket is ours from here. The status is committed on first
       // output (onHead) rather than up front, so a render failure before any
@@ -477,7 +479,7 @@ export const handleRender = async (
         if (!reply.raw.headersSent) reply.raw.writeHead(200, headers as any);
       };
       const commitErrorHead = () => {
-        if (!reply.raw.headersSent) reply.raw.writeHead(500, { ...headers, 'Content-Type': 'text/html; charset=utf-8' } as any);
+        if (!reply.raw.headersSent) reply.raw.writeHead(500, headers as any);
       };
 
       const abortedState = { aborted: false };

--- a/packages/server/src/utils/test/HandleRender.test.ts
+++ b/packages/server/src/utils/test/HandleRender.test.ts
@@ -134,6 +134,22 @@ vi.mock('node:stream', () => {
   return { ...mod, default: mod };
 });
 
+/**
+ * The streamed head is written from one normalised object. `reply.getHeaders()` returns lowercase
+ * keys and `writeHead` serialises the keys it is given, so a key differing only by case is a second
+ * header line on the wire. Required headers are pinned by the individual tests; this pins the
+ * property that makes them safe, without freezing the complete header set.
+ *
+ * Wire-level proof that duplicate keys really do reach the socket lives in
+ * `test/StreamingHeadNormalisation.test.ts` (a real listener reading `rawHeaders`).
+ */
+const expectNormalisedHead = (headers: Record<string, unknown>): void => {
+  const keys = Object.keys(headers);
+
+  expect(keys.map((key) => key.toLowerCase())).toEqual(keys);
+  expect(new Set(keys.map((key) => key.toLowerCase())).size).toBe(keys.length);
+};
+
 describe('handleRender', () => {
   let mockReq: any;
   let mockReply: any;
@@ -2053,8 +2069,11 @@ describe('handleRender', () => {
       expect(mockReply.raw.writeHead).toHaveBeenCalledTimes(1);
       expect(mockReply.raw.writeHead).toHaveBeenCalledWith(
         500,
-        expect.objectContaining({ 'Content-Type': 'text/html; charset=utf-8', 'x-request-id': 'fatal-episode-1' }),
+        expect.objectContaining({ 'content-type': 'text/html; charset=utf-8', 'x-request-id': 'fatal-episode-1' }),
       );
+      // The pre-head 500 commits the SAME normalised object as the 200 path, so it cannot
+      // reintroduce a case variant of a header the reply already carries.
+      expectNormalisedHead(mockReply.raw.writeHead.mock.calls[0][1]);
       expect(mockReply.raw.end).toHaveBeenCalledWith('Internal Server Error');
       expect(mockReply.raw.destroy).not.toHaveBeenCalled();
     });
@@ -2270,7 +2289,7 @@ describe('handleRender', () => {
       expect(writes).not.toContain('taujs:data-ready');
     });
 
-    it('streaming: does not add CSP header when getHeader returns undefined', async () => {
+    it('streaming: carries no CSP header when the reply has none', async () => {
       const mockRoute = createMockRouteMatch({ render: 'streaming', meta: {} });
       mockSelectedRoute = mockRoute;
 
@@ -2296,7 +2315,51 @@ describe('handleRender', () => {
       await handleRender(mockReq, mockReply, mockSelectedRoute, mockProcessedConfigs, mockServiceRegistry, mockMaps);
 
       const [, headers] = mockReply.raw.writeHead.mock.calls[0];
+      expect(headers['content-security-policy']).toBeUndefined();
       expect(headers['Content-Security-Policy']).toBeUndefined();
+      expectNormalisedHead(headers);
+    });
+
+    it('streaming: a CSP already on the reply reaches the head exactly once, and existing headers survive', async () => {
+      const mockRoute = createMockRouteMatch({ render: 'streaming', meta: {} });
+      mockSelectedRoute = mockRoute;
+
+      // Exactly what the CSP plugin leaves behind: a lowercase entry in the reply's header store.
+      mockReply.getHeaders = vi.fn().mockReturnValue({
+        'content-security-policy': "default-src 'self'",
+        'x-request-id': 'head-normalisation-1',
+        'x-host-policy': 'caller-owned',
+      });
+
+      vi.mocked(Templates.ensureNonNull).mockReturnValue('<html></html>');
+      vi.mocked(Templates.processTemplate).mockReturnValue({
+        beforeHead: '<html><head>',
+        afterHead: '',
+        beforeBody: '</head><body>',
+        afterBody: '</body></html>',
+      });
+
+      vi.mocked(DataRoutes.fetchInitialData).mockResolvedValue({});
+
+      mockMaps.renderModules.set('/test/client', {
+        renderStream: vi.fn((writable: any, callbacks: any) => {
+          callbacks.onHead?.('<title>X</title>');
+          writable.emit('finish');
+          return { abort: vi.fn(), done: Promise.resolve() };
+        }),
+      });
+
+      await handleRender(mockReq, mockReply, mockSelectedRoute, mockProcessedConfigs, mockServiceRegistry, mockMaps);
+
+      const [status, headers] = mockReply.raw.writeHead.mock.calls[0];
+
+      expect(status).toBe(200);
+      expectNormalisedHead(headers);
+      expect(headers['content-security-policy']).toBe("default-src 'self'");
+      expect(headers['content-type']).toBe('text/html; charset=utf-8');
+      // Everything the reply already carried survives the normalisation.
+      expect(headers['x-request-id']).toBe('head-normalisation-1');
+      expect(headers['x-host-policy']).toBe('caller-owned');
     });
   });
 


### PR DESCRIPTION
Unit 1 of the streaming response-hook follow-up, ruled 2026-08-04. Scope is the head write only: hijacking, stream timing, failure handling, deferred settlement and telemetry do not move.

`reply.getHeaders()` returns lowercase keys, so the mixed-case `Content-Security-Policy` the head write added back became a SEPARATE header line on the wire, and `Content-Type` had the same shape. Any CSP established before the raw handoff was emitted twice, including the one taujs's own CSP plugin sets in `onRequest`, so this reached ordinary standalone applications and not only embedded hosts. Both lines always carried the same value, leaving the policy in force unchanged, but a duplicated security header is invalid hygiene and hosts or proxies may flag or reject it.

The 200 and pre-head 500 paths now commit one normalised object built from `reply.getHeaders()` with a lowercase `content-type`. Every header the reply already carried survives under its canonical lowercase name.

The defect is case-variant duplication caused by two object keys, not repeated header lines as such: repeated lines are legitimate for `set-cookie` and are not rejected here.

Evidence:

- `test/StreamingHeadNormalisation.test.ts` boots a caller-owned host on an ephemeral port with a real streaming renderer that reaches `onHead`, completes its writable and hits the response terminal, then reads `IncomingMessage.rawHeaders`. Proven RED first: 2 CSP lines before the fix, 1 after. It pins single occurrence and surviving values for the single-valued headers under test - CSP, `content-type`, the caller's `x-host-policy` and taujs's `x-request-id`. `inject()` cannot see the defect at all, because light-my-request reports the folded header value, so an inject-based test would pass vacuously.
- `utils/test/HandleRender.test.ts` gains `expectNormalisedHead` (all keys lowercase, no case-variant collisions) applied to the captured `writeHead` object on both the 200 and the pre-head 500 path, plus a test that a CSP already on the reply reaches the head once while `x-request-id` and a caller header survive.
- Mutation check: restoring the CSP re-addition fails the wire test and both unit assertions; restoring the mixed-case `Content-Type` fails three unit assertions (not the wire test, because a reply carries no content-type before the handoff, so that mutation duplicates nothing).

Recorded delta: the pre-head 500 assertion moves from `'Content-Type'` to `'content-type'`, which is the fix, not a regression.

Full workspace green: `pnpm -r typecheck`, `pnpm -r test` (server 986), `check-format`, `check-exports`.