### PR TITLE
fix(server): admit vite.server.allowedHosts in development

### DIFF
--- a/.changeset/vite-server-config-composition.md
+++ b/.changeset/vite-server-config-composition.md
@@ -1,0 +1,31 @@
+---
+'@taujs/server': minor
+---
+
+A declared `vite.server.allowedHosts` now reaches the development server, so τjs can run behind a proxy.
+
+Vite 6.1+ rejects any request whose `Host` is not localhost-like unless `server.allowedHosts` permits it - a DNS-rebinding defence. A reverse proxy or process supervisor commonly presents such a host, and development behind one then answered Vite's 403 block page instead of the application, with no supported way to allow it: τjs composed its dev config by writing `server` as a whole object **after** the user's, silently discarding the declared field.
+
+The composition now merges. The framework stays authoritative for exactly two fields:
+
+- `server.middlewareMode` stays `true` - τjs owns the request pipeline;
+- `server.hmr` is derived from the resolved dev host and port, and is replaced **whole** rather than deep-merged. A partly-user, partly-framework `hmr` would pair a user port with a framework host and fail in a way that looks like a τjs bug.
+
+Both remain warned-and-dropped invariants if declared, alongside `root`, `configFile` and the rest.
+
+The admitted surface is deliberately one field, `server.allowedHosts`:
+
+```ts
+// taujs.config.ts
+export default {
+  vite: {
+    server: { allowedHosts: ['app.internal'] },
+  },
+};
+```
+
+Everything else under Vite's `server` stays withheld, each for a reason: `ws: false` would disable the WebSocket connection HMR runs on; `host`, `port`, `strictPort`, `https` and `open` configure Vite's own HTTP listener, which does not exist in middleware mode because Fastify owns it; and `proxy` overlaps caller-route ownership. Supplying any of them **in development** warns and is not applied; in a build the whole `server` object is stripped silently, so nothing under it warns there. More can be admitted later, one at a time, with evidence that each works in middleware mode.
+
+The security posture is narrowed, never removed: a host you have not declared is still refused.
+
+`server` is development-only, and now behaves like `optimizeDeps` on the build side: absent from client and SSR builds **silently**. `config.vite` is one declaration feeding the development server and every app build, so warning there would report the recipe above as misuse, once per app, on every build.

