### PR TITLE
feat(server): installation-level mountPrefix and publicBasePath - RFC 0012 PR 1

### DIFF
--- a/.changeset/rfc-0012-non-root-base-paths.md
+++ b/.changeset/rfc-0012-non-root-base-paths.md
@@ -1,0 +1,28 @@
+---
+'@taujs/server': minor
+---
+
+feat(server): non-root base paths - installation-level mountPrefix and publicBasePath (RFC 0012)
+
+A taujs installation can now be mounted under a non-root prefix and addressed behind a
+reverse proxy, in both proxy topologies. Two new optional fields on the config server block:
+
+- `mountPrefix` - where Fastify RECEIVES the installation: one scope prefix under which every
+  declared route (all apps), taujs static and the development introspection surface register.
+- `publicBasePath` - what taujs EMITS in front of every URL it generates (asset, preload and
+  CSS links, the bootstrap module URL, the dev beacon) and what the Vite base derives from,
+  composed around the existing per-app entryPoint spelling. Defaults to `mountPrefix`; the
+  two differ exactly when the proxy STRIPS the public prefix before forwarding
+  (`mountPrefix: ''` with the public prefix declared here).
+
+Defaults are unchanged behaviour byte-for-byte. Coordinates are validated at function entry
+to a canonical form (`''` or `/segment(/segment)*`, URI-unreserved segment characters) and
+rejected, never silently normalised; explicit `publicBasePath: ''` alongside a non-empty
+mount is rejected as unsupported. On a taujs-created host the SPA fallback is confined to
+the mounted subtree, with an ordinary 404 outside it. Caller-supplied static registrations
+compose with the mount as normal Fastify nested routes; host-root static remains available
+via `staticAssets: false` plus a caller registration. In development, requests delegated to
+Vite are projected between the mount and public path spaces (pathname only, query preserved
+byte-exact), so module URLs and the HMR pathname compose correctly under a prefix. HMR
+socket origin and port under supervisors, and reverse-proxy host admission for the
+introspection endpoints, remain separate follow-ups.

--- a/.changeset/rfc-0012-non-root-base-paths.md
+++ b/.changeset/rfc-0012-non-root-base-paths.md
@@ -21,8 +21,9 @@ rejected, never silently normalised; explicit `publicBasePath: ''` alongside a n
 mount is rejected as unsupported. On a taujs-created host the SPA fallback is confined to
 the mounted subtree, with an ordinary 404 outside it. Caller-supplied static registrations
 compose with the mount as normal Fastify nested routes; host-root static remains available
-via `staticAssets: false` plus a caller registration. In development, requests delegated to
-Vite are projected between the mount and public path spaces (pathname only, query preserved
-byte-exact), so module URLs and the HMR pathname compose correctly under a prefix. HMR
+via `staticAssets: false` plus a caller registration. In development the shared Vite base
+derives from `publicBasePath`, carrying module URLs and the HMR pathname; Vite's middleware
+mode natively accepts both public-prefixed and proxy-stripped request paths, so taujs owns
+only the base derivation and the confinement of dev delegation to the mounted subtree. HMR
 socket origin and port under supervisors, and reverse-proxy host admission for the
 introspection endpoints, remain separate follow-ups.

--- a/packages/server/src/Build.ts
+++ b/packages/server/src/Build.ts
@@ -14,7 +14,7 @@ import path from 'node:path';
 import { build } from 'vite';
 
 import { TEMPLATE } from './constants';
-import { extractBuildConfigs } from './core/config/Setup';
+import { extractBuildConfigs, extractPathCoordinates, viteBaseFor } from './core/config/Setup';
 import { emitGraphArtifact } from './core/introspection/EmitGraph';
 import { processConfigs } from './utils/AssetManager';
 import { resolveEntryFile } from './utils/Entry';
