### PR TITLE
docs(server): publish the host hook-observability matrix for SSR and streaming

### DIFF
--- a/packages/server/src/test/HostHookObservability.test.ts
+++ b/packages/server/src/test/HostHookObservability.test.ts
@@ -1,0 +1,321 @@
+// @vitest-environment node
+//
+// Unit 2 of `followups/streaming-response-host-policy.md`: which Fastify lifecycle hooks a host can
+// use to establish response policy, for SSR and for streaming, in both ownership modes.
+//
+// Two questions are recorded SEPARATELY, because conflating them would publish a misleading
+// "supported hooks" table:
+//
+//   1. is the hook INVOKED;
+//   2. does a header mutation made there SURVIVE to the wire.
+//
+// `onResponse` is why: it is invoked for both strategies, but it runs after the response has
+// completed, so mutation is not available there at all.
+//
+// Real listener throughout. `inject()` has already been shown to conceal wire behaviour on this
+// seam (Unit 1), so the acceptance evidence is read from `IncomingMessage.rawHeaders` off a real
+// socket. ONE boot per ownership mode installs all seven hooks and answers every cell.
+//
+// A plain JSON control route rides the same boot: `preSerialization` is invoked there and its
+// mutation survives, which is what makes it PAYLOAD-SHAPE dependent rather than something τjs
+// omits. τjs page responses are a string (SSR) or a raw stream (streaming); neither is serialised.
+
+import http from 'node:http';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import fastify from 'fastify';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createServer } from '../CreateServer';
+import { testRenderer } from './support/renderer';
+
+import type { FastifyInstance } from 'fastify';
+import type { TaujsConfig } from '../Config';
+
+const HOOKS = ['onRequest', 'preParsing', 'preValidation', 'preHandler', 'preSerialization', 'onSend', 'onResponse'] as const;
+
+type Hook = (typeof HOOKS)[number];
+/** `json` is the payload-shape control, not a τjs render strategy. */
+type Probe = 'ssr' | 'streaming' | 'json';
+type HostMode = 'caller-owned' | 'taujs-created';
+
+const PATHS: Record<Probe, string> = { ssr: '/matrix-ssr', streaming: '/matrix-streamed', json: '/matrix-json' };
+const MUTATION = 'hook-mutation';
+
+const headerFor = (hook: Hook): string => `x-hook-${hook.toLowerCase()}`;
+const probeOf = (url: string | undefined): Probe | undefined => (Object.entries(PATHS) as Array<[Probe, string]>).find(([, value]) => value === url)?.[0];
+
+/** Real SSR and streaming render functions: the streaming one reaches `onHead` and the terminal. */
+const RENDER_MODULE = [
+  "const tag = Symbol.for('taujs.render-contract/v1');",
+  "const brand = (fn) => Object.defineProperty(fn, tag, { value: { key: 'test', contractVersion: 'v1' } });",
+  "export const renderSSR = brand(async () => ({ headContent: '', appHtml: '<main>ssr</main>' }));",
+  'export const renderStream = brand((writable, callbacks) => {',
+  '  callbacks.onHead(\'<meta name="matrix" content="taujs">\');',
+  "  writable.write('<main>streamed</main>');",
+  '  callbacks.onShellReady?.();',
+  "  callbacks.onAllReady?.({ marker: 'matrix' });",
+  '  writable.end();',
+  '  return { abort() {}, done: Promise.resolve() };',
+  '});',
+].join('\n');
+
+const fixture = async (): Promise<{ root: string; clientRoot: string }> => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'taujs-hook-matrix-'));
+  const clientRoot = path.join(root, 'client');
+  const appRoot = path.join(clientRoot, 'app');
+  const ssrRoot = path.join(root, 'ssr', 'app');
+
+  await mkdir(path.join(appRoot, '.vite'), { recursive: true });
+  await mkdir(path.join(appRoot, 'assets'), { recursive: true });
+  await mkdir(path.join(ssrRoot, '.vite'), { recursive: true });
+  await writeFile(path.join(root, 'package.json'), '{"type":"module"}\n');
+  await writeFile(path.join(appRoot, 'index.html'), '<!doctype html><html><head><!--ssr-head--></head><body><div id="app"><!--ssr-html--></div></body></html>');
+  await writeFile(path.join(appRoot, '.vite', 'manifest.json'), JSON.stringify({ 'entry-client.ts': { file: 'assets/matrix-client.js' } }));
+  await writeFile(path.join(appRoot, 'assets', 'matrix-client.js'), 'export const marker = "matrix";\n');
+  await writeFile(path.join(ssrRoot, '.vite', 'ssr-manifest.json'), '{}');
+  await writeFile(path.join(ssrRoot, 'entry-server.js'), RENDER_MODULE);
+
+  return { root, clientRoot };
+};
+
+const config: TaujsConfig = {
+  apps: [
+    {
+      appId: 'hook-matrix-app',
+      entryPoint: 'app',
+      renderer: testRenderer(),
+      routes: [
+        { path: PATHS.ssr, attr: { render: 'ssr' } },
+        { path: PATHS.streaming, attr: { render: 'streaming', meta: {} } },
+      ],
+    },
+  ],
+};
+
+type Observations = {
+  invocations: Map<string, number>;
+  completions: Array<{ probe: Probe; statusCode: number }>;
+};
+
+const key = (hook: Hook, probe: Probe): string => `${hook}|${probe}`;
+
+/** Installs all seven hooks; each records its invocation and attempts a header mutation. */
+const installHooks = (app: FastifyInstance, seen: Observations): void => {
+  const note = (hook: Hook, url: string | undefined) => {
+    const probe = probeOf(url);
+    if (!probe) return;
+    seen.invocations.set(key(hook, probe), (seen.invocations.get(key(hook, probe)) ?? 0) + 1);
+  };
+
+  app.addHook('onRequest', (request, reply, done) => {
+    note('onRequest', request.url);
+    reply.header(headerFor('onRequest'), MUTATION);
+    done();
+  });
+
+  app.addHook('preParsing', (request, reply, payload, done) => {
+    note('preParsing', request.url);
+    reply.header(headerFor('preParsing'), MUTATION);
+    done(null, payload);
+  });
+
+  app.addHook('preValidation', (request, reply, done) => {
+    note('preValidation', request.url);
+    reply.header(headerFor('preValidation'), MUTATION);
+    done();
+  });
+
+  app.addHook('preHandler', (request, reply, done) => {
+    note('preHandler', request.url);
+    reply.header(headerFor('preHandler'), MUTATION);
+    done();
+  });
+
+  app.addHook('preSerialization', (request, reply, payload, done) => {
+    note('preSerialization', request.url);
+    reply.header(headerFor('preSerialization'), MUTATION);
+    done(null, payload);
+  });
+
+  app.addHook('onSend', (request, reply, payload, done) => {
+    note('onSend', request.url);
+    reply.header(headerFor('onSend'), MUTATION);
+    done(null, payload);
+  });
+
+  app.addHook('onResponse', (request, reply, done) => {
+    note('onResponse', request.url);
+    const probe = probeOf(request.url);
+    if (probe) seen.completions.push({ probe, statusCode: reply.statusCode });
+    // Attempted deliberately: the matrix records that a mutation here cannot reach the wire.
+    try {
+      reply.header(headerFor('onResponse'), MUTATION);
+    } catch {
+      // Whether Fastify rejects it or accepts it into a dead store, it never reaches the client.
+    }
+    done();
+  });
+};
+
+type Wire = { status: number; headers: Map<string, string[]>; body: string };
+
+const readWire = (port: number, url: string): Promise<Wire> =>
+  new Promise((resolve, reject) => {
+    const request = http.get({ host: '127.0.0.1', port, path: url }, (response) => {
+      let body = '';
+      response.setEncoding('utf8');
+      response.on('data', (chunk) => (body += chunk));
+      response.on('error', reject);
+      response.on('end', () => {
+        const headers = new Map<string, string[]>();
+
+        for (let i = 0; i < response.rawHeaders.length; i += 2) {
+          const name = response.rawHeaders[i]!.toLowerCase();
+          headers.set(name, [...(headers.get(name) ?? []), response.rawHeaders[i + 1]!]);
+        }
+
+        resolve({ status: response.statusCode ?? 0, headers, body });
+      });
+    });
+
+    request.on('error', reject);
+  });
+
+const open: FastifyInstance[] = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  const apps = open.splice(0);
+  const dirs = roots.splice(0);
+
+  try {
+    // Deliberately unguarded: on a real-host contract test, a teardown failure IS a failure.
+    await Promise.all(apps.map((app) => app.close()));
+  } finally {
+    await Promise.all(dirs.map((root) => rm(root, { recursive: true, force: true })));
+  }
+});
+
+/**
+ * The two documented public flows:
+ *
+ * - caller-owned: root hooks registered BEFORE the instance is handed to `createServer`;
+ * - τjs-created: hooks added to the RETURNED app AFTER `createServer` and BEFORE `listen`, which is
+ *   why created mode returns `{ app, net }`.
+ */
+const boot = async (mode: HostMode): Promise<{ app: FastifyInstance; port: number; seen: Observations }> => {
+  const { root, clientRoot } = await fixture();
+  roots.push(root);
+
+  const seen: Observations = { invocations: new Map(), completions: [] };
+  let app: FastifyInstance;
+
+  if (mode === 'caller-owned') {
+    app = fastify({ logger: false });
+    installHooks(app, seen);
+    app.get(PATHS.json, async () => ({ probe: 'json' }));
+    await createServer({ config, fastify: app, clientRoot });
+  } else {
+    const created = await createServer({ config, clientRoot });
+    app = created.app!;
+    installHooks(app, seen);
+    app.get(PATHS.json, async () => ({ probe: 'json' }));
+  }
+
+  open.push(app);
+  await app.listen({ port: 0, host: '127.0.0.1' });
+
+  const address = app.server.address();
+
+  return { app, port: typeof address === 'object' && address !== null ? address.port : 0, seen };
+};
+
+const invocationsOf = (seen: Observations, probe: Probe): Record<Hook, number> =>
+  Object.fromEntries(HOOKS.map((hook) => [hook, seen.invocations.get(key(hook, probe)) ?? 0])) as Record<Hook, number>;
+
+const survivorsOf = (wire: Wire): Record<Hook, string | null> =>
+  Object.fromEntries(HOOKS.map((hook) => [hook, wire.headers.get(headerFor(hook))?.[0] ?? null])) as Record<Hook, string | null>;
+
+// The frozen matrix. Same in both ownership modes; any divergence is a finding, not a detail.
+const INVOKED: Record<Probe, Record<Hook, number>> = {
+  ssr: { onRequest: 1, preParsing: 1, preValidation: 1, preHandler: 1, preSerialization: 0, onSend: 1, onResponse: 1 },
+  streaming: { onRequest: 1, preParsing: 1, preValidation: 1, preHandler: 1, preSerialization: 0, onSend: 0, onResponse: 1 },
+  json: { onRequest: 1, preParsing: 1, preValidation: 1, preHandler: 1, preSerialization: 1, onSend: 1, onResponse: 1 },
+};
+
+const SURVIVES: Record<Probe, Record<Hook, string | null>> = {
+  ssr: {
+    onRequest: MUTATION,
+    preParsing: MUTATION,
+    preValidation: MUTATION,
+    preHandler: MUTATION,
+    preSerialization: null, // not invoked: an HTML string is not serialised
+    onSend: MUTATION,
+    onResponse: null, // invoked, but the response has already completed
+  },
+  streaming: {
+    onRequest: MUTATION,
+    preParsing: MUTATION,
+    preValidation: MUTATION,
+    preHandler: MUTATION,
+    preSerialization: null, // not invoked: a raw stream is not serialised
+    onSend: null, // NOT invoked: the head was committed after `reply.hijack()`
+    onResponse: null, // invoked, but the response has already completed
+  },
+  json: {
+    onRequest: MUTATION,
+    preParsing: MUTATION,
+    preValidation: MUTATION,
+    preHandler: MUTATION,
+    preSerialization: MUTATION, // the control: an object payload IS serialised
+    onSend: MUTATION,
+    onResponse: null,
+  },
+};
+
+describe.each(['caller-owned', 'taujs-created'] as const)('host hook observability matrix (real listener): %s', (mode) => {
+  it('pins invocation, mutation survival and completion for every hook and both render strategies', async () => {
+    const { app, port, seen } = await boot(mode);
+
+    const wires: Record<Probe, Wire> = {
+      ssr: await readWire(port, PATHS.ssr),
+      streaming: await readWire(port, PATHS.streaming),
+      json: await readWire(port, PATHS.json),
+    };
+
+    // `onResponse` fires on the raw response's `finish`, which can land after the client has read
+    // the last byte, so completion is awaited rather than assumed.
+    await vi.waitFor(() => expect(seen.completions).toHaveLength(3), { timeout: 2000 });
+
+    // The responses are real: SSR rendered, streaming reached `onHead` AND its data terminal.
+    expect(wires.ssr.status).toBe(200);
+    expect(wires.ssr.body).toContain('<main>ssr</main>');
+    expect(wires.streaming.status).toBe(200);
+    expect(wires.streaming.body).toContain('<meta name="matrix" content="taujs">');
+    expect(wires.streaming.body).toContain('<main>streamed</main>');
+    expect(wires.streaming.body).toContain('taujs:data-ready');
+    expect(wires.json.status).toBe(200);
+
+    for (const probe of ['ssr', 'streaming', 'json'] as const) {
+      expect({ probe, invoked: invocationsOf(seen, probe) }).toEqual({ probe, invoked: INVOKED[probe] });
+      expect({ probe, survives: survivorsOf(wires[probe]) }).toEqual({ probe, survives: SURVIVES[probe] });
+    }
+
+    // Completion is observed exactly once per response, with the real status, on every strategy.
+    // Compared by probe, not chronologically: `onResponse` lands after the client has read the
+    // final byte, so its relative ordering is scheduling rather than contract.
+    expect([...seen.completions].sort((left, right) => left.probe.localeCompare(right.probe))).toEqual([
+      { probe: 'json', statusCode: 200 },
+      { probe: 'ssr', statusCode: 200 },
+      { probe: 'streaming', statusCode: 200 },
+    ]);
+
+    // The boundary behind the τjs-created flow: hooks must be installed before the instance boots.
+    // Fastify enforces it, so "after createServer and before listen" is a real constraint rather
+    // than a stylistic recommendation.
+    expect(() => app.addHook('onRequest', (_request, _reply, done) => done())).toThrow();
+  });
+});