--- a/packages/server/src/Build.ts
+++ b/packages/server/src/Build.ts
@@ -64,8 +64,10 @@ export function resolveInputs(isSSRBuild: boolean, mainExists: boolean, paths: {
  * - `resolve.*` (except `alias`): Merged with framework resolve config
  * - `esbuild`, `logLevel`: Direct overrides
  *
- * `optimizeDeps` is development-only (RFC 0005 §6) and is stripped from every build config -
- * declare it on `vite` in `taujs.config.ts` for the dev server instead.
+ * `optimizeDeps` and `server.*` are development-only and are stripped from every build config
+ * SILENTLY - `config.vite` is one declaration feeding the dev server and every build, so warning
+ * here would report ordinary configuration as misuse. Declare them on `vite` in `taujs.config.ts`
+ * for the dev server.
  *
  * **Protected fields (warned when supplied, never applied):**
  * - `root`, `base`, `publicDir`, `appType`, `configFile`: Framework-controlled
@@ -73,7 +75,6 @@ export function resolveInputs(isSSRBuild: boolean, mainExists: boolean, paths: {
  * - `build.ssr`, `ssrManifest`, `format`, `target`, `manifest`: Framework-controlled for SSR integrity
  * - `build.rollupOptions.input`: Framework manages entry points
  * - `resolve.alias`: Use the top-level `alias` in `taujs.config.ts` (or the `taujsBuild()` option) instead
- * - `server.*`: Dev-mode only; never applies to builds
  *
  * @example
  * ```ts

--- a/packages/server/src/ViteConfig.ts
+++ b/packages/server/src/ViteConfig.ts
@@ -24,7 +24,7 @@
  * `Config.ts`); the Vite-typed surface belongs alongside `Config.ts`/`Build.ts`, which already
  * import from `vite`.
  */
-import type { DepOptimizationOptions, ESBuildOptions, LogLevel, PluginOption, ResolveOptions, Rollup } from 'vite';
+import type { DepOptimizationOptions, ESBuildOptions, LogLevel, PluginOption, ResolveOptions, Rollup, ServerOptions } from 'vite';
 import type { BuildOptions, CSSOptions } from 'vite';
 
 /**
@@ -39,12 +39,44 @@ import type { BuildOptions, CSSOptions } from 'vite';
 export type TaujsOptimizeDeps = Pick<DepOptimizationOptions, 'include' | 'exclude' | 'esbuildOptions'>;
 
 /**
+ * INTERNAL shape for `TaujsViteConfig['server']` - not exported from the package. Reference it as
+ * `TaujsViteConfig['server']` if you need to name it.
+ *
+ * An ALLOWLIST of one, matching every other surface in this file, rather than "`ServerOptions`
+ * minus what we own". The exclusion form was tried and rejected: it admitted options τjs cannot
+ * honestly honour in middleware mode, and it would silently widen the public surface every time
+ * Vite adds a field.
+ *
+ * Deliberately withheld, each for a reason:
+ *
+ * - `ws` - Vite documents `ws: false` as disabling the WebSocket connection, which would break the
+ *   HMR facility τjs owns through `server.hmr`. Admitting a field that disables an invariant we
+ *   claim is a contradiction, not a customisation.
+ * - `host`, `port`, `strictPort`, `https`, `open` - these configure Vite's own HTTP listener, and
+ *   in middleware mode Vite has no listener. Fastify owns it. They would be inert, which is worse
+ *   than absent: the editor would suggest them and nothing would happen.
+ * - `proxy` - overlaps caller-route ownership, which is a separate, unresolved design question.
+ *   It cannot be admitted before that is settled.
+ *
+ * More can be admitted later, one at a time, each with evidence that it works in middleware mode.
+ * That is the same bar `optimizeDeps` was held to.
+ *
+ * Development-only: nothing under `server` reaches a build, silently, exactly like `optimizeDeps`.
+ */
+type TaujsViteServer = Pick<ServerOptions, 'allowedHosts'>;
+
+/**
  * RFC 0005 Amended contract §4 (support matrix) - the allowlisted Vite override object. Only the
  * matrix-admitted fields appear; the protected invariants (`root`, `base`, `publicDir`,
- * `configFile`, `server`, `appType`, `build.outDir`/`ssr`/`ssrManifest`/`format`/`target`/`manifest`,
+ * `configFile`, `appType`, `server.middlewareMode`, `server.hmr`,
+ * `build.outDir`/`ssr`/`ssrManifest`/`format`/`target`/`manifest`,
  * `build.rollupOptions.input`, `resolve.alias`) are ABSENT from the type, so the editor refuses them
  * up front rather than the merge dropping them later. Aliases have their own declarative home
  * (top-level `alias`), so `resolve` here is the alias-free `ResolveOptions`.
+ *
+ * Under `server`, ONLY `allowedHosts` is admitted. It applies to the shared development server, and
+ * is silently absent from every build (like `optimizeDeps`) rather than reported there as a
+ * rejected override.
  */
 export type TaujsViteConfig = {
   /** Appended to the framework plugin list (append + dedupe by name; §5). */
@@ -63,6 +95,11 @@ export type TaujsViteConfig = {
   logLevel?: LogLevel;
   /** `resolve` subset - `alias` is intentionally excluded (use top-level `alias`). */
   resolve?: ResolveOptions;
+  /**
+   * Dev-server subset - `middlewareMode` and `hmr` are framework-owned and excluded. Declare
+   * `allowedHosts` here to run development behind a proxy that presents a non-localhost `Host`.
+   */
+  server?: TaujsViteServer;
   /** Build-tuning subset - the framework owns everything else under `build`. */
   build?: {
     sourcemap?: BuildOptions['sourcemap'];

--- a/packages/server/src/test/Build.test.ts
+++ b/packages/server/src/test/Build.test.ts
@@ -1502,7 +1502,7 @@ describe('Build.ts - Full Coverage', () => {
       consoleWarnSpy.mockRestore();
     });
 
-    it('should warn about server config in build (dev-only)', async () => {
+    it('does NOT warn about server config in a build - it is dev-only, exactly like optimizeDeps', async () => {
       const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       await taujsBuild({
@@ -1516,7 +1516,12 @@ describe('Build.ts - Full Coverage', () => {
         },
       });
 
-      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('[taujs:build:admin] Ignored Vite config overrides: server'));
+      // `server` used to be rejected outright, so warning was right then. It is now a supported
+      // DEV-ONLY surface declared through the same shared `config.vite`, so a build must ignore it
+      // silently - otherwise the documented `allowedHosts` recipe reports itself as misuse, once per
+      // app, on every build.
+      const warned = consoleWarnSpy.mock.calls.map((call) => String(call[0])).join('\n');
+      expect(warned).not.toContain('Ignored Vite config overrides: server');
 
       consoleWarnSpy.mockRestore();
     });
@@ -2498,7 +2503,7 @@ describe('Build.ts - Full Coverage', () => {
       });
     });
 
-    it('mergeViteConfig restores invariants, initialises rollupOptions, and warns when protected fields/server are overridden without context', () => {
+    it('mergeViteConfig restores invariants, initialises rollupOptions, and warns for protected fields without context', () => {
       const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       // framework with only the minimal bits we care about, no build/rollupOptions
@@ -2510,13 +2515,13 @@ describe('Build.ts - Full Coverage', () => {
       };
 
       const userOverride: ViteConfigOverride = {
-        // top-level protected + server to populate ignoredKeys
+        // top-level protected fields, to populate ignoredKeys
         root: '/user-root',
         base: '/user-base/',
         publicDir: '/user-public',
-        server: {
-          port: 4000,
-        } as any,
+        // `server` is deliberately NOT here any more: it is dev-only and silently absent from a
+        // build, so it no longer contributes to this warning. Its build-side silence is asserted
+        // in ViteMergeEngine.test.ts and Build.test.ts's own dev-only cell.
       };
 
       // NOTE: no context passed → should use "[taujs:build]" prefix branch
@@ -2544,7 +2549,6 @@ describe('Build.ts - Full Coverage', () => {
       expect(msg).toContain('root');
       expect(msg).toContain('base');
       expect(msg).toContain('publicDir');
-      expect(msg).toContain('server');
 
       consoleWarnSpy.mockRestore();
     });

--- a/packages/server/src/test/TaujsViteConfig.test-d.ts
+++ b/packages/server/src/test/TaujsViteConfig.test-d.ts
@@ -55,8 +55,11 @@ void fullCallback;
 // ── §4: `TaujsViteConfig` rejects the protected invariants ───────────────────────────────────────
 // @ts-expect-error - `root` is framework-controlled; not part of the surface.
 const _root: TaujsViteConfig = { root: '/nope' };
-// @ts-expect-error - `server.*` is dev-owned and protected.
-const _server: TaujsViteConfig = { server: { port: 5173 } };
+// @ts-expect-error - `server.middlewareMode` is framework-owned: τjs runs Vite as middleware.
+const _middlewareMode: TaujsViteConfig = { server: { middlewareMode: true } };
+// @ts-expect-error - `server.hmr` is framework-owned, derived from the resolved dev host/port and
+// applied whole rather than deep-merged.
+const _hmr: TaujsViteConfig = { server: { hmr: { port: 24678 } } };
 // @ts-expect-error - `configFile` is pinned to `false` by the framework.
 const _configFile: TaujsViteConfig = { configFile: false };
 // @ts-expect-error - `base` is framework-controlled.
@@ -71,7 +74,23 @@ const _resolveAlias: TaujsViteConfig = { resolve: { alias: { '@x': '/x' } } };
 const _outDir: TaujsViteConfig = { build: { outDir: 'out' } };
 // @ts-expect-error - `build.rollupOptions.input` is framework-managed (entry points).
 const _input: TaujsViteConfig = { build: { rollupOptions: { input: { main: 'x' } } } };
-void [_root, _server, _configFile, _base, _publicDir, _appType, _resolveAlias, _outDir, _input];
+void [_root, _middlewareMode, _hmr, _configFile, _base, _publicDir, _appType, _resolveAlias, _outDir, _input];
+
+// `allowedHosts` is the whole admitted `server` surface, and the reason it exists: without it, a
+// development server behind a proxy presenting a non-localhost `Host` answers 403 with no declared
+// way to allow it.
+const _allowedHosts: TaujsViteConfig = { server: { allowedHosts: ['web.plt.local'] } };
+void _allowedHosts;
+
+// @ts-expect-error - `ws` is withheld: `ws: false` disables the WebSocket connection, which would
+// break the HMR facility the framework owns through `server.hmr`.
+const _ws: TaujsViteConfig = { server: { ws: false } };
+// @ts-expect-error - `host`/`port` configure Vite's own HTTP listener, which does not exist in
+// middleware mode; Fastify owns the listener.
+const _listener: TaujsViteConfig = { server: { host: '0.0.0.0', port: 5173 } };
+// @ts-expect-error - `proxy` overlaps caller-route ownership, an unresolved design question.
+const _proxy: TaujsViteConfig = { server: { proxy: {} } };
+void [_ws, _listener, _proxy];
 
 // Admitted fields DO type-check.
 const _ok: TaujsViteConfig = {

--- a/packages/server/src/test/ViteAllowedHostsDevelopment.test.ts
+++ b/packages/server/src/test/ViteAllowedHostsDevelopment.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment node
+//
+// Development behind a proxy: the acceptance evidence for `config.vite.server.allowedHosts`.
+//
+// Vite 6.1+ enforces `server.allowedHosts` as a DNS-rebinding defence, rejecting any request whose
+// `Host` is not localhost-like. A reverse proxy or process supervisor commonly presents such a
+// host, and τjs development behind one then answered 403 - with no way to allow it through the
+// declared Vite surface, because composition wrote `server` as a whole object AFTER the user spread.
+//
+// This drives REAL development boots with a REAL Vite server and a REAL listener, because the
+// defining feature of the topology is the rewritten `Host` arriving on the wire. `inject()` would
+// exercise the same middleware but would not be the thing under test.
+//
+// Both ownership modes are covered: a caller-owned host (RFC 0010 mode B) and a τjs-created host.
+// The security posture is asserted in the same boot as the fix - an ALLOWED host serves while an
+// UNDECLARED one is still refused, so admitting the field cannot be mistaken for weakening it.
+
+import http from 'node:http';
+
+import fastify from 'fastify';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { closeAll, developmentFixture, PATHS, taujsConfig } from './support/hostOwnership';
+
+import type { TaujsConfig } from '../Config';
+import type { FastifyInstance } from 'fastify';
+
+/**
+ * The host value is the one ACTUALLY observed in the original report, so this regression stays
+ * traceable to its evidence. Nothing here is specific to that proxy: any hostname a proxy or
+ * supervisor substitutes reproduces it, and no product code knows the value.
+ */
+const PROXY_HOST = 'web.plt.local';
+const UNDECLARED_HOST = 'not-declared.example';
+
+const loadDevelopmentCreateServer = async () => {
+  const original = process.env.NODE_ENV;
+  process.env.NODE_ENV = 'development';
+  vi.resetModules();
+
+  try {
+    return (await import('../CreateServer')).createServer;
+  } finally {
+    process.env.NODE_ENV = original;
+  }
+};
+
+/** A real request with a proxy-rewritten `Host`, which is the whole topology in one header. */
+const requestAs = (port: number, host: string, url: string): Promise<{ status: number; body: string }> =>
+  new Promise((resolve, reject) => {
+    const request = http.get({ host: '127.0.0.1', port, path: url, headers: { host } }, (response) => {
+      let body = '';
+
+      response.setEncoding('utf8');
+      response.on('data', (chunk) => (body += chunk));
+      response.on('end', () => resolve({ status: response.statusCode ?? 0, body }));
+    });
+
+    request.on('error', reject);
+  });
+
+const withAllowedHosts = (allowedHosts?: string[]): TaujsConfig => ({
+  ...taujsConfig(),
+  ...(allowedHosts ? { vite: { server: { allowedHosts } } } : {}),
+});
+
+type Boot = { port: number; close: () => Promise<void> };
+
+const bootDevelopment = async (options: { callerOwned: boolean; allowedHosts?: string[] }): Promise<Boot> => {
+  const { root, clientRoot } = await developmentFixture();
+  const previousCwd = process.cwd();
+
+  process.chdir(root);
+
+  try {
+    const createServer = await loadDevelopmentCreateServer();
+    const config = withAllowedHosts(options.allowedHosts);
+
+    let app: FastifyInstance | undefined;
+
+    if (options.callerOwned) {
+      app = fastify({ logger: false });
+      await createServer({ config, fastify: app, clientRoot, projectRoot: root });
+    } else {
+      app = (await createServer({ config, clientRoot, projectRoot: root })).app;
+    }
+
+    // A τjs-created host returns its instance optionally; a boot that produced none is a failed
+    // precondition for every assertion below, so say so here rather than at a confusing call site.
+    if (!app) throw new Error('development boot produced no Fastify instance');
+
+    await app.listen({ host: '127.0.0.1', port: 0 });
+
+    const address = app.server.address();
+    const port = typeof address === 'object' && address !== null ? address.port : 0;
+
+    return { port, close: async () => void (await app.close()) };
+  } finally {
+    process.chdir(previousCwd);
+  }
+};
+
+afterEach(async () => {
+  await closeAll();
+});
+
+describe.each([
+  ['caller-owned host', true],
+  ['τjs-created host', false],
+] as const)('development behind a proxy - %s', (_label, callerOwned) => {
+  it('refuses a proxy host when none is declared, which is the defect this unit fixes', async () => {
+    const boot = await bootDevelopment({ callerOwned });
+
+    try {
+      const blocked = await requestAs(boot.port, PROXY_HOST, PATHS.taujsPage);
+
+      // Vite's own block page, not a τjs response: the request never reaches routing.
+      expect(blocked.status).toBe(403);
+      expect(blocked.body.toLowerCase()).toContain('not allowed');
+    } finally {
+      await boot.close();
+    }
+  });
+
+  it('serves the page and Vite resources once the host is declared', async () => {
+    const boot = await bootDevelopment({ callerOwned, allowedHosts: [PROXY_HOST] });
+
+    try {
+      const page = await requestAs(boot.port, PROXY_HOST, PATHS.taujsPage);
+
+      expect(page.status).toBe(200);
+      expect(page.body).toContain('<!doctype html');
+
+      // Modules matter as much as the page: a development page that cannot load `/@vite/client`
+      // renders once and never hydrates or hot-reloads, which would look like a partial fix.
+      const client = await requestAs(boot.port, PROXY_HOST, '/@vite/client');
+
+      expect(client.status).toBe(200);
+    } finally {
+      await boot.close();
+    }
+  });
+
+  it('still refuses an UNDECLARED host, so the defence is narrowed rather than removed', async () => {
+    const boot = await bootDevelopment({ callerOwned, allowedHosts: [PROXY_HOST] });
+
+    try {
+      const blocked = await requestAs(boot.port, UNDECLARED_HOST, PATHS.taujsPage);
+
+      expect(blocked.status).toBe(403);
+      expect(blocked.body.toLowerCase()).toContain('not allowed');
+    } finally {
+      await boot.close();
+    }
+  });
+});

--- a/packages/server/src/test/ViteDevWiring.test.ts
+++ b/packages/server/src/test/ViteDevWiring.test.ts
@@ -91,7 +91,7 @@ async function runDev(viteOverride?: TaujsViteOverride) {
   return createServerMock.mock.calls[0]![0] as any;
 }
 
-async function runBuild(viteOverride?: TaujsViteOverride) {
+async function runBuild(viteOverride?: TaujsViteOverride, options: { isSSRBuild?: boolean } = {}) {
   const setup = await import('../core/config/Setup');
   const assets = await import('../utils/AssetManager');
   const apps = [
@@ -110,9 +110,10 @@ async function runBuild(viteOverride?: TaujsViteOverride) {
   vi.mocked(assets.processConfigs).mockReturnValue(apps as any);
 
   const { taujsBuild } = await import('../Build');
-  await taujsBuild({ config: { apps: [], vite: viteOverride } as any, projectRoot, clientBaseDir, isSSRBuild: false });
+  await taujsBuild({ config: { apps: [], vite: viteOverride } as any, projectRoot, clientBaseDir, isSSRBuild: options.isSSRBuild ?? false });
 
-  return buildMock.mock.calls[0]![0] as any;
+  // The LAST call: a single test may compose both the client and the SSR build.
+  return buildMock.mock.calls.at(-1)![0] as any;
 }
 
 beforeEach(() => {
@@ -182,33 +183,92 @@ describe('VS4 - optimizeDeps is dev-only', () => {
   });
 });
 
-describe('VS4 - dev invariants are protected: warned, never applied', () => {
-  it('smuggled server / resolve.alias / root warn via the engine and do not reach the dev config', async () => {
+describe('VS4 - server.* is dev-only', () => {
+  it('a declared server.* reaches development and is SILENTLY absent from client and SSR builds', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    // The allowlist `TaujsViteConfig` type forbids all three; a JS/`as any` cast still reaches the
+    // `config.vite` is ONE declaration feeding the dev server and every app build. The documented
+    // `allowedHosts` recipe must therefore be silent on the build side - warning would report normal
+    // configuration as misuse, once per app, on every build.
+    const fixture: TaujsViteConfig = { server: { allowedHosts: ['app.internal'] } };
+
+    const devConfig = await runDev(fixture);
+    expect(devConfig.server.allowedHosts).toEqual(['app.internal']);
+
+    const clientBuild = await runBuild(fixture);
+    expect(clientBuild.server).toBeUndefined();
+
+    const ssrBuild = await runBuild(fixture, { isSSRBuild: true });
+    expect(ssrBuild.server).toBeUndefined();
+
+    const warned = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(warned).not.toContain('server');
+  });
+});
+
+describe('VS4 - dev invariants are protected: warned, never applied', () => {
+  it('smuggled framework-owned server fields / resolve.alias / root warn and do not reach the dev config', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    // The allowlist `TaujsViteConfig` type forbids all of these; a JS/`as any` cast still reaches the
     // runtime engine, which must warn and drop them (RFC 0005 §4 - Protected in dev).
     const smuggled = {
-      server: { port: 9999 },
+      // `ws` and the listener-owned fields are withheld from the type; a JS/`as any` cast still
+      // reaches the runtime, which must refuse them. `ws: false` would disable the WebSocket
+      // channel HMR runs on, and `host`/`port` describe a listener Vite does not own here.
+      server: { middlewareMode: false, hmr: { port: 24678 }, ws: false, host: '0.0.0.0', port: 5173 },
       resolve: { alias: { '@evil': '/tmp/evil' } },
       root: '/tmp/not-the-root',
     } as unknown as TaujsViteConfig;
 
     const devConfig = await runDev(smuggled);
 
-    // One aggregated warn line names every rejected field.
+    // One aggregated warn line names every rejected field. The owned SUBKEYS are named, not the
+    // whole `server` key - `server` itself is now a supported surface in dev.
     const warned = warnSpy.mock.calls.map((c) => String(c[0])).join('\n');
     expect(warned).toContain('[taujs:dev]');
-    expect(warned).toContain('server');
+    expect(warned).toContain('server.middlewareMode');
+    expect(warned).toContain('server.hmr');
+    expect(warned).toContain('server.ws');
+    expect(warned).toContain('server.host');
+    expect(warned).toContain('server.port');
     expect(warned).toContain('resolve.alias');
     expect(warned).toContain('root');
 
     // None applied: dev keeps its own middlewareMode + hmr, its own root, and no smuggled alias.
     expect(devConfig.server.middlewareMode).toBe(true);
-    expect(devConfig.server.hmr).toBeDefined();
-    expect(devConfig.server.port).toBeUndefined();
+    expect(devConfig.server.hmr).toEqual({ clientPort: 5174, host: undefined, port: 5174, protocol: 'ws' });
     expect(devConfig.root).toBe(clientBaseDir);
     expect(devConfig.resolve.alias).not.toHaveProperty('@evil');
+
+    // Refused, not applied inertly: nothing that could disable HMR or describe a listener Vite does
+    // not own survives into the dev config.
+    expect(devConfig.server.ws).toBeUndefined();
+    expect(devConfig.server.host).toBeUndefined();
+    expect(devConfig.server.port).toBeUndefined();
+  });
+
+  it('a declared server.allowedHosts survives composition, and the framework keeps middlewareMode and hmr', async () => {
+    // The unit's reason to exist: Vite 6.1+ rejects a non-localhost `Host` unless it is allowed, so
+    // development behind a proxy or supervisor commonly needs this field to reach Vite.
+    const devConfig = await runDev({ server: { allowedHosts: ['web.plt.local'] } } as TaujsViteConfig);
+
+    expect(devConfig.server.allowedHosts).toEqual(['web.plt.local']);
+
+    // The framework's two fields are applied AFTER the user spread, with hmr replaced WHOLE.
+    expect(devConfig.server.middlewareMode).toBe(true);
+    expect(devConfig.server.hmr).toEqual({ clientPort: 5174, host: undefined, port: 5174, protocol: 'ws' });
+  });
+
+  it('composition does not mutate the caller-supplied config object', async () => {
+    const declared = { server: { allowedHosts: ['web.plt.local'] } } as TaujsViteConfig;
+    const snapshot = structuredClone(declared);
+
+    await runDev(declared);
+
+    // A caller may reuse or freeze the object it declared; composition must read it, never write it.
+    expect(declared).toEqual(snapshot);
   });
 });
 

--- a/packages/server/src/test/ViteMergeEngine.test.ts
+++ b/packages/server/src/test/ViteMergeEngine.test.ts
@@ -28,11 +28,21 @@ describe('ViteMergeEngine - profiles (declared data)', () => {
     expect(BUILD_PROFILE.admitBuild).toBe(true);
     expect(BUILD_PROFILE.protectedBuild).toContain('manifest');
     // VS8: `appType` protected in build too (§4 matrix lists it Protected in all columns), matching dev.
-    expect(BUILD_PROFILE.protectedTop).toEqual(expect.arrayContaining(['root', 'base', 'publicDir', 'configFile', 'server', 'appType']));
+    expect(BUILD_PROFILE.protectedTop).toEqual(expect.arrayContaining(['root', 'base', 'publicDir', 'configFile', 'appType']));
+    // A build has no dev server, so `server` never reaches a build config - SILENTLY, like
+    // `optimizeDeps`, because the same `config.vite` declaration also feeds the dev server.
+    expect(BUILD_PROFILE.admitServer).toBe(false);
 
     expect(DEV_PROFILE.admitBuild).toBe(false);
     // VS4 ruling: dev protects `base`/`publicDir` too (matrix Protected in all columns).
-    expect(DEV_PROFILE.protectedTop).toEqual(expect.arrayContaining(['root', 'base', 'publicDir', 'configFile', 'server', 'appType']));
+    expect(DEV_PROFILE.protectedTop).toEqual(expect.arrayContaining(['root', 'base', 'publicDir', 'configFile', 'appType']));
+    // Dev admits exactly ONE `server` field. Rejecting the whole key is what made `allowedHosts`
+    // inexpressible, and with it development behind a proxy.
+    expect(DEV_PROFILE.admitServer).toBe(true);
+    // An ALLOWLIST of one. `ws` would disable the HMR channel the framework owns, and
+    // `host`/`port`/`https` configure a listener Vite does not have in middleware mode.
+    expect(DEV_PROFILE.admittedServer).toEqual(['allowedHosts']);
+    expect(DEV_PROFILE.protectedTop).not.toContain('server');
   });
 
   it('normalisePlugins and getFrameworkInvariants remain reachable from the engine', () => {
@@ -163,7 +173,6 @@ describe('ViteMergeEngine - composeViteConfig (build profile)', () => {
       'base',
       'publicDir',
       'configFile',
-      'server',
       'appType',
       'build.outDir',
       'build.manifest',
@@ -173,6 +182,10 @@ describe('ViteMergeEngine - composeViteConfig (build profile)', () => {
     ]) {
       expect(msg).toContain(field);
     }
+
+    // `server` is NOT among them any more: it is a supported dev-only surface, silently absent from
+    // builds rather than reported as a rejected override.
+    expect(msg).not.toContain('server');
 
     // VS8: the smuggled build-side `appType` is warned and never applied (not silently dropped).
     expect((merged as any).appType).toBeUndefined();
@@ -198,6 +211,47 @@ describe('ViteMergeEngine - composeViteConfig (build profile)', () => {
     );
 
     expect((merged as any).optimizeDeps).toBeUndefined();
+    warn.mockRestore();
+  });
+
+  it('strips server from the composed build config SILENTLY, exactly like optimizeDeps', () => {
+    const warn = spyWarn();
+
+    // `config.vite` is the SHARED surface: the same declaration feeds the dev server and every app
+    // build. Warning here would make the documented dev-only `allowedHosts` recipe report itself as
+    // misuse once per app on every build, which is why this is silent rather than protected.
+    const merged = composeViteConfig(
+      buildFramework(),
+      [{ source: 'config.vite', config: { server: { allowedHosts: ['app.internal'] } } as any }],
+      BUILD_PROFILE,
+      '[taujs:build:admin]',
+    );
+
+    expect((merged as any).server).toBeUndefined();
+
+    const warned = warn.mock.calls.map(([m]) => String(m)).join('\n');
+    expect(warned).not.toContain('server');
+
+    warn.mockRestore();
+  });
+
+  it('is silent for the build-only escape hatch too - one rule, whichever layer supplied it', () => {
+    const warn = spyWarn();
+
+    // `taujsBuild({ vite })` is explicitly build-only, and takes a WIDER type (`Partial<InlineConfig>`)
+    // than `config.vite`, so `server` is reachable there without any cast. It is still silent, on
+    // the same rule rather than a special case: dev-only fields are stripped from builds by their
+    // own semantics, not by which layer supplied them - exactly as `optimizeDeps` already behaves.
+    const merged = composeViteConfig(
+      buildFramework(),
+      [{ source: 'taujsBuild.vite', config: { server: { allowedHosts: ['app.internal'] } } as any }],
+      BUILD_PROFILE,
+      '[taujs:build:admin]',
+    );
+
+    expect((merged as any).server).toBeUndefined();
+    expect(warn.mock.calls.map(([m]) => String(m)).join('\n')).not.toContain('server');
+
     warn.mockRestore();
   });
 });

--- a/packages/server/src/utils/DevServer.ts
+++ b/packages/server/src/utils/DevServer.ts
@@ -50,8 +50,10 @@ export type SetupDevServerOptions = {
    * The resolved, engine-merged dev Vite fragment (VS4), assembled ONCE in `SSRServer` via
    * `resolveDevViteConfig`: `plugins` (apps -> config.vite), `define`, `css` (scss `modern-compiler`
    * default merged with any user `css.preprocessorOptions`), `esbuild`, `logLevel`, `optimizeDeps`,
-   * and non-`alias` `resolve` keys. Framework invariants (`root`, `server`, `appType`, `configFile`,
-   * `mode`, `resolve.alias`) are applied HERE and NEVER read from this fragment.
+   * non-`alias` `resolve` keys, and the admitted `server.*` fields. Framework invariants (`root`,
+   * `appType`, `configFile`, `mode`, `resolve.alias`) are applied HERE and NEVER read from this
+   * fragment - as are `server.middlewareMode` and `server.hmr`, which are applied on top of whatever
+   * `server.*` the fragment carries.
    */
   viteConfig?: InlineConfig;
 };
@@ -98,7 +100,7 @@ export const setupDevServer = async (options: SetupDevServerOptions): Promise<Vi
   // Split the engine-merged fragment (VS4) into its admitted dev fields. `build` (an empty `{}` the
   // engine spreads from the framework layer) and the invariant carriers are dropped; everything else
   // (`define`, `esbuild`, `logLevel`, `optimizeDeps`) rides through untouched in `...admittedDevFields`.
-  const { build: _ignoredBuild, plugins: mergedPlugins, resolve: mergedResolve, css: mergedCss, ...admittedDevFields } = viteConfig ?? {};
+  const { build: _ignoredBuild, plugins: mergedPlugins, resolve: mergedResolve, css: mergedCss, server: mergedServer, ...admittedDevFields } = viteConfig ?? {};
 
   const viteDevServer = await createServer({
     ...admittedDevFields,
@@ -164,7 +166,16 @@ export const setupDevServer = async (options: SetupDevServerOptions): Promise<Vi
       alias: resolvedAlias,
     },
     root: baseClientRoot,
+    // MERGE, never replace. Writing this object whole discarded every declared `server.*` field,
+    // `allowedHosts` among them - so development behind a proxy presenting a non-localhost `Host`
+    // was unreachable, with no supported way to allow it.
+    //
+    // The framework stays authoritative for exactly two fields, applied AFTER the spread so no
+    // declared value can displace them. `hmr` is replaced WHOLE rather than deep-merged: a
+    // half-user, half-framework `hmr` would pair a user port with a framework host and fail in a
+    // way that looks like a τjs bug. The merge engine already warns on both.
     server: {
+      ...mergedServer,
       middlewareMode: true,
       hmr: {
         clientPort: hmrPort,

--- a/packages/server/src/utils/ViteMergeEngine.ts
+++ b/packages/server/src/utils/ViteMergeEngine.ts
@@ -83,11 +83,15 @@ export type ViteMergeProfile = {
   admitBuild: boolean;
   protectedTop: readonly string[];
   protectedBuild: readonly string[];
+  /** Whether `server.*` is configurable at all: dev has a dev server, a build does not. */
+  admitServer: boolean;
+  /** The ONLY `server` subkeys a user may set. Anything else is warned and dropped. */
+  admittedServer: readonly string[];
 };
 
 /**
- * Build profile (RFC 0005 §4 matrix): the framework owns roots, outputs, inputs, aliases, manifests
- * and the dev-only `server.*`. `manifest` is protected here WITH a warning - aligning it to its
+ * Build profile (RFC 0005 §4 matrix): the framework owns roots, outputs, inputs, aliases and
+ * manifests. `server.*` is dev-only and simply never reaches a build config. `manifest` is protected here WITH a warning - aligning it to its
  * siblings (it was silently restored before, the one Ground-truth inconsistency VS3 fixes).
  * `configFile` is an EXPLICIT protected invariant (pinned to `false` by the framework), no longer
  * merely never-copied. `appType` is protected here too (VS8): the §4 matrix lists it Protected in
@@ -97,13 +101,19 @@ export type ViteMergeProfile = {
 export const BUILD_PROFILE: ViteMergeProfile = {
   mode: 'build',
   admitBuild: true,
-  protectedTop: ['root', 'base', 'publicDir', 'configFile', 'server', 'appType'],
+  protectedTop: ['root', 'base', 'publicDir', 'configFile', 'appType'],
   protectedBuild: ['outDir', 'ssr', 'ssrManifest', 'format', 'target', 'manifest'],
+  // A build has no dev server. `server` is DROPPED SILENTLY rather than warned about, because
+  // `config.vite` is shared: warning would make the documented dev-only recipe look like misuse on
+  // every build. Same treatment as `optimizeDeps`.
+  admitServer: false,
+  admittedServer: [],
 };
 
 /**
  * Dev profile (RFC 0005 §4 matrix + §6). CONSUMED by `resolveDevViteConfig` (VS4). `build.*` is not
- * admitted in dev (the whole `build` key is rejected), and the framework owns `server.*`, `appType`,
+ * admitted in dev (the whole `build` key is rejected), and the framework owns `server.middlewareMode`
+ * and `server.hmr` (the rest of `server.*` is a supported dev surface), `appType`,
  * `root`, `base`, `publicDir`, `configFile`, and `resolve.alias`. `optimizeDeps` is dev-only and
  * merged separately via `mergeOptimizeDeps` (never through this field-copy path).
  *
@@ -117,8 +127,24 @@ export const BUILD_PROFILE: ViteMergeProfile = {
 export const DEV_PROFILE: ViteMergeProfile = {
   mode: 'dev',
   admitBuild: false,
-  protectedTop: ['root', 'base', 'publicDir', 'configFile', 'server', 'appType'],
+  protectedTop: ['root', 'base', 'publicDir', 'configFile', 'appType'],
   protectedBuild: [],
+  /**
+   * ONE `server` field is configurable in dev: `allowedHosts`.
+   *
+   * Rejecting the whole key made the declared surface unable to express it, which Vite requires
+   * whenever a proxy or supervisor presents a non-localhost `Host` - so development behind such a
+   * host answered 403 with no supported way to allow it.
+   *
+   * Everything else is refused, and the reasons differ. `middlewareMode` must stay `true` (τjs owns
+   * the request pipeline). `hmr` is host-derived and replaced WHOLE, never deep-merged: a
+   * partially-user-supplied `hmr` would silently pair a user port with a framework host, which is
+   * worse than refusing it. `ws` would disable the channel that HMR runs on; `host`/`port`/
+   * `strictPort`/`https`/`open` describe a listener Vite does not own in middleware mode; `proxy`
+   * overlaps caller-route ownership.
+   */
+  admitServer: true,
+  admittedServer: ['allowedHosts'],
 };
 
 /** A resolved user override layer (function forms already resolved) with its source label. */
@@ -300,10 +326,33 @@ function applyLayer(
     }
   }
 
-  // Protected top-level keys. `server` keeps its truthy check (legacy string in the warning).
-  if (userConfig.server) ignoredKeys.push('server');
+  // server.*: admitted in dev only, and SILENTLY absent from builds - exactly like `optimizeDeps`.
+  //
+  // It must not warn there. `config.vite` is the SHARED surface: one declaration feeds the dev
+  // server and every app build, so warning would make the documented dev-only recipe report itself
+  // as misuse once per app on every build. Dev-only means dev-only in both directions.
+  if (userConfig.server && profile.admitServer) {
+    const userServer = userConfig.server as Record<string, unknown>;
+
+    merged.server ??= {};
+
+    for (const [key, value] of Object.entries(userServer)) {
+      // An ALLOWLIST, not "everything except what we own". Vite's `server` carries fields τjs
+      // cannot honour in middleware mode - `ws` would disable the HMR channel the framework owns,
+      // and `host`/`port`/`https` configure a listener Vite does not have here - so an unadmitted
+      // key is warned and dropped exactly like a protected one, rather than applied inertly.
+      if (!profile.admittedServer.includes(key)) {
+        ignoredKeys.push(`server.${key}`);
+        continue;
+      }
+
+      claim(`server.${key}`, source);
+      (merged.server as Record<string, any>)[key] = value;
+    }
+  }
+
+  // Protected top-level keys.
   for (const key of profile.protectedTop) {
-    if (key === 'server') continue;
     if (key in userConfig) ignoredKeys.push(key);
   }
 
@@ -392,9 +441,11 @@ export function mergeOptimizeDeps(layers: readonly OptimizeDepsLayer[]): TaujsOp
  *   default, NOT replacing it), `esbuild`, `logLevel`, and non-`alias` `resolve` keys.
  * - `optimizeDeps` (§6 subset) is merged and validated separately via `mergeOptimizeDeps`
  *   (include/exclude contradiction throws here) and is DEV-ONLY - it never reaches a build config.
- * - Dev invariants (`server.*`, `appType`, `root`, `base`, `publicDir`, `configFile`,
- *   `resolve.alias`) are protected by DEV_PROFILE: supplying them via `config.vite` WARNS, never
- *   applies. `taujsBuild({ vite })` is build-only and deliberately NOT consulted here.
+ * - `server.*` is a supported DEV-ONLY surface (`allowedHosts` and the rest), merged here and, like
+ *   `optimizeDeps`, silently absent from every build rather than warned about there.
+ * - Dev invariants (`server.middlewareMode`, `server.hmr`, `appType`, `root`, `base`, `publicDir`,
+ *   `configFile`, `resolve.alias`) are protected by DEV_PROFILE: supplying them via `config.vite`
+ *   WARNS, never applies. `taujsBuild({ vite })` is build-only and deliberately NOT consulted here.
  *
  * Returns an `InlineConfig` fragment carrying only the admitted dev fields (plus the framework css
  * default and the app+config.vite plugin list). Framework invariants are applied by `setupDevServer`.

--- a/website/src/content/docs/guides/build-deployment.md
+++ b/website/src/content/docs/guides/build-deployment.md
@@ -267,8 +267,34 @@ Allowed customisations: `plugins` (appended after app plugins, then deduped by n
 Protected fields (framework-controlled; supplying one logs a warning and the framework value
 is kept): `root`, `base`, `publicDir`, `appType`, `build.outDir`, `build.ssr` / `ssrManifest`,
 `build.format`, `build.target`, `build.manifest`, `build.rollupOptions.input`, `resolve.alias`
-(use the `alias` option instead), `server.*`, `configFile`. `appType`, `build.manifest`, and
-`configFile` warn on supply like every other protected field.
+(use the `alias` option instead), `configFile`. `appType`, `build.manifest`, and `configFile`
+warn on supply like every other protected field.
+
+Development-only fields are a separate case: `optimizeDeps` and `server.*` configure the shared
+development server and are absent from every build **without** a warning, because the same
+`config.vite` declaration feeds both. See below.
+
+### Development server options (`config.vite.server`)
+
+These apply to the shared development server only, never to a build.
+
+Vite refuses any request whose `Host` is not localhost-like unless you allow it, which is a
+DNS-rebinding defence. A reverse proxy or process supervisor commonly presents such a host, and
+development behind one then answers Vite's 403 block page until the host is declared:
+
+```typescript
+// taujs.config.ts
+export default defineConfig({
+  vite: {
+    server: { allowedHosts: ["app.internal"] },
+  },
+});
+```
+
+τjs keeps two fields for itself: `middlewareMode` (it owns the request pipeline) and `hmr`
+(derived from the resolved development host and port, and applied whole rather than field by
+field). Declaring either warns and is not applied. A host you have not declared is still
+refused.
 
 ### Alias Configuration
 

--- a/website/src/content/docs/reference/taujs-config.md
+++ b/website/src/content/docs/reference/taujs-config.md
@@ -284,6 +284,9 @@ type TaujsViteConfig = {
   logLevel?: LogLevel;
   // resolve subset - alias is intentionally excluded (use the top-level alias field).
   resolve?: ResolveOptions;
+  // Dev-only. An allowlist of one: everything else under Vite's `server` is either
+  // framework-owned or meaningless in middleware mode. See the matrix below.
+  server?: Pick<ServerOptions, "allowedHosts">;
   // Build-tuning subset - the framework owns everything else under build.
   build?: {
     sourcemap?: BuildOptions["sourcemap"];
@@ -417,13 +420,27 @@ The matrix is the supported set. `Dev` is the shared development server; `Client
 | `build.rollupOptions.external`                         | N/A       | Yes          | Yes       | Override                               |
 | `build.rollupOptions.output.manualChunks`              | N/A       | Yes          | Yes       | Merge into output                      |
 | aliases                                                | Yes       | Yes          | Yes       | Via top-level `alias` only             |
-| `root`, `base`, `publicDir`, `configFile`, `appType`, `server.*`, `build.outDir`, `build.ssr` / `ssrManifest`, `build.format` / `target` / `manifest`, `build.rollupOptions.input`, `resolve.alias` | Protected | Protected | Protected | Rejected; logged at warn |
+| `server.allowedHosts`                                  | Yes       | N/A          | N/A       | Dev-only; stripped from builds         |
+| `server.*` other than `allowedHosts`                   | Protected | N/A          | N/A       | Dev: warned and dropped. Builds: stripped silently with the whole dev-only `server` object |
+| `root`, `base`, `publicDir`, `configFile`, `appType`, `build.outDir`, `build.ssr` / `ssrManifest`, `build.format` / `target` / `manifest`, `build.rollupOptions.input`, `resolve.alias` | Protected | Protected | Protected | Rejected; logged at warn |
 
 Protected fields are absent from `TaujsViteConfig`, so they cannot be supplied through the
 typed surface at all. If one reaches the merge engine anyway (a JavaScript config, or an
 `as any` cast), it is rejected and logged at warn rather than silently applied - including
 `build.manifest`, which warns like its siblings. In dev the whole `build` key is rejected
-(builds are a per-app concern), and `optimizeDeps` never reaches any build config.
+(builds are a per-app concern).
+
+**Development-only fields are the exception to "always warned".** `optimizeDeps` and
+`server.allowedHosts` configure the shared development server, and the same `config.vite`
+declaration also reaches every app build - so a build strips them **silently**. Warning there
+would report ordinary configuration as misuse once per app on every build.
+
+Under `server`, only `allowedHosts` is admitted. `ws` is withheld because `ws: false` disables
+the WebSocket connection HMR runs on, which the framework owns through `server.hmr`; `host`,
+`port`, `strictPort`, `https` and `open` configure Vite's own HTTP listener, which does not
+exist in middleware mode because Fastify owns the listener; and `proxy` overlaps caller-route
+ownership. Supplying any of them **in development** warns and is not applied. In a build the
+whole `server` object is stripped silently, so nothing under it warns there.
 
 ### How τjs composes Vite config
 


### PR DESCRIPTION
Vite 6.1+ refuses any request whose `Host` is not localhost-like unless `server.allowedHosts` permits it, a DNS-rebinding defence. A reverse proxy or process supervisor commonly presents such a host, and τjs development behind one answered Vite's 403 block page instead of the application - with no supported way to allow it, because two separate places discarded the field:

- the merge engine rejected the whole `server` key in both profiles, warning and dropping it;
- `setupDevServer` then wrote `server` as a whole object AFTER spreading the user's fields, overwriting anything that had survived.

Fixing either alone would have changed nothing observable.

ONE field is admitted, `server.allowedHosts`, as an explicit allowlist enforced at both the type and the runtime. An exclusion type was tried and rejected: it admitted `ws`, whose documented `ws: false` disables the WebSocket connection HMR runs on - letting a user break the facility τjs owns through `server.hmr` - along with `host`/`port`/`strictPort`/`https`/`open`, which configure a listener Vite does not have in middleware mode because Fastify owns it, and `proxy`, which overlaps unresolved caller-route ownership. It would also have widened the public surface silently with each Vite release, against the explicit-allowlist design every other surface in that file follows. Smuggled fields are warned and dropped rather than applied inertly.

τjs actively supplies exactly two values: `middlewareMode` stays `true` because it owns the request pipeline, and `hmr` is derived from the resolved dev host and port and applied WHOLE rather than deep-merged - a half-user, half-framework `hmr` would pair a user port with a framework host and fail looking like a τjs bug.

`server` is development-only and behaves like `optimizeDeps` on the build side: absent from client and SSR builds SILENTLY. `config.vite` is one declaration feeding the dev server and every app build, so warning there would report the documented recipe as misuse, once per app, on every build. That rule is source-independent - `taujsBuild({ vite })` takes a wider type and is silent for the same reason, not as a special case.

Evidence, primary first: real development boots with a real Vite server and a real listener, in BOTH ownership modes, proving an undeclared proxy host is refused, a declared one serves the page and `/@vite/client`, and a host that was never declared is STILL refused - the defence is narrowed, not removed. Backed by composition regressions through the public config path (the field survives, the framework's two values are applied on top, the caller's config object is not mutated), by dev-versus-build evidence for both build kinds, and by type-level contract tests. Both halves of the fix are mutation-checked.

Documentation: the reference matrix gains `server.allowedHosts` as a dev-only row and separates warned-in-development from silently-stripped-in-builds; the build guide moves dev-only fields out of the build-time override lists into their own section with the proxy recipe.

Two rulings carried into the follow-up: `proxy` stays withheld until responsibility 2 resolves caller-route ownership, and `vite.server` remains an explicit allowlist, expanded one field at a time with middleware-mode evidence.