@@ -214,6 +214,10 @@ export async function taujsBuild({
   const extractedConfigs = extractBuildConfigs(config);
   const processedConfigs = processConfigs(extractedConfigs, clientBaseDir, TEMPLATE);
 
+  // RFC 0012: the same validation createServer runs, so dev and build cannot disagree about a
+  // coordinate's validity; `publicBasePath` composes into every app's Vite `base` below.
+  const { publicBasePath } = extractPathCoordinates(config);
+
   // ESC-1 (RFC 0006) phase 1 - GLOBAL ownership preparation over ALL apps (never the filtered
   // `configsToBuild`), before the per-app build loop. Exclusions are computed against the global
   // other-key claims even for a filtered build, so chain-global contributions never leak into an
@@ -315,7 +319,10 @@ export async function taujsBuild({
     if (discovered) console.warn(`[taujs:build:${entryPoint}] ${formerlyDiscoveredViteConfigWarning(discovered)}`);
 
     const frameworkConfig: InlineConfig = {
-      base: entryPoint ? `/${entryPoint}/` : '/',
+      // RFC 0012 (verdict-round ruling): the canonical publicBasePath composes AROUND the
+      // existing entryPoint spelling; with publicBasePath '' this is the pre-RFC formula
+      // byte-for-byte. entryPoint is deliberately not normalised here.
+      base: viteBaseFor(publicBasePath, entryPoint),
       configFile: false,
       build: {
         outDir,

--- a/packages/server/src/CreateServer.ts
+++ b/packages/server/src/CreateServer.ts
@@ -5,7 +5,7 @@ import { performance } from 'node:perf_hooks';
 import Fastify from 'fastify';
 import pc from 'picocolors';
 
-import { extractBuildConfigs, extractRoutes, extractSecurity } from './core/config/Setup';
+import { extractBuildConfigs, extractPathCoordinates, extractRoutes, extractSecurity } from './core/config/Setup';
 import { REGEX } from './core/constants';
 import { normaliseError } from './core/errors/AppError';
 
@@ -66,6 +66,12 @@ const resolveClientRoot = (userClientRoot?: string): string => {
 export const createServer = async (opts: CreateServerOptions): Promise<CreateServerResult> => {
   const t0 = performance.now();
   const clientRoot = resolveClientRoot(opts.clientRoot);
+
+  // RFC 0012 (PR-1 review): the two installation-level addressing coordinates, validated at
+  // FUNCTION ENTRY - invalid configuration must fail before any host state exists, so neither a
+  // τjs-created Fastify instance nor a caller-host registration (banner) happens first. Build
+  // validates identically via taujsBuild. Defaults ('' / '') are today's behaviour.
+  const { mountPrefix, publicBasePath } = extractPathCoordinates(opts.config);
 
   // RFC 0010: the one internal ownership fact. Supplying a Fastify instance means the caller owns
   // the server and τjs owns only an encapsulated scope within it; omitting one means τjs created
@@ -130,6 +136,15 @@ export const createServer = async (opts: CreateServerOptions): Promise<CreateSer
       : `${CONTENT.TAG} [ownership] Fastify created by τjs - whole-server shell, CSP and request identity`,
   );
 
+  // RFC 0012: mounting is boot-visible for the same reason ownership is - without this line a
+  // reader cannot tell from the logs why every τjs URL moved.
+  if (mountPrefix !== '' || publicBasePath !== '') {
+    logger.info(
+      { component: 'addressing', mountPrefix, publicBasePath },
+      `${CONTENT.TAG} [addressing] mounted at '${mountPrefix || '/'}', emitting under '${publicBasePath || '/'}'`,
+    );
+  }
+
   // RFC security model §2: relaxing the loopback guard must shout in the boot summary —
   // exact text, not a debug line.
   if (isDevelopment && opts.config.introspection?.allowNonLoopback) {
@@ -159,7 +174,13 @@ export const createServer = async (opts: CreateServerOptions): Promise<CreateSer
   printContractReport(logger, report);
 
   try {
-    await app.register(ssrServerPlugin({ callerOwnedHost }), {
+    // RFC 0012: the mount is Fastify's own scope-prefix primitive on the one τjs registration.
+    // `mounted` flips the plugin to its encapsulated form on a τjs-created host too - fastify-plugin
+    // ignores `prefix` when it breaks encapsulation, and an encapsulated prefixed scope is also what
+    // CONFINES the created-host shell to the mounted subtree (prefix-keyed not-found).
+    await app.register(ssrServerPlugin({ callerOwnedHost, mounted: mountPrefix !== '' }), {
+      prefix: mountPrefix || undefined,
+      publicBasePath,
       clientRoot,
       configs,
       routes,

--- a/packages/server/src/SSRServer.ts
+++ b/packages/server/src/SSRServer.ts
@@ -183,6 +183,11 @@ const installOwnedScope = async (scope: FastifyInstance, opts: SSRServerOptions,
       logger,
       devNet: opts.devNet,
       viteConfig: devViteConfig,
+      // RFC 0012 (PR 2): reception stays single-sourced from Fastify - the register-time
+      // prefix IS `scope.prefix` on the encapsulated registration; emission is the validated
+      // coordinate threaded from createServer.
+      mountPrefix: scope.prefix || '',
+      publicBasePath,
     });
 
     // RFC 0010: τjs creates the Vite server, so τjs closes it. Guarded because `onClose` can be

--- a/packages/server/src/SSRServer.ts
+++ b/packages/server/src/SSRServer.ts
@@ -45,7 +45,7 @@ export { TEMPLATE };
  * form and the ownership behaviour from drifting apart.
  */
 const installOwnedScope = async (scope: FastifyInstance, opts: SSRServerOptions, callerOwnedHost: boolean): Promise<void> => {
-  const { alias, configs, routes, serviceRegistry = {}, clientRoot, security } = opts;
+  const { alias, configs, routes, serviceRegistry = {}, clientRoot, security, publicBasePath = '' } = opts;
 
   const logger = opts.runtimeLogger
     ? createRuntimeLogger(opts.runtimeLogger, {
@@ -77,7 +77,7 @@ const installOwnedScope = async (scope: FastifyInstance, opts: SSRServerOptions,
     maps.renderModules,
     maps.ssrManifests,
     maps.templates,
-    { logger },
+    { logger, publicBasePath },
   );
 
   // Tri-state contract: `undefined` installs the default production registration, explicit
@@ -265,6 +265,7 @@ const installOwnedScope = async (scope: FastifyInstance, opts: SSRServerOptions,
         debug: opts.debug,
         logger,
         viteDevServer,
+        publicBasePath,
       });
     });
   }
@@ -289,6 +290,7 @@ const installOwnedScope = async (scope: FastifyInstance, opts: SSRServerOptions,
           debug: opts.debug,
           logger,
           viteDevServer,
+          publicBasePath,
         },
       );
     });
@@ -336,9 +338,15 @@ const installOwnedScope = async (scope: FastifyInstance, opts: SSRServerOptions,
  * ruled thesis: a caller-supplied instance gets an encapsulated child, and an instance τjs created
  * gets the complete experience installed at its root. Both forms are wrapped, so the plugin is named
  * in the host's plugin tree either way - registration is visible, policy is not.
+ *
+ * RFC 0012: `mounted` also selects the encapsulated form. fastify-plugin ignores a register-time
+ * `prefix` when it breaks encapsulation, so a MOUNTED τjs-created host must encapsulate for the
+ * scope-prefix primitive to apply at all - and that same prefixed scope is what confines the
+ * created-host shell (prefix-keyed not-found) to the mounted subtree, with an ordinary 404 outside.
+ * Unmounted created hosts keep today's root installation byte-for-byte.
  */
-export const ssrServerPlugin = ({ callerOwnedHost }: { callerOwnedHost: boolean }): FastifyPluginAsync<SSRServerOptions> =>
+export const ssrServerPlugin = ({ callerOwnedHost, mounted = false }: { callerOwnedHost: boolean; mounted?: boolean }): FastifyPluginAsync<SSRServerOptions> =>
   fp(async (scope: FastifyInstance, opts: SSRServerOptions) => installOwnedScope(scope, opts, callerOwnedHost), {
     name: 'τjs-ssr-server',
-    encapsulate: callerOwnedHost,
+    encapsulate: callerOwnedHost || mounted,
   });

--- a/packages/server/src/core/config/Setup.ts
+++ b/packages/server/src/core/config/Setup.ts
@@ -33,6 +33,75 @@ export const extractBuildConfigs = <A extends CoreAppConfig = CoreAppConfig>(con
   return config.apps.map(({ appId, entryPoint, plugins, renderer }) => ({ appId, entryPoint, plugins, renderer })) as A[];
 };
 
+/**
+ * RFC 0012: the canonical form for the two installation-level path coordinates. Either `''`
+ * (root) or slash-led segments of unreserved characters with no trailing slash. Deliberately
+ * conservative: no percent-encoding, no sub-delimiters, no dot segments - widen only on a
+ * demonstrated topology. The charset also keeps the value inert inside the single-quoted
+ * beacon script string and double-quoted HTML attributes, so composition sites need no
+ * per-site escaping argument.
+ */
+const CANONICAL_PATH_COORDINATE = /^\/[A-Za-z0-9._~-]+(\/[A-Za-z0-9._~-]+)*$/;
+
+const DOT_SEGMENT = /(^|\/)\.\.?(\/|$)/;
+
+export type PathCoordinates = {
+  mountPrefix: string;
+  publicBasePath: string;
+};
+
+const assertCanonicalCoordinate = (field: 'mountPrefix' | 'publicBasePath', value: string): void => {
+  if (value === '') return;
+  if (value === '/') throw new Error(`server.${field}: '/' is not a value - the root form is spelled '' (or omit the field)`);
+  if (DOT_SEGMENT.test(value) || !CANONICAL_PATH_COORDINATE.test(value)) {
+    throw new Error(
+      `server.${field}: '${value}' is not canonical. Expected '' or '/segment(/segment)*' - leading '/', no trailing '/', ` +
+        `segments of [A-Za-z0-9._~-] only, no '.' or '..' segments, no query, fragment, scheme or host. Values are rejected, never normalised.`,
+    );
+  }
+};
+
+/**
+ * RFC 0012: validate and resolve the installation-level addressing coordinates. `mountPrefix`
+ * is where Fastify receives the installation; `publicBasePath` is what τjs emits and what the
+ * Vite `base` derives from. `publicBasePath` defaults to `mountPrefix`; the inverse corner
+ * (explicit `''` with a non-empty mount) is rejected as unsupported pending a real topology
+ * (RFC 0012 §2 rule 1). Called by BOTH `createServer` and `taujsBuild`, so dev and build
+ * cannot disagree about validity.
+ */
+export const extractPathCoordinates = (config: Pick<CoreTaujsConfig, 'server'>): PathCoordinates => {
+  const declaredMount = config.server?.mountPrefix;
+  const declaredPublic = config.server?.publicBasePath;
+
+  if (declaredMount !== undefined && typeof declaredMount !== 'string') throw new Error('server.mountPrefix must be a string');
+  if (declaredPublic !== undefined && typeof declaredPublic !== 'string') throw new Error('server.publicBasePath must be a string');
+
+  const mountPrefix = declaredMount ?? '';
+  assertCanonicalCoordinate('mountPrefix', mountPrefix);
+
+  if (declaredPublic === '' && mountPrefix !== '') {
+    throw new Error(
+      `server.publicBasePath: '' alongside mountPrefix '${mountPrefix}' (emit root-absolute while mounted) is unsupported pending a real topology (RFC 0012). ` +
+        `Omit publicBasePath to inherit the mountPrefix.`,
+    );
+  }
+
+  const publicBasePath = declaredPublic ?? mountPrefix;
+  assertCanonicalCoordinate('publicBasePath', publicBasePath);
+
+  return { mountPrefix, publicBasePath };
+};
+
+/**
+ * RFC 0012 (verdict-round ruling): the per-app Vite `base`, composing the canonical
+ * `publicBasePath` AROUND the existing `entryPoint` spelling. With `publicBasePath: ''` this
+ * reproduces the pre-RFC formula byte-for-byte (`entryPoint ? '/entryPoint/' : '/'`), so
+ * root-mounted output is unchanged by construction. `entryPoint` is deliberately NOT
+ * normalised here - existing non-canonical spellings are preserved for compatibility, without
+ * endorsement (RFC 0012 §2 intent statement).
+ */
+export const viteBaseFor = (publicBasePath: string, entryPoint: string): string => (entryPoint ? `${publicBasePath}/${entryPoint}/` : `${publicBasePath}/`);
+
 // This is deliberately a migration lint, not a second route parser. Fastify remains the only
 // authority for valid route syntax. These are stale path-to-regexp forms that Fastify may accept
 // as literals (or with materially different semantics), allowing a formerly live route to die

--- a/packages/server/src/core/config/types.ts
+++ b/packages/server/src/core/config/types.ts
@@ -302,6 +302,25 @@ export type CoreTaujsConfig = {
     host?: string;
     port?: number;
     hmrPort?: number;
+    /**
+     * RFC 0012: where Fastify RECEIVES the τjs installation - the single scope prefix under
+     * which every declared route (all apps), τjs static and the development `/__taujs/*`
+     * surface register. Installation-level; `entryPoint` remains the per-app layout
+     * namespace and is never a substitute for this. Canonical form only (`''` or
+     * `/segment(/segment)*`, no trailing slash) - non-canonical values are rejected at
+     * config validation, never silently normalised. Default `''` (root - today's behaviour
+     * byte-for-byte).
+     */
+    mountPrefix?: string;
+    /**
+     * RFC 0012: what τjs EMITS in front of every URL it generates (asset, preload and CSS
+     * links, the bootstrap module URL, the dev beacon) and the value the Vite `base`
+     * derives from. Defaults to `mountPrefix`; the two differ exactly when a proxy STRIPS
+     * the public prefix (declare `mountPrefix: ''` with the public prefix here). Explicit
+     * `''` alongside a non-empty `mountPrefix` is rejected as unsupported (no measured
+     * topology). Same canonical form as `mountPrefix`.
+     */
+    publicBasePath?: string;
   };
   // RFC 0005 (VS2): the declarative home for the alias maps that are programmatic-only today
   // (`createServer`/`taujsBuild` options). Vite-free (plain `Record`), so it lives on the core

--- a/packages/server/src/test/Build.test.ts
+++ b/packages/server/src/test/Build.test.ts
@@ -7,7 +7,10 @@ vi.mock('vite', () => ({
   }),
 }));
 
-vi.mock('../core/config/Setup', () => ({
+vi.mock('../core/config/Setup', async (importOriginal) => ({
+  // RFC 0012: keep the real pure exports (extractPathCoordinates, viteBaseFor) - only the
+  // extraction this suite drives is replaced.
+  ...(await importOriginal<typeof import('../core/config/Setup')>()),
   extractBuildConfigs: vi.fn().mockReturnValue([]),
 }));
 
@@ -361,6 +364,40 @@ describe('Build.ts - Full Coverage', () => {
       const buildConfig = vi.mocked(build).mock.calls[0]![0] as InlineConfig;
       expect(buildConfig.base).toBe('/admin/');
       expect(buildConfig.root).toBe('/project/src/client/admin');
+    });
+
+    // RFC 0012 (PR-1 review, finding 4): the SEAM regression - viteBaseFor proven installed at
+    // the Build.ts base assignment, not merely correct in isolation. Default-coordinate
+    // retention ('/' and '/admin/') is the two tests above; reverting the wiring to the legacy
+    // inline formula keeps those green and fails these two.
+    it('RFC 0012: publicBasePath composes into the build base for a root app', async () => {
+      const rootAppConfig = {
+        ...mockAppConfig,
+        entryPoint: '',
+      };
+      vi.mocked(processConfigs).mockReturnValue([rootAppConfig] as any);
+
+      await taujsBuild({
+        config: { apps: [], server: { publicBasePath: '/app' } },
+        projectRoot: mockProjectRoot,
+        clientBaseDir: mockClientBaseDir,
+        isSSRBuild: false,
+      });
+
+      const buildConfig = vi.mocked(build).mock.calls[0]![0] as InlineConfig;
+      expect(buildConfig.base).toBe('/app/');
+    });
+
+    it('RFC 0012: publicBasePath composes AROUND a named entryPoint in the build base', async () => {
+      await taujsBuild({
+        config: { apps: [], server: { publicBasePath: '/app' } },
+        projectRoot: mockProjectRoot,
+        clientBaseDir: mockClientBaseDir,
+        isSSRBuild: false,
+      });
+
+      const buildConfig = vi.mocked(build).mock.calls[0]![0] as InlineConfig;
+      expect(buildConfig.base).toBe('/app/admin/');
     });
 
     it('should process multiple apps sequentially', async () => {

--- a/packages/server/src/test/CreateServer.test.ts
+++ b/packages/server/src/test/CreateServer.test.ts
@@ -384,7 +384,7 @@ describe('createServer', () => {
     expect(registerMock).toHaveBeenCalledTimes(1);
     expect(registerMock).toHaveBeenNthCalledWith(1, SSRServerPlugin, expect.any(Object));
     expect(registerMock).not.toHaveBeenCalledWith(bannerPluginMock, expect.anything());
-    expect(ssrServerPluginCalls.at(-1)).toEqual({ callerOwnedHost: true });
+    expect(ssrServerPluginCalls.at(-1)).toEqual({ callerOwnedHost: true, mounted: false });
   });
 
   it('sets logger minLevel to "info" in production NODE_ENV', async () => {

--- a/packages/server/src/test/DevAddressing.test.ts
+++ b/packages/server/src/test/DevAddressing.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment node
+/**
+ * RFC 0012 PR 2 acceptance - development addressing: the shared dev Vite base and the
+ * mount-domain confinement of the delegator, proven on SEPARATE strip and preserve real
+ * development boots (real Vite, real caller-owned host - the delegator's guarded arm; the
+ * owned-scope arm shares the same hook and `scope.prefix` sourcing).
+ *
+ * There is deliberately NO request-path rewriting to test: pinned Vite (7.3.6) middleware
+ * mode natively accepts BOTH public-prefixed and proxy-stripped request paths - its
+ * baseMiddleware answers a base mismatch with a plain `next()` into its own transform and
+ * static middlewares registered immediately after (dist/node/chunks/config.js, base
+ * mismatch fallthrough and middleware stack assembly). τjs owns exactly two dev
+ * transformations: the derived `base` (emission) and the mount-domain guard (confinement).
+ * These boots PIN that middleware contract: if a future Vite stops accepting stripped
+ * paths, the strip cells fail and the question comes back for review.
+ *
+ * Mutation standard: reverting the dev `base` derivation fails the page-HTML cells;
+ * reverting the mount-domain guard fails the out-of-mount cell (verified on disk).
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import fastify from 'fastify';
+
+import { CALLER_CSP, OWNER, PATHS, closeAll, developmentFixture, taujsConfig } from './support/hostOwnership';
+
+import type { FastifyInstance } from 'fastify';
+import type { TaujsConfig } from '../Config';
+
+afterEach(closeAll);
+
+// Real development boots. NODE_ENV is snapshotted at module evaluation (System.ts), so each
+// boot re-imports createServer under development, mirroring HostOwnershipDevelopment.test.ts.
+const loadDevelopmentCreateServer = async () => {
+  const original = process.env.NODE_ENV;
+  process.env.NODE_ENV = 'development';
+  vi.resetModules();
+
+  try {
+    return (await import('../CreateServer')).createServer;
+  } finally {
+    process.env.NODE_ENV = original;
+  }
+};
+
+const buildCallerHost = (): FastifyInstance => {
+  const app = fastify({ logger: false });
+
+  app.decorate('authenticate', async () => undefined);
+  app.addHook('onRequest', (_request, reply, done) => {
+    reply.header('Content-Security-Policy', CALLER_CSP);
+    done();
+  });
+  app.get(PATHS.callerBefore, async () => ({ owner: OWNER.callerBefore }));
+  app.setNotFoundHandler(async (_request, reply) => reply.status(404).type('application/json').send({ owner: OWNER.callerNotFound }));
+
+  return app;
+};
+
+const withServer = (server: NonNullable<TaujsConfig['server']>): TaujsConfig => ({ ...taujsConfig(), server });
+
+describe('RFC 0012 PR 2 - STRIP development evidence (mount "", publicBasePath "/pub")', () => {
+  it('serves stripped module URLs natively, emits public-space HTML, and falls through to the host', async () => {
+    const createServer = await loadDevelopmentCreateServer();
+    const { clientRoot } = await developmentFixture();
+    const app = buildCallerHost();
+
+    await createServer({ config: withServer({ publicBasePath: '/pub' }), fastify: app, clientRoot });
+
+    try {
+      // A STRIPPED module request arrives in root space; Vite (base '/pub/') accepts it
+      // natively - middleware mode falls a base mismatch through to its own transform
+      // middleware. This cell PINS that contract.
+      const module = await app.inject({ method: 'GET', url: '/app/entry-client.ts' });
+      expect(module.statusCode).toBe(200);
+      expect(String(module.headers['content-type'])).toContain('javascript');
+
+      // A query-carrying module request serves identically - nothing rewrites the URL.
+      const withQuery = await app.inject({ method: 'GET', url: '/app/entry-client.ts?import' });
+      expect(withQuery.statusCode).toBe(200);
+
+      // The served page emits PUBLIC-space URLs: Vite's own client via the derived base,
+      // and the τjs-generated bootstrap via publicBasePath.
+      const page = await app.inject({ method: 'GET', url: PATHS.taujsPage });
+      expect(page.statusCode).toBe(200);
+      expect(page.body).toContain('src="/pub/@vite/client"');
+      expect(page.body).toContain('src="/pub/app/entry-client.ts"');
+
+      // Fallthrough: a miss leaves Vite via next() and the CALLER's not-found answers -
+      // the delegation never captures the host.
+      const miss = await app.inject({ method: 'GET', url: '/no-such-page' });
+      expect(miss.statusCode).toBe(404);
+      expect(miss.body).toContain(OWNER.callerNotFound);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('RFC 0012 PR 2 - PRESERVE development evidence (mountPrefix "/mnt")', () => {
+  it('serves mount-space module URLs, emits mounted HTML, and confines the delegator to the subtree', async () => {
+    const createServer = await loadDevelopmentCreateServer();
+    const { clientRoot } = await developmentFixture();
+    const app = buildCallerHost();
+
+    await createServer({ config: withServer({ mountPrefix: '/mnt' }), fastify: app, clientRoot });
+
+    try {
+      // A PRESERVED module request arrives in mount space; Vite's base is '/mnt/', so its
+      // baseMiddleware strips and serves - the designed path.
+      const module = await app.inject({ method: 'GET', url: '/mnt/app/entry-client.ts' });
+      expect(module.statusCode).toBe(200);
+      expect(String(module.headers['content-type'])).toContain('javascript');
+
+      // The mounted page emits mount-space URLs throughout.
+      const page = await app.inject({ method: 'GET', url: `/mnt${PATHS.taujsPage}` });
+      expect(page.statusCode).toBe(200);
+      expect(page.body).toContain('src="/mnt/@vite/client"');
+      expect(page.body).toContain('src="/mnt/app/entry-client.ts"');
+
+      // MOUNT-DOMAIN GUARD: the same module URL OUTSIDE the mount never reaches Vite - the
+      // caller's own not-found answers. Reverting the guard serves JavaScript here (Vite
+      // would accept the stripped spelling natively), which is exactly the leak the guard
+      // exists to stop.
+      const outside = await app.inject({ method: 'GET', url: '/app/entry-client.ts' });
+      expect(outside.statusCode).toBe(404);
+      expect(outside.body).toContain(OWNER.callerNotFound);
+
+      // A miss INSIDE the mount still falls through to the caller.
+      const insideMiss = await app.inject({ method: 'GET', url: '/mnt/no-such-page' });
+      expect(insideMiss.statusCode).toBe(404);
+      expect(insideMiss.body).toContain(OWNER.callerNotFound);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/server/src/test/MountAddressing.test.ts
+++ b/packages/server/src/test/MountAddressing.test.ts
@@ -26,16 +26,7 @@ import { extractPathCoordinates, viteBaseFor } from '../core/config/Setup';
 import { createMaps, loadAssets, processConfigs } from '../utils/AssetManager';
 import { buildTaujsDevStamp } from '../utils/Templates';
 import { testRenderer } from './support/renderer';
-import {
-  OWNER,
-  PATHS,
-  TAUJS_ASSET_PATH,
-  closeAll,
-  createCreatedHost,
-  createEmbeddedHost,
-  productionFixture,
-  taujsConfig,
-} from './support/hostOwnership';
+import { OWNER, PATHS, TAUJS_ASSET_PATH, closeAll, createCreatedHost, createEmbeddedHost, productionFixture, taujsConfig } from './support/hostOwnership';
 
 import type { AppConfig, TaujsConfig } from '../Config';
 import type { AppRoute } from '../core/config/types';
@@ -113,9 +104,7 @@ describe('RFC 0012 - canonical coordinate validation (cell 7)', () => {
     app.decorate('authenticate', async () => undefined);
     const before = app.printRoutes();
 
-    await expect(
-      createServer({ config: withAddressing({ mountPrefix: '/bad/' }), fastify: app, clientRoot: '/nowhere' }),
-    ).rejects.toThrow(/not canonical/);
+    await expect(createServer({ config: withAddressing({ mountPrefix: '/bad/' }), fastify: app, clientRoot: '/nowhere' })).rejects.toThrow(/not canonical/);
 
     expect(app.printRoutes()).toBe(before);
     await app.close();
@@ -224,7 +213,7 @@ describe('RFC 0012 - strip-shape cell: emission differs from reception (cell 1, 
 });
 
 describe('RFC 0012 - root byte-compatibility (cell 4, response level)', () => {
-  it('emits today\'s root-absolute URLs exactly when both coordinates default', async () => {
+  it("emits today's root-absolute URLs exactly when both coordinates default", async () => {
     const host = await createEmbeddedHost();
     await host.activate(createServer as never, withAddressing({}, [ROOT_ROUTE]));
 
@@ -288,7 +277,10 @@ describe('RFC 0012 - loadAssets emission regression (PR-1 review, finding 4)', (
     await mkdir(path.join(appRoot, '.vite'), { recursive: true });
     await mkdir(path.join(ssrRoot, '.vite'), { recursive: true });
     await writeFile(path.join(root, 'package.json'), '{"type":"module"}\n');
-    await writeFile(path.join(appRoot, 'index.html'), '<!doctype html><html><head><!--ssr-head--></head><body><div id="app"><!--ssr-html--></div></body></html>');
+    await writeFile(
+      path.join(appRoot, 'index.html'),
+      '<!doctype html><html><head><!--ssr-head--></head><body><div id="app"><!--ssr-html--></div></body></html>',
+    );
     await writeFile(
       path.join(appRoot, '.vite', 'manifest.json'),
       JSON.stringify({ 'entry-client.ts': { file: 'assets/rfc0012-client.js', css: ['assets/rfc0012.css'] } }),

--- a/packages/server/src/test/MountAddressing.test.ts
+++ b/packages/server/src/test/MountAddressing.test.ts
@@ -1,0 +1,393 @@
+// @vitest-environment node
+/**
+ * RFC 0012 PR 1 acceptance - installation-level addressing: canonical validation,
+ * the Fastify scope-prefix mount, emission composition and the ownership contracts.
+ *
+ * Cell numbering follows the RFC §6 suite. The strip/preserve DEVELOPMENT cells and the
+ * Vite pathname projection are PR 2 (one coordinated release gate); everything here is
+ * provable on the production path plus unit-level emission.
+ *
+ * Mutation standard: reverting the scope prefix fails the preserve cells; reverting
+ * emission composition fails the strip-shape and entryPoint-composition cells; reverting
+ * validation fails the canonical cells; reverting fp's `mounted` encapsulation switch
+ * fails the created-host confinement cells (prefix would silently stop applying).
+ */
+import { afterAll, describe, expect, it } from 'vitest';
+
+import fastify from 'fastify';
+
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { createServer } from '../CreateServer';
+import { TEMPLATE } from '../constants';
+import { extractPathCoordinates, viteBaseFor } from '../core/config/Setup';
+import { createMaps, loadAssets, processConfigs } from '../utils/AssetManager';
+import { buildTaujsDevStamp } from '../utils/Templates';
+import { testRenderer } from './support/renderer';
+import {
+  OWNER,
+  PATHS,
+  TAUJS_ASSET_PATH,
+  closeAll,
+  createCreatedHost,
+  createEmbeddedHost,
+  productionFixture,
+  taujsConfig,
+} from './support/hostOwnership';
+
+import type { AppConfig, TaujsConfig } from '../Config';
+import type { AppRoute } from '../core/config/types';
+
+afterAll(closeAll);
+
+/** The support config plus a server block and (optionally) extra first-app routes. */
+const withAddressing = (server: NonNullable<TaujsConfig['server']>, extraRoutes: readonly AppRoute[] = [], base: TaujsConfig = taujsConfig()): TaujsConfig => {
+  // `TaujsConfig['apps']` is an intersection whose first arm types `renderer` as `unknown`;
+  // pin the AppConfig arm so the mapped copy keeps the refined element type.
+  const apps: readonly AppConfig[] = base.apps;
+
+  return {
+    ...base,
+    server,
+    apps: apps.map((app, index): AppConfig => (index === 0 ? { ...app, routes: [...(app.routes ?? []), ...extraRoutes] } : app)),
+  };
+};
+
+const ROOT_ROUTE: AppRoute = { path: '/', attr: { render: 'ssr' } };
+
+describe('RFC 0012 - canonical coordinate validation (cell 7)', () => {
+  it('defaults to root addressing and inherits publicBasePath from mountPrefix', () => {
+    expect(extractPathCoordinates({})).toEqual({ mountPrefix: '', publicBasePath: '' });
+    expect(extractPathCoordinates({ server: {} })).toEqual({ mountPrefix: '', publicBasePath: '' });
+    expect(extractPathCoordinates({ server: { mountPrefix: '/app' } })).toEqual({ mountPrefix: '/app', publicBasePath: '/app' });
+    expect(extractPathCoordinates({ server: { mountPrefix: '', publicBasePath: '/pub' } })).toEqual({ mountPrefix: '', publicBasePath: '/pub' });
+    expect(extractPathCoordinates({ server: { mountPrefix: '/a/b-2', publicBasePath: '/x_9' } })).toEqual({
+      mountPrefix: '/a/b-2',
+      publicBasePath: '/x_9',
+    });
+  });
+
+  it.each([
+    ['/', "'/' is not a value"],
+    ['/app/', 'not canonical'],
+    ['app', 'not canonical'],
+    ['//app', 'not canonical'],
+    ['/app//x', 'not canonical'],
+    ['/a/../b', 'not canonical'],
+    ['/.', "'/' is not a value|not canonical"],
+    ['/a?b=c', 'not canonical'],
+    ['/a#f', 'not canonical'],
+    ['https://evil.example', 'not canonical'],
+    ['/a b', 'not canonical'],
+    ["/a'b", 'not canonical'],
+  ])('rejects the non-canonical mountPrefix %j, never normalises it', (value, messagePattern) => {
+    expect(() => extractPathCoordinates({ server: { mountPrefix: value } })).toThrow(new RegExp(messagePattern));
+    expect(() => extractPathCoordinates({ server: { publicBasePath: value } })).toThrow(new RegExp(messagePattern));
+  });
+
+  it('rejects the inverse corner: explicit publicBasePath "" with a non-empty mountPrefix', () => {
+    expect(() => extractPathCoordinates({ server: { mountPrefix: '/app', publicBasePath: '' } })).toThrow(/unsupported pending a real topology/);
+    // The root spelling of the same shape is fine - both empty is simply the default.
+    expect(extractPathCoordinates({ server: { mountPrefix: '', publicBasePath: '' } })).toEqual({ mountPrefix: '', publicBasePath: '' });
+  });
+
+  it('rejects non-string coordinates', () => {
+    expect(() => extractPathCoordinates({ server: { mountPrefix: 5 as unknown as string } })).toThrow(/must be a string/);
+    expect(() => extractPathCoordinates({ server: { publicBasePath: null as unknown as string } })).toThrow(/must be a string/);
+  });
+
+  it('enforces the FROZEN v1 charset: URI-unreserved segments only (PR-1 review ruling)', () => {
+    // Sub-delimiters and percent-encoding are rejected in v1; widening is an RFC-level change.
+    expect(() => extractPathCoordinates({ server: { mountPrefix: '/@team' } })).toThrow(/not canonical/);
+    expect(() => extractPathCoordinates({ server: { mountPrefix: '/a%20b' } })).toThrow(/not canonical/);
+    expect(() => extractPathCoordinates({ server: { mountPrefix: '/a+b' } })).toThrow(/not canonical/);
+    expect(extractPathCoordinates({ server: { mountPrefix: '/A-z0.9_~' } })).toEqual({ mountPrefix: '/A-z0.9_~', publicBasePath: '/A-z0.9_~' });
+  });
+
+  it('fails at function entry: no host state exists when a coordinate is invalid (PR-1 review)', async () => {
+    // A caller-owned host must be untouched by a failed boot - validation precedes both
+    // Fastify construction and any caller-host registration.
+    const app = fastify({ logger: false });
+    app.decorate('authenticate', async () => undefined);
+    const before = app.printRoutes();
+
+    await expect(
+      createServer({ config: withAddressing({ mountPrefix: '/bad/' }), fastify: app, clientRoot: '/nowhere' }),
+    ).rejects.toThrow(/not canonical/);
+
+    expect(app.printRoutes()).toBe(before);
+    await app.close();
+  });
+});
+
+describe('RFC 0012 - viteBaseFor (verdict-round ruling; root compatibility by construction)', () => {
+  const legacyFormula = (entryPoint: string) => (entryPoint ? `/${entryPoint}/` : '/');
+
+  it('reproduces the pre-RFC Build.ts formula byte-for-byte when publicBasePath is ""', () => {
+    // Including tolerated non-canonical entryPoint spellings - preserved, not endorsed.
+    for (const entryPoint of ['', 'app', 'admin', 'nested/dir', '.', './x', 'x/', '/x']) {
+      expect(viteBaseFor('', entryPoint)).toBe(legacyFormula(entryPoint));
+    }
+  });
+
+  it('composes the canonical publicBasePath AROUND the existing entryPoint spelling', () => {
+    expect(viteBaseFor('/app', '')).toBe('/app/');
+    expect(viteBaseFor('/app', 'admin')).toBe('/app/admin/');
+    expect(viteBaseFor('/app', 'nested/dir')).toBe('/app/nested/dir/');
+    // Tolerated odd spelling passes through unchanged inside the composition.
+    expect(viteBaseFor('/app', 'x/')).toBe('/app/x//');
+  });
+});
+
+describe('RFC 0012 - beacon URL composition', () => {
+  it('prefixes the beacon fetch with the emission coordinate, byte-identical at ""', () => {
+    expect(buildTaujsDevStamp('rid', 'tok')).toContain("fetch('/__taujs/beacon'");
+    expect(buildTaujsDevStamp('rid', 'tok', undefined, '')).toContain("fetch('/__taujs/beacon'");
+    expect(buildTaujsDevStamp('rid', 'tok', undefined, '/mnt')).toContain("fetch('/mnt/__taujs/beacon'");
+  });
+});
+
+describe('RFC 0012 - preserve cell: caller-owned host, mounted installation (cells 2, 7)', () => {
+  it('serves every τjs surface under the mount and leaves the rest of the host to the caller', async () => {
+    const host = await createEmbeddedHost();
+    await host.activate(createServer as never, withAddressing({ mountPrefix: '/mnt' }, [ROOT_ROUTE]));
+
+    // Declared routes of the installation serve under the prefix...
+    const page = await host.app.inject({ method: 'GET', url: `/mnt${PATHS.taujsPage}` });
+    expect(page.statusCode).toBe(200);
+    expect(page.body).toContain(OWNER.taujsPage);
+
+    // ...and the mount root serves for BOTH direct spellings (frozen contract, RFC §2 rule 5).
+    expect((await host.app.inject({ method: 'GET', url: '/mnt' })).statusCode).toBe(200);
+    expect((await host.app.inject({ method: 'GET', url: '/mnt/' })).statusCode).toBe(200);
+
+    // τjs static (entryPoint 'app') composes on reception: /mnt + /app/assets/...
+    const asset = await host.app.inject({ method: 'GET', url: `/mnt${TAUJS_ASSET_PATH}` });
+    expect(asset.statusCode).toBe(200);
+    expect(asset.body).toContain(OWNER.taujsPage);
+
+    // Emission composes the SAME coordinate (publicBasePath defaults to mountPrefix).
+    expect(page.body).toContain(`/mnt${TAUJS_ASSET_PATH}`);
+
+    // The unprefixed spellings belong to the CALLER: its not-found answers, not τjs.
+    const outsidePage = await host.app.inject({ method: 'GET', url: PATHS.taujsPage });
+    expect(outsidePage.statusCode).toBe(404);
+    expect(outsidePage.body).toContain(OWNER.callerNotFound);
+    const outsideAsset = await host.app.inject({ method: 'GET', url: TAUJS_ASSET_PATH });
+    expect(outsideAsset.statusCode).toBe(404);
+
+    // Caller routes at the host root are untouched by the mount.
+    expect((await host.app.inject({ method: 'GET', url: PATHS.callerBefore })).statusCode).toBe(200);
+    expect((await host.app.inject({ method: 'GET', url: PATHS.callerAfter })).statusCode).toBe(200);
+
+    // Misses INSIDE the mount also stay the caller's (no τjs shell on a caller-owned host).
+    const insideMiss = await host.app.inject({ method: 'GET', url: '/mnt/pw-0012-unmatched' });
+    expect(insideMiss.statusCode).toBe(404);
+    expect(insideMiss.body).toContain(OWNER.callerNotFound);
+
+    await host.close();
+  });
+
+  it('mounts a declared terminal wildcard under the prefix like any route (cell 2)', async () => {
+    const host = await createEmbeddedHost();
+    await host.activate(createServer as never, withAddressing({ mountPrefix: '/mnt' }, [], taujsConfig({ wildcard: true })));
+
+    expect((await host.app.inject({ method: 'GET', url: '/mnt/anything/nested' })).statusCode).toBe(200);
+    // Outside the mount the wildcard does NOT exist: the caller's not-found answers.
+    const outside = await host.app.inject({ method: 'GET', url: '/anything/nested' });
+    expect(outside.statusCode).toBe(404);
+    expect(outside.body).toContain(OWNER.callerNotFound);
+
+    await host.close();
+  });
+});
+
+describe('RFC 0012 - strip-shape cell: emission differs from reception (cell 1, server half)', () => {
+  it('emits under publicBasePath while receiving at the root mount', async () => {
+    const host = await createEmbeddedHost();
+    await host.activate(createServer as never, withAddressing({ mountPrefix: '', publicBasePath: '/pub' }, [ROOT_ROUTE]));
+
+    // Reception unchanged: routes and static answer at the root, exactly as an upstream
+    // behind a stripping proxy receives them.
+    const page = await host.app.inject({ method: 'GET', url: PATHS.taujsPage });
+    expect(page.statusCode).toBe(200);
+    expect((await host.app.inject({ method: 'GET', url: TAUJS_ASSET_PATH })).statusCode).toBe(200);
+
+    // Emission carries the PUBLIC coordinate: what a browser must be told.
+    expect(page.body).toContain(`/pub${TAUJS_ASSET_PATH}`);
+    expect(page.body).not.toContain(`src="${TAUJS_ASSET_PATH}`);
+
+    await host.close();
+  });
+});
+
+describe('RFC 0012 - root byte-compatibility (cell 4, response level)', () => {
+  it('emits today\'s root-absolute URLs exactly when both coordinates default', async () => {
+    const host = await createEmbeddedHost();
+    await host.activate(createServer as never, withAddressing({}, [ROOT_ROUTE]));
+
+    const page = await host.app.inject({ method: 'GET', url: PATHS.taujsPage });
+    expect(page.statusCode).toBe(200);
+    expect(page.body).toContain(`src="${TAUJS_ASSET_PATH}"`);
+
+    await host.close();
+  });
+});
+
+describe('RFC 0012 - created-host confinement (cells 6, frozen ownership contract)', () => {
+  it('confines the SPA fallback to the mounted subtree and answers an ordinary 404 outside', async () => {
+    const host = await createCreatedHost();
+    const { app } = await host.activate(createServer as never, withAddressing({ mountPrefix: '/mnt' }, [ROOT_ROUTE]));
+    expect(app).toBeDefined();
+
+    // Inside the subtree: pages serve, and an extensionless miss gets the confined shell -
+    // whose emitted URLs carry the mount.
+    expect((await app!.inject({ method: 'GET', url: `/mnt${PATHS.taujsPage}` })).statusCode).toBe(200);
+    const shell = await app!.inject({ method: 'GET', url: '/mnt/pw-0012-unmatched' });
+    expect(shell.statusCode).toBe(200);
+    expect(shell.headers['content-type']).toContain('text/html');
+    expect(shell.body).toContain(`/mnt${TAUJS_ASSET_PATH}`);
+
+    // The extension heuristic is unchanged INSIDE the subtree.
+    expect((await app!.inject({ method: 'GET', url: '/mnt/looks.like.file' })).statusCode).toBe(404);
+
+    // OUTSIDE the subtree: an ordinary 404, never the shell - one mounted installation
+    // does not claim unrelated host URLs.
+    const outside = await app!.inject({ method: 'GET', url: '/pw-0012-unmatched' });
+    expect(outside.statusCode).toBe(404);
+    expect(outside.headers['content-type']).not.toContain('text/html');
+    expect(outside.body).not.toContain('<main');
+
+    await host.close();
+  });
+
+  it('keeps the unmounted created host byte-compatible: whole-server shell at the root', async () => {
+    const host = await createCreatedHost();
+    const { app } = await host.activate(createServer as never, withAddressing({}, [ROOT_ROUTE]));
+
+    const shell = await app!.inject({ method: 'GET', url: '/pw-0012-unmatched' });
+    expect(shell.statusCode).toBe(200);
+    expect(shell.headers['content-type']).toContain('text/html');
+    expect(shell.body).toContain(`src="${TAUJS_ASSET_PATH}"`);
+
+    await host.close();
+  });
+});
+
+describe('RFC 0012 - loadAssets emission regression (PR-1 review, finding 4)', () => {
+  // The runtime cells above primarily prove the bootstrap URL; this proves ALL THREE emission
+  // maps - bootstrap, CSS links and preload links - receive the coordinate at the seam.
+  const emissionFixture = async (): Promise<string> => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'taujs-rfc0012-emission-'));
+    const clientRoot = path.join(root, 'client');
+    const appRoot = path.join(clientRoot, 'app');
+    const ssrRoot = path.join(root, 'ssr', 'app');
+
+    await mkdir(path.join(appRoot, '.vite'), { recursive: true });
+    await mkdir(path.join(ssrRoot, '.vite'), { recursive: true });
+    await writeFile(path.join(root, 'package.json'), '{"type":"module"}\n');
+    await writeFile(path.join(appRoot, 'index.html'), '<!doctype html><html><head><!--ssr-head--></head><body><div id="app"><!--ssr-html--></div></body></html>');
+    await writeFile(
+      path.join(appRoot, '.vite', 'manifest.json'),
+      JSON.stringify({ 'entry-client.ts': { file: 'assets/rfc0012-client.js', css: ['assets/rfc0012.css'] } }),
+    );
+    await writeFile(path.join(ssrRoot, '.vite', 'ssr-manifest.json'), JSON.stringify({ 'some-module': ['assets/rfc0012-preload.js', 'assets/rfc0012.css'] }));
+    await writeFile(
+      path.join(ssrRoot, 'entry-server.js'),
+      [
+        "const tag = Symbol.for('taujs.render-contract/v1');",
+        "const brand = (fn) => Object.defineProperty(fn, tag, { value: { key: 'test', contractVersion: 'v1' } });",
+        "export const renderSSR = brand(async () => ({ headContent: '', appHtml: '' }));",
+        'export const renderStream = brand(() => ({ abort() {}, done: Promise.resolve() }));',
+      ].join('\n'),
+    );
+
+    return clientRoot;
+  };
+
+  const runLoadAssets = async (clientRoot: string, publicBasePath: string) => {
+    const processed = processConfigs([{ appId: 'emission', entryPoint: 'app', renderer: testRenderer() }], clientRoot, TEMPLATE);
+    const maps = createMaps();
+
+    await loadAssets(
+      processed,
+      clientRoot,
+      maps.bootstrapModules,
+      maps.cssLinks,
+      maps.manifests,
+      maps.preloadLinks,
+      maps.renderModules,
+      maps.ssrManifests,
+      maps.templates,
+      { publicBasePath },
+    );
+
+    const key = processed[0]!.clientRoot;
+    return { bootstrap: maps.bootstrapModules.get(key), css: maps.cssLinks.get(key), preload: maps.preloadLinks.get(key) };
+  };
+
+  it('composes publicBasePath into bootstrap, CSS and preload maps alike', async () => {
+    const clientRoot = await emissionFixture();
+    const { bootstrap, css, preload } = await runLoadAssets(clientRoot, '/pub');
+
+    expect(bootstrap).toBe('/pub/app/assets/rfc0012-client.js');
+    expect(css).toContain('href="/pub/app/assets/rfc0012.css"');
+    expect(preload).toContain('href="/pub/app/assets/rfc0012-preload.js"');
+    expect(preload).toContain('href="/pub/app/assets/rfc0012.css"');
+  });
+
+  it('keeps all three maps byte-compatible with today at the default coordinate', async () => {
+    const clientRoot = await emissionFixture();
+    const { bootstrap, css, preload } = await runLoadAssets(clientRoot, '');
+
+    expect(bootstrap).toBe('/app/assets/rfc0012-client.js');
+    expect(css).toContain('href="/app/assets/rfc0012.css"');
+    expect(preload).toContain('href="/app/assets/rfc0012-preload.js"');
+    expect(preload).toContain('href="/app/assets/rfc0012.css"');
+  });
+});
+
+describe('RFC 0012 - static composition (cell 8, semantic preservation)', () => {
+  it('composes a caller-supplied static prefix with the mount and keeps a meaningful option working', async () => {
+    const assetRoot = await mkdtemp(path.join(os.tmpdir(), 'taujs-rfc0012-static-'));
+    await writeFile(path.join(assetRoot, 'cell8.txt'), 'RFC0012_STATIC_CELL8\n');
+
+    const app = fastify({ logger: false });
+    app.decorate('authenticate', async () => undefined);
+    app.setNotFoundHandler(async (_req, reply) => reply.status(404).send({ owner: OWNER.callerNotFound }));
+
+    const clientRoot = await productionFixture();
+    const fastifyStatic = await import('@fastify/static');
+    await createServer({
+      config: withAddressing({ mountPrefix: '/mnt' }),
+      fastify: app,
+      clientRoot,
+      staticAssets: {
+        plugin: fastifyStatic.default,
+        options: {
+          root: assetRoot,
+          prefix: '/cdn/',
+          index: false,
+          setHeaders: (res: { setHeader: (k: string, v: string) => void }) => res.setHeader('x-rfc0012-static', 'cell8'),
+        },
+      },
+    });
+
+    // The registration's effective route COMPOSES with the installation mount (Fastify used
+    // normally), and the caller's own option still takes effect there.
+    const composed = await app.inject({ method: 'GET', url: '/mnt/cdn/cell8.txt' });
+    expect(composed.statusCode).toBe(200);
+    expect(composed.body).toContain('RFC0012_STATIC_CELL8');
+    expect(composed.headers['x-rfc0012-static']).toBe('cell8');
+
+    // The host-root spelling is NOT claimed by τjs; the documented escape is
+    // staticAssets:false plus a caller registration on the host they own.
+    const hostRoot = await app.inject({ method: 'GET', url: '/cdn/cell8.txt' });
+    expect(hostRoot.statusCode).toBe(404);
+    expect(hostRoot.body).toContain(OWNER.callerNotFound);
+
+    await app.close();
+  });
+});

--- a/packages/server/src/test/ViteAlias.test.ts
+++ b/packages/server/src/test/ViteAlias.test.ts
@@ -46,7 +46,10 @@ vi.mock('../utils/Templates', () => ({
   overrideCSSHMRConsoleError: hoisted.overrideCSSHMRConsoleErrorMock,
 }));
 
-vi.mock('../core/config/Setup', () => ({
+vi.mock('../core/config/Setup', async (importOriginal) => ({
+  // RFC 0012: keep the real pure exports (extractPathCoordinates, viteBaseFor) - only the
+  // extraction this suite drives is replaced.
+  ...(await importOriginal<typeof import('../core/config/Setup')>()),
   extractBuildConfigs: vi.fn(),
 }));
 

--- a/packages/server/src/test/ViteConfigMigration.test.ts
+++ b/packages/server/src/test/ViteConfigMigration.test.ts
@@ -43,7 +43,10 @@ vi.mock('../utils/Templates', () => ({
   overrideCSSHMRConsoleError: hoisted.overrideCSSHMRConsoleErrorMock,
 }));
 
-vi.mock('../core/config/Setup', () => ({
+vi.mock('../core/config/Setup', async (importOriginal) => ({
+  // RFC 0012: keep the real pure exports (extractPathCoordinates, viteBaseFor) - only the
+  // extraction this suite drives is replaced.
+  ...(await importOriginal<typeof import('../core/config/Setup')>()),
   extractBuildConfigs: vi.fn(),
 }));
 

--- a/packages/server/src/test/ViteDevWiring.test.ts
+++ b/packages/server/src/test/ViteDevWiring.test.ts
@@ -49,7 +49,10 @@ vi.mock('../utils/Templates', () => ({
   overrideCSSHMRConsoleError: hoisted.overrideCSSHMRConsoleErrorMock,
 }));
 
-vi.mock('../core/config/Setup', () => ({
+vi.mock('../core/config/Setup', async (importOriginal) => ({
+  // RFC 0012: keep the real pure exports (extractPathCoordinates, viteBaseFor) - only the
+  // extraction this suite drives is replaced.
+  ...(await importOriginal<typeof import('../core/config/Setup')>()),
   extractBuildConfigs: vi.fn(),
 }));
 

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -40,6 +40,13 @@ export type SSRServerOptions = {
   security?: SecurityConfig;
   /** `undefined` → default production registration; `false` → no static plugin; otherwise the caller's registration. */
   staticAssets?: StaticAssetsRegistration;
+  /**
+   * RFC 0012: the validated installation-level EMISSION coordinate, threaded from
+   * `createServer` (`extractPathCoordinates`). Composed in front of every τjs-generated URL
+   * (bootstrap, css, preload, dev beacon). `''` (the default) is today's root-absolute
+   * emission byte-for-byte. RECEPTION is the register-time `prefix`, not this value.
+   */
+  publicBasePath?: string;
   debug?: DebugConfig;
   /** Internal runtime logger selection threaded from createServer; not a public createServer option. */
   runtimeLogger?: RuntimeLoggerSelection;

--- a/packages/server/src/utils/AssetManager.ts
+++ b/packages/server/src/utils/AssetManager.ts
@@ -86,9 +86,14 @@ export const loadAssets = async (
   renderModules: Map<string, RenderModule>,
   ssrManifests: Map<string, SSRManifest>,
   templates: Map<string, string>,
-  opts: { logger?: Logs } = {},
+  opts: { logger?: Logs; publicBasePath?: string } = {},
 ) => {
   const logger = resolveLogs(opts.logger);
+  // RFC 0012: every URL this function produces gains the installation's emission coordinate.
+  // Canonical ('' or '/x' with no trailing slash), so plain prepending composes; '' is today's
+  // output byte-for-byte. The per-app segment stays `adjustedRelativePath` (the entryPoint
+  // spelling, deliberately unnormalised - RFC 0012 §2 intent statement).
+  const publicBasePath = opts.publicBasePath ?? '';
 
   for (const config of processedConfigs) {
     const { clientRoot, entryServer, entryClient, htmlTemplate, entryPoint } = config;
@@ -104,7 +109,7 @@ export const loadAssets = async (
         // The bootstrap URL must point at the real file for Vite dev; probe the
         // stem against ENTRY_EXTENSIONS the same way the server entry is resolved.
         const entryClientFile = resolveEntryFile(clientRoot, entryClient);
-        const bootstrapModule = `/${adjustedRelativePath}/${entryClientFile}`.replace(/\/{2,}/g, '/');
+        const bootstrapModule = `${publicBasePath}${`/${adjustedRelativePath}/${entryClientFile}`.replace(/\/{2,}/g, '/')}`;
         bootstrapModules.set(clientRoot, bootstrapModule);
         continue;
       }
@@ -135,11 +140,11 @@ export const loadAssets = async (
         });
       }
 
-      const bootstrapModule = `/${adjustedRelativePath}/${manifestEntry.file}`.replace(/\/{2,}/g, '/');
+      const bootstrapModule = `${publicBasePath}${`/${adjustedRelativePath}/${manifestEntry.file}`.replace(/\/{2,}/g, '/')}`;
       bootstrapModules.set(clientRoot, bootstrapModule);
 
-      preloadLinks.set(clientRoot, renderPreloadLinks(ssrManifest, adjustedRelativePath));
-      cssLinks.set(clientRoot, getCssLinks(manifest, adjustedRelativePath));
+      preloadLinks.set(clientRoot, renderPreloadLinks(ssrManifest, `${publicBasePath}${adjustedRelativePath}`));
+      cssLinks.set(clientRoot, getCssLinks(manifest, `${publicBasePath}${adjustedRelativePath}`));
 
       // Renderer v1: every app MUST declare a valid renderer contribution (fail-closed at boot - the outer
       // catch rethrows in production). Every renderer ships a render module the host validates; there is

--- a/packages/server/src/utils/DevServer.ts
+++ b/packages/server/src/utils/DevServer.ts
@@ -57,10 +57,27 @@ export type SetupDevServerOptions = {
    * `server.*` the fragment carries.
    */
   viteConfig?: InlineConfig;
+  /**
+   * RFC 0012 (PR 2): the installation's RECEPTION coordinate, single-sourced from Fastify
+   * (`scope.prefix` of the one τjs registration). When non-empty, the delegator's domain is
+   * CONFINED to the mounted subtree - outside the subtree is not τjs's to answer (the dev
+   * face of the frozen ownership contract). No request rewriting happens: pinned Vite's
+   * middleware mode natively accepts BOTH public-prefixed and proxy-stripped request paths
+   * (base mismatch → plain `next()` into its own transform/static middlewares).
+   */
+  mountPrefix?: string;
+  /**
+   * RFC 0012 (PR 2): the installation's validated EMISSION coordinate. Derives the shared dev
+   * Vite `base` (`publicBasePath + '/'`), which carries dev module URLs and the HMR socket
+   * PATHNAME.
+   */
+  publicBasePath?: string;
 };
 
 export const setupDevServer = async (options: SetupDevServerOptions): Promise<ViteDevServer> => {
   const { app, clientRoot: baseClientRoot, alias, declarativeAlias, projectRoot, debug, devNet, viteConfig } = options;
+  const mountPrefix = options.mountPrefix ?? '';
+  const publicBasePath = options.publicBasePath ?? '';
 
   const logger =
     options.logger ??
@@ -167,6 +184,11 @@ export const setupDevServer = async (options: SetupDevServerOptions): Promise<Vi
       alias: resolvedAlias,
     },
     root: baseClientRoot,
+    // RFC 0012 (PR 2): the shared dev base derives from the installation's emission coordinate,
+    // carrying dev module URLs AND the HMR socket PATHNAME with it. `''` yields `'/'` - Vite's
+    // own default, byte-compatible. A framework invariant like `root`: the engine already
+    // protects `base` from user layers in both profiles, and that ruling is unchanged.
+    base: `${publicBasePath}/`,
     // MERGE, never replace. Writing this object whole discarded every declared `server.*` field,
     // `allowedHosts` among them - so development behind a proxy presenting a non-localhost `Host`
     // was unreachable, with no supported way to allow it.
@@ -203,6 +225,18 @@ export const setupDevServer = async (options: SetupDevServerOptions): Promise<Vi
     // Classification is only meaningful on the caller-owned root delegator; the created-host path
     // stays exactly as it was, including never reading the request's route identity.
     if (callerOwnedRootDelegator && !request.is404 && selectedRouteFrom(request) === null) return;
+
+    // RFC 0012 (PR 2): when mounted, the delegator's DOMAIN is the mounted subtree - an
+    // out-of-mount URL is not τjs's to answer (frozen ownership contract), so it never
+    // reaches Vite and falls straight through to the host's own handling. No request
+    // rewriting: Vite's middleware mode accepts both public-prefixed and proxy-stripped
+    // paths natively, so mount-space URLs are delegated AS RECEIVED.
+    if (mountPrefix !== '') {
+      const rawUrl = request.raw.url ?? '';
+      const queryIndex = rawUrl.indexOf('?');
+      const pathname = queryIndex === -1 ? rawUrl : rawUrl.slice(0, queryIndex);
+      if (!(pathname === mountPrefix || pathname.startsWith(`${mountPrefix}/`))) return;
+    }
 
     await new Promise<void>((resolve) => {
       viteDevServer.middlewares(request.raw, reply.raw, () => {

--- a/packages/server/src/utils/HandleNotFound.ts
+++ b/packages/server/src/utils/HandleNotFound.ts
@@ -31,6 +31,8 @@ export const handleNotFound = async (
     debug?: DebugConfig;
     logger?: Logs;
     viteDevServer?: ViteDevServer;
+    /** RFC 0012: the installation's validated emission coordinate; prefixes the dev beacon URL. */
+    publicBasePath?: string;
   } = {},
 ) => {
   const { viteDevServer } = opts;
@@ -92,7 +94,10 @@ export const handleNotFound = async (
     // with, so it gets its own — only when the structural gate holds (dev decoration).
     const devtools = (req as { server?: { taujsIntrospection?: { token: string } } }).server?.taujsIntrospection;
     if (devtools && requestContext) {
-      processedTemplate = processedTemplate.replace('</body>', `${buildTaujsDevStamp(requestContext.requestId, devtools.token, cspNonce)}</body>`);
+      processedTemplate = processedTemplate.replace(
+        '</body>',
+        `${buildTaujsDevStamp(requestContext.requestId, devtools.token, cspNonce, opts.publicBasePath ?? '')}</body>`,
+      );
     }
 
     logger.debug?.('ssr', { status: 200 }, 'Sending not-found fallback HTML');

--- a/packages/server/src/utils/HandleRender.ts
+++ b/packages/server/src/utils/HandleRender.ts
@@ -125,6 +125,8 @@ export const handleRender = async (
     debug?: DebugConfig;
     logger?: Logs;
     viteDevServer?: ViteDevServer;
+    /** RFC 0012: the installation's validated emission coordinate; prefixes the dev beacon URL. */
+    publicBasePath?: string;
   } = {},
 ) => {
   const { viteDevServer } = opts;
@@ -256,7 +258,7 @@ export const handleRender = async (
     // Dev stamp (spec 03 §7): present only when the structural gate holds — the decoration
     // exists solely on dev boots, so production HTML never carries it.
     const devtools = (req as { server?: { taujsIntrospection?: { token: string } } }).server?.taujsIntrospection;
-    const devStamp = devtools ? buildTaujsDevStamp(requestId, devtools.token, cspNonce) : '';
+    const devStamp = devtools ? buildTaujsDevStamp(requestId, devtools.token, cspNonce, opts.publicBasePath ?? '') : '';
     // R1-01 (design 4): each branch sets `ctx.signal` from its request AbortController BEFORE the
     // data is fetched, so loaders that honour `ctx.signal` stop on client disconnect / deadline.
     const ctx = { requestId, logger: reqLogger, headers, recorder, signal: undefined as AbortSignal | undefined };

--- a/packages/server/src/utils/Templates.ts
+++ b/packages/server/src/utils/Templates.ts
@@ -215,14 +215,16 @@ export const extractHeadInner = (html: string): string => {
 // structural dev gate holds (callers check for the introspection decoration) — the Gate 0B
 // prod test asserts its absence. Values are JSON-encoded; requestId is SAFE_REQUEST_ID-validated
 // upstream and the token is base64url, so neither can break out of the script context.
-export const buildTaujsDevStamp = (requestId: string, token: string, nonce?: string): string => {
+// RFC 0012: `basePath` is the installation's validated emission coordinate; its canonical
+// charset ([A-Za-z0-9._~-] segments) cannot break out of the single-quoted URL string.
+export const buildTaujsDevStamp = (requestId: string, token: string, nonce?: string, basePath = ''): string => {
   const nonceAttr = nonce ? ` nonce="${nonce}"` : '';
   const script =
     `window.__TAUJS_REQUEST_ID__=${JSON.stringify(requestId)};window.__TAUJS_DEV_TOKEN__=${JSON.stringify(token)};` +
     '(function(){var t=window.__TAUJS_REQUEST_ID__,k=window.__TAUJS_DEV_TOKEN__;if(!t||!k)return;var t0=null,sent=false;' +
     'function send(ok,err){if(sent)return;sent=true;var b={requestId:t,ok:ok};if(t0!=null)b.ms=Math.round(performance.now()-t0);' +
     'if(err)b.error=String(err).slice(0,500);' +
-    "try{fetch('/__taujs/beacon',{method:'POST',headers:{'content-type':'application/json','x-taujs-token':k},body:JSON.stringify(b),keepalive:true}).catch(function(){})}catch(e){}}" +
+    `try{fetch('${basePath}/__taujs/beacon',{method:'POST',headers:{'content-type':'application/json','x-taujs-token':k},body:JSON.stringify(b),keepalive:true}).catch(function(){})}catch(e){}}` +
     "window.__TAUJS_DEVTOOLS_HOOK__={emit:function(ev,p){if(ev==='hydration:start')t0=performance.now();" +
     "else if(ev==='hydration:success')send(true);else if(ev==='hydration:error')send(false,(p&&p.message)||p)}};})();";
 

--- a/website/src/content/docs/guides/build-deployment.md
+++ b/website/src/content/docs/guides/build-deployment.md
@@ -661,6 +661,51 @@ server {
 }
 ```
 
+### Non-root base paths
+
+A τjs installation can be mounted behind a prefix in either ordinary proxy topology. Two
+`server` coordinates describe it: `mountPrefix` is where Fastify receives the installation,
+`publicBasePath` is what browsers are told (see the
+[configuration reference](/reference/taujs-config/#non-root-mounting-mountprefix-and-publicbasepath)
+for validation and defaults). Existing root deployments need no changes.
+
+**Root (default).** No configuration; behaviour is unchanged.
+
+**Prefix-preserving proxy.** The proxy forwards the path intact, so Fastify receives
+`/app/...`:
+
+```nginx
+location /app/ {
+  proxy_pass http://nodejs;   # no URI part: the path is preserved
+}
+```
+
+```typescript
+server: {
+  mountPrefix: "/app";        // publicBasePath inherits '/app'
+}
+```
+
+**Stripping proxy.** The proxy removes the prefix before forwarding, so Fastify receives
+root-space paths while browsers use `/app/...`:
+
+```nginx
+location /app/ {
+  proxy_pass http://nodejs/;  # trailing slash: /app/x is forwarded as /x
+}
+```
+
+```typescript
+server: {
+  mountPrefix: "",            // receive at root
+  publicBasePath: "/app";     // emit under the public prefix
+}
+```
+
+Whether your proxy strips or preserves is the proxy's own configuration - τjs expresses
+both topologies through the two coordinates and never infers the prefix from forwarding
+headers.
+
 ### Option D: Container Deployment
 
 ```dockerfile

--- a/website/src/content/docs/guides/static-assets.md
+++ b/website/src/content/docs/guides/static-assets.md
@@ -124,6 +124,18 @@ staticAssets: [
 τjs sorts mounts by prefix depth before registration so a more specific prefix is registered first.
 Fastify still rejects exact route collisions at boot.
 
+### Composition with a mounted installation
+
+When the installation declares a `server.mountPrefix`, custom static registrations compose
+with it exactly as Fastify composes any nested plugin route: a registration with
+`prefix: "/cdn/"` inside an installation mounted at `/app` serves at `/app/cdn/`. Existing
+option semantics are unchanged; τjs does not rewrite the configured static prefix to
+account for the installation mount - Fastify composes it with the enclosing scope.
+
+A host-root mount is still available when you want it: pass `staticAssets: false` so τjs
+registers nothing, and register your static plugin on the Fastify instance you own - a
+caller-root `/cdn/` then serves at `/cdn/` regardless of where τjs is mounted.
+
 ## Caller-owned Fastify and terminal wildcards
 
 A supplied host may register its own `@fastify/static` before τjs. That works when the route shapes do

--- a/website/src/content/docs/reference/taujs-config.md
+++ b/website/src/content/docs/reference/taujs-config.md
@@ -32,7 +32,7 @@ export default defineConfig({
   apps: [
     {
       appId: "web",
-      entryPoint: "client",
+      entryPoint: "",
       routes: [
         {
           path: "/",
@@ -62,6 +62,8 @@ type ServerConfig = {
   host?: string; // Default: 'localhost'
   port?: number; // Default: 5173
   hmrPort?: number; // Default: 5174
+  mountPrefix?: string; // Default: '' (root)
+  publicBasePath?: string; // Default: mountPrefix
 };
 
 type AppConfig = {
@@ -129,6 +131,61 @@ server: {
 npm run dev -- --host    # Automatically becomes 0.0.0.0
 ```
 
+### Non-root mounting: `mountPrefix` and `publicBasePath`
+
+Two installation-level coordinates make a τjs installation deployable under a non-root
+prefix. They describe external addressing, not project layout:
+
+- **`mountPrefix`** - where Fastify RECEIVES the installation. One scope prefix under which
+  every declared route (all apps), τjs static assets and the development introspection
+  surface register. Default `''` (root).
+- **`publicBasePath`** - what τjs EMITS in front of every URL it generates: asset, preload
+  and CSS links, the bootstrap module URL and the development beacon. It also derives each
+  app's Vite `base`. Defaults to `mountPrefix`.
+
+The two differ exactly when a reverse proxy STRIPS the public prefix before forwarding:
+
+```typescript
+// Root (default) - no configuration needed; existing deployments are unchanged.
+server: {}
+
+// Prefix-preserving proxy: /app/x arrives as /app/x.
+server: { mountPrefix: "/app" }
+
+// Stripping proxy: browsers use /app/x, the proxy forwards /x.
+server: { mountPrefix: "", publicBasePath: "/app" }
+```
+
+**Validation.** A coordinate is either `''` or `/segment(/segment)*` - leading `/`, no
+trailing `/`, segments of URI-unreserved characters only (`[A-Za-z0-9._~-]`). Anything else
+is rejected at startup with a message naming the rule; values are never silently
+normalised. Declaring `publicBasePath: ""` alongside a non-empty `mountPrefix` (emit
+root-absolute while mounted) is rejected as unsupported.
+
+**Separation from `entryPoint`.** `entryPoint` keeps its layout meaning: `''` remains the
+canonical single-application root layout, and a named entry point remains a subordinate
+application directory. The deployment coordinates compose AROUND it - `publicBasePath:
+"/app"` with `entryPoint: "admin"` emits `/app/admin/assets/...`. Never substitute
+`entryPoint: "app"` for `publicBasePath: "/app"`; deployment does not change layout.
+
+**Routing boundary.** `/app` and `/app/` both reach the mounted root route. Deeper
+trailing-slash matching remains the Fastify owner's policy - a caller-owned host keeps its
+own `ignoreTrailingSlash` choice, and the τjs-created default stays strict. On a
+τjs-created host the SPA fallback is confined to the mounted subtree; outside it the
+server answers an ordinary 404. Application routers and hard-coded links need their own
+base configuration, because τjs does not rewrite them.
+
+**What τjs does not do.** Application-authored links (`href` values in your components) are
+never rewritten - τjs prefixes only the URLs it generates itself. Proxy rewrite
+configuration stays proxy-owned; τjs reads no forwarding headers
+(`X-Forwarded-Prefix` included).
+
+**Development.** The shared dev Vite `base` follows `publicBasePath`, so dev module URLs
+and the HMR socket pathname compose with the prefix, and dev delegation is confined to the
+mounted subtree. Two adjacent concerns remain separate limitations: HMR socket origin and
+port under process supervisors, and reverse-proxy host admission for the `/__taujs/*`
+introspection endpoints.
+
 ## App Configuration
 
 Define frontend applications with their entry points and routes.
@@ -137,7 +194,7 @@ Define frontend applications with their entry points and routes.
 apps: [
   {
     appId: "web",
-    entryPoint: "client",
+    entryPoint: "", // canonical root layout: the app lives at the client root
     routes: [
       /* ... */
     ],
@@ -147,7 +204,7 @@ apps: [
   },
   {
     appId: "admin",
-    entryPoint: "admin",
+    entryPoint: "admin", // subordinate application directory and build namespace
     routes: [
       /* ... */
     ],
@@ -160,7 +217,7 @@ apps: [
 | Property     | Type             | Required | Description                    |
 | ------------ | ---------------- | -------- | ------------------------------ |
 | `appId`      | `string`         | Yes      | Unique identifier for this app |
-| `entryPoint` | `string`         | Yes      | Directory under client root    |
+| `entryPoint` | `string`         | Yes      | `''` for the canonical root layout, or a directory under the client root |
 | `routes`     | `AppRoute[]`     | No       | Route definitions              |
 | `plugins`    | `PluginOption[]` | No       | Vite plugins for this app      |
 
@@ -230,6 +287,9 @@ client/{entryPoint}/
 ├── entry-client.tsx    # Client hydration entry
 └── entry-server.tsx    # SSR render entry
 ```
+
+With `entryPoint: ""` (the canonical root layout) these files live directly in the client
+root.
 
 ## Vite Configuration
 


### PR DESCRIPTION
First half of the non-root base-path feature (RFC 0012). Today a τjs installation is
undeployable under a non-root prefix, and the two ordinary reverse-proxy topologies fail on
disjoint surfaces: behind a **stripping** proxy the server side works but every emitted URL
is root-absolute, so assets, navigation and the dev beacon all resolve to dead origin-root
paths; behind a **prefix-preserving** proxy nothing can match at all - exact routes, scoped
wildcards, caller routes and static alike. Measured end to end in the RFC's evidence phase;
no proxy communicates the prefix (`X-Forwarded-Prefix` was absent on every measured hop and
is deliberately never read).

## The model

Two validated, installation-level coordinates on the config `server` block:

- **`mountPrefix`** - where Fastify RECEIVES the installation: one scope prefix under which
  every declared route (all apps), τjs static and the development `/__taujs/*` surface
  register. Implemented with Fastify's own scope-prefix primitive on the one existing τjs
  registration - no parallel router.
- **`publicBasePath`** - what τjs EMITS in front of every URL it generates (asset, preload
  and CSS links, the bootstrap module URL, the dev beacon) and what each app's production
  Vite `base` derives from. Defaults to `mountPrefix`; the two differ exactly when the
  proxy strips (declare `mountPrefix: ''` with the public prefix here).

`entryPoint` keeps its original layout meaning untouched: empty is the canonical
single-application root layout, non-empty is a subordinate application directory, and the
deployment coordinates compose AROUND the existing spelling
(`/app` + entryPoint `admin` emits `/app/admin/assets/...`). Deployment never forces a
layout change, and `entryPoint` is not a substitute for `publicBasePath`.

## What this PR does

- **Validation at function entry**, before any host state exists: canonical form only
  (`''` or `/segment(/segment)*`, URI-unreserved segment characters - a frozen conservative
  v1), rejected with a message naming the rule, never silently normalised. The unsupported
  inverse corner (explicit `''` public with a non-empty mount) is rejected outright. A
  failed boot leaves a caller-supplied Fastify byte-untouched.
- **The mount**: one register-time `prefix`. A mounted τjs-created host flips to the
  encapsulated registration form (fastify-plugin ignores `prefix` when it breaks
  encapsulation), and that same prefixed scope naturally CONFINES the SPA fallback:
  prefix-keyed not-found inside the subtree, an ordinary 404 outside it - one mounted
  installation never claims unrelated host URLs.
- **Emission seams**: `publicBasePath` composes at the existing seams - the four
  `loadAssets` URL productions (bootstrap, CSS, preload, manifest resolution), the dev
  beacon stamp, and the production Vite `base` formula in `taujsBuild`
  (`entryPoint ? publicBasePath + '/' + entryPoint + '/' : publicBasePath + '/'` - with the
  default this reproduces today's formula byte-for-byte, so root compatibility holds by
  construction).
- **Static, tri-state respected**: the default registration rides the mounted scope;
  `staticAssets: false` remains the opt-out; a caller-supplied registration keeps its
  options untouched and composes with the mount as any nested Fastify plugin route does
  (`/cdn/` inside `/app` serves at `/app/cdn/`; host-root `/cdn/` = `staticAssets: false`
  plus a caller registration on the host).
- **Defaults are today's behaviour byte-for-byte** - the root-mounted baseline is an
  acceptance cell, not an aspiration.

## Evidence

`packages/server/src/test/MountAddressing.test.ts` - 29 cells: canonical validation
(including the frozen charset and the function-entry guarantee), preserve topology
(everything under the mount, caller untouched outside, wildcard under mount), strip-shape
emission (receive at root, emit under the public prefix), created-host confinement plus
unmounted byte-compat, root emission byte-compat, static composition with a meaningful
caller option proven working, and beacon composition. Plus seam regressions: the build
`base` proven installed at the `taujsBuild` assignment (root and named apps, custom and
default coordinates) and all three `loadAssets` emission maps proven to compose the
coordinate. Mutations verified on disk: removing the mount fails the preserve and
confinement cells; killing emission composition fails the strip-shape and emission cells.

## Release gate

Carries the completed-feature changeset (`@taujs/server` minor).