--- a/website/src/content/docs/guides/content-security-policy.md
+++ b/website/src/content/docs/guides/content-security-policy.md
@@ -64,6 +64,16 @@ The nonce is automatically applied to:
 
 **You do not add nonces manually** - τjs handles this.
 
+### Applying your own CSP from a hook
+
+τjs manages the policy for the pages it renders. If the host applies its own CSP, or any other
+response header, the hook it uses decides which pages receive it: an `onSend` policy reaches SSR
+pages but never streamed ones, because a streamed response commits its head before Fastify's send
+phase. Use `onRequest` for an unconditional policy like this one, or `preHandler` when the policy
+depends on the route or on authentication having succeeded. Both reach every strategy. See
+[Response policy and lifecycle hooks](/guides/host-ownership/#response-policy-and-lifecycle-hooks)
+for the verified matrix.
+
 ## Development vs Production
 
 ### Development Mode

--- a/website/src/content/docs/guides/host-ownership.md
+++ b/website/src/content/docs/guides/host-ownership.md
@@ -113,6 +113,82 @@ inbound correlation header after Fastify has created the request; a caller that 
 inbound correlation configures it at Fastify construction with a validating `genReqId`. See
 [Logging and Telemetry](/guides/logging-telemetry/#request-identity) for the recipe.
 
+## Response policy and lifecycle hooks
+
+Host response policy, such as cache headers, security headers or a marker header, is applied with a
+Fastify lifecycle hook. Where that hook must sit depends on the render strategy, because a streamed
+response commits its head as soon as the renderer produces one and writes the rest to the socket
+directly.
+
+Two questions decide whether a hook is a usable policy point, and they have different answers:
+
+1. Is the hook **invoked**?
+2. Does a header set there **reach the client**?
+
+| Hook | SSR: invoked | SSR: header reaches client | Streaming: invoked | Streaming: header reaches client |
+| --- | --- | --- | --- | --- |
+| `onRequest` | Yes | Yes | Yes | Yes |
+| `preParsing` | Yes | Yes | Yes | Yes |
+| `preValidation` | Yes | Yes | Yes | Yes |
+| `preHandler` | Yes | Yes | Yes | Yes |
+| `preSerialization` | No | Not applicable | No | Not applicable |
+| `onSend` | Yes | Yes | **No** | **No** |
+| `onResponse` | Yes | No, already sent | Yes | No, already sent |
+
+The table is identical for both installation shapes. It is verified against a real listener, not an
+injected request, because header behaviour on a streamed response is only observable on the wire.
+
+Both `onRequest` and `preHandler` reach every strategy, so either covers all rendered pages. Which
+one depends on what the policy is:
+
+- **`onRequest`** for unconditional host-wide policy, such as security headers.
+- **`preHandler`** for route-selected or authentication-sensitive policy, such as HTML caching. It
+  runs after authentication and validation have succeeded, so a rejected request does not carry a
+  header that assumed success.
+- **`onSend`** only when SSR pages and ordinary Fastify responses are deliberately the entire
+  target.
+
+`onSend` is the important exception. A streaming page hands the raw socket to the renderer, so
+Fastify's send phase never runs for it: an `onSend` policy silently applies to SSR pages and to
+ordinary JSON routes while skipping every streamed page. Nothing reports the difference, so compare
+responses rather than assuming coverage.
+
+`preSerialization` runs only when Fastify serialises a payload. τjs page responses are an HTML
+string or a raw stream, so neither shape is serialised. This is payload shape, not a τjs omission:
+the same hook on the same server runs normally for a route returning an object.
+
+`onResponse` is invoked for every strategy and is the right place to observe completion, including
+the final status of a streamed response. It runs after the response has been sent, so it is an
+observation point rather than a policy point.
+
+### Where to register hooks
+
+On a caller-owned instance, register hooks before passing the instance to `createServer`:
+
+```ts
+app.addHook('onRequest', async (_request, reply) => {
+  reply.header('X-Host-Policy', 'applied');
+});
+
+await createServer({ config, fastify: app });
+```
+
+On a τjs-created instance, add them to the returned app before `listen()`:
+
+```ts
+const { app } = await createServer({ config });
+
+app.addHook('onRequest', async (_request, reply) => {
+  reply.header('X-Host-Policy', 'applied');
+});
+
+await app.listen({ port: 3000 });
+```
+
+Both flows reach τjs page routes, including the routes τjs registers in its own encapsulated scope.
+The boundary is the server boot: Fastify rejects `addHook` once the instance has booted, so hooks
+must be installed before `listen()`.
+
 ## Running τjs inside another runtime
 
 Because a supplied instance keeps its own lifecycle, τjs can run as a subsystem of a larger Fastify

--- a/website/src/content/docs/guides/static-assets.md
+++ b/website/src/content/docs/guides/static-assets.md
@@ -229,7 +229,7 @@ cache.
 A simple host-level Fastify policy can target known public pages:
 
 ```ts
-fastify.addHook("onSend", async (request, reply, payload) => {
+fastify.addHook("preHandler", async (request, reply) => {
   const pathname = request.raw.url?.split("?")[0] ?? "";
 
   if (pathname === "/" || pathname === "/pricing") {
@@ -238,10 +238,20 @@ fastify.addHook("onSend", async (request, reply, payload) => {
       "public, max-age=60, stale-while-revalidate=300",
     );
   }
-
-  return payload;
 });
 ```
+
+Use `preHandler`, not `onSend` and not `onRequest`. A streamed page commits its response head
+before Fastify's send phase, so an `onSend` policy reaches SSR pages and ordinary JSON routes while
+silently skipping every streamed page. `onRequest` reaches both strategies but runs before
+authentication and validation, so a rejected protected request could still carry a public cache
+header. `preHandler` reaches both and runs only once those stages have succeeded. See
+[Response policy and lifecycle hooks](/guides/host-ownership/#response-policy-and-lifecycle-hooks).
+
+Streaming cache policy is necessarily decided before rendering, because the head is committed as
+soon as the renderer produces one. If caching must depend on successful completion or on the final
+status, enforce it at a proxy or CDN that can observe the complete response, rather than through an
+early hook.
 
 τjs does not provide static-site generation, build-time HTML export or automatic cache headers.
 `hydrate: false` removes the client application from a rendered route; it does not make the HTML


### PR DESCRIPTION
Unit 2 of the streaming response-hook follow-up. Evidence and documentation only: no product code changes, so no changeset.

## Why

A host applies response policy - security headers, cache headers, a marker header - with a Fastify lifecycle hook. Nothing said which of those hooks a streamed page reaches. A streamed page commits its head as soon as the renderer produces one and writes the rest to the socket directly, so Fastify's send phase never runs for it: an `onSend` policy silently applies to SSR pages and ordinary JSON routes while skipping every streamed page, with nothing reporting the difference.

Two questions decide whether a hook is usable, and they have different answers, so the table keeps them apart rather than publishing a single misleading "supported hooks" column:

1. is the hook **invoked**;
2. does a header set there **reach the client**.

`onResponse` is the case that proves the distinction. It runs for both strategies, but after the response has completed, so it is an observation point and never a policy point.

## The matrix

| Hook | SSR: invoked | SSR: reaches client | Streaming: invoked | Streaming: reaches client |
| --- | --- | --- | --- | --- |
| `onRequest` | Yes | Yes | Yes | Yes |
| `preParsing` | Yes | Yes | Yes | Yes |
| `preValidation` | Yes | Yes | Yes | Yes |
| `preHandler` | Yes | Yes | Yes | Yes |
| `preSerialization` | No | Not applicable | No | Not applicable |
| `onSend` | Yes | Yes | **No** | **No** |
| `onResponse` | Yes | No, already sent | Yes | No, already sent |

Identical in both installation shapes, so there is no divergence finding.

Measured rather than reasoned about, which was the right call: two expectations going in were wrong. `preParsing` does run for GET page requests, and hooks added to a τjs-created instance after `createServer` do reach the routes τjs registers in its own encapsulated scope.

`preSerialization` runs only when Fastify serialises a payload, and τjs page responses are an HTML string or a raw stream. A plain JSON control route riding the same boot proves that is payload shape rather than a τjs omission: the hook fires there and its mutation survives.

## Evidence

`packages/server/src/test/HostHookObservability.test.ts` is the permanent record. One real boot per ownership mode installs all seven hooks, each with its own header so mutations cannot be confused, and answers every cell from `IncomingMessage.rawHeaders` off a real socket. `inject()` is not used for acceptance: it was shown in the Unit 1 work to conceal wire behaviour on exactly this seam.

Both ownership modes go through their precise public flows:

- caller-owned: root hooks registered **before** the instance is passed to `createServer`;
- τjs-created: hooks added to the returned app **after** `createServer` and **before** `listen()`, which is why created mode returns `{ app, net }`.

The created-host result is recorded as observed and then bounded, so incidental registration behaviour is not promoted into a contract: the test also pins that Fastify rejects `addHook` once the instance has booted, which is what makes "after `createServer`, before `listen()`" a real constraint rather than a style preference.

The streamed probe is a genuine stream, reaching `onHead`, writing app bytes and hitting the response terminal, all asserted from the body. Teardown failures fail the test rather than being swallowed, and completion is compared by probe rather than chronologically, since `onResponse` lands after the client has read the final byte.

## Documentation

- **`guides/host-ownership.md`** carries the authoritative matrix, where to register hooks in each ownership mode, and which hook suits which policy: `onRequest` for unconditional host-wide policy such as security headers, `preHandler` for route-selected or authentication-sensitive policy such as HTML caching, `onSend` only when SSR and ordinary Fastify responses are deliberately the entire target.
- **`guides/content-security-policy.md`** cross-references it, since a host-applied CSP is the obvious practical case.
- **`guides/static-assets.md`** recommended an `onSend` hook for HTML cache headers, which silently excluded every streamed page. It is now `preHandler`: it reaches both strategies and runs only after authentication and validation have succeeded, so a rejected protected request cannot go out carrying a public cache header. The copy also states the honest limit - streaming cache policy is necessarily decided before rendering, so caching that depends on successful completion or final status belongs at a proxy or CDN able to observe the whole response.

## Scope

Unit 2 of three in the streaming response-hook follow-up, and it stands alone. Unit 1 (the head-normalisation fix) shipped in `@taujs/server` 0.21.1. Unit 3 remains open and deliberately unanswered here: whether a Fastify-owned send path could preserve the streaming guarantees while keeping `onSend` observable, which is a bounded evidence spike rather than an assumption in either direction.

## Verification

`pnpm -r typecheck`, `pnpm -r test` (server 988), `check-format`, `check-exports`, and a clean 25-page website build with both new cross-reference anchors resolving in the built HTML.
