### PR TITLE
feat(server): development addressing - derived dev Vite base and mount-domain confinement - RFC 0012 PR 2

### DIFF
--- a/.changeset/rfc-0012-non-root-base-paths.md
+++ b/.changeset/rfc-0012-non-root-base-paths.md
@@ -1,0 +1,28 @@
+---
+'@taujs/server': minor
+---
+
+feat(server): non-root base paths - installation-level mountPrefix and publicBasePath (RFC 0012)
+
+A taujs installation can now be mounted under a non-root prefix and addressed behind a
+reverse proxy, in both proxy topologies. Two new optional fields on the config server block:
+
+- `mountPrefix` - where Fastify RECEIVES the installation: one scope prefix under which every
+  declared route (all apps), taujs static and the development introspection surface register.
+- `publicBasePath` - what taujs EMITS in front of every URL it generates (asset, preload and
+  CSS links, the bootstrap module URL, the dev beacon) and what the Vite base derives from,
+  composed around the existing per-app entryPoint spelling. Defaults to `mountPrefix`; the
+  two differ exactly when the proxy STRIPS the public prefix before forwarding
+  (`mountPrefix: ''` with the public prefix declared here).
+
+Defaults are unchanged behaviour byte-for-byte. Coordinates are validated at function entry
+to a canonical form (`''` or `/segment(/segment)*`, URI-unreserved segment characters) and
+rejected, never silently normalised; explicit `publicBasePath: ''` alongside a non-empty
+mount is rejected as unsupported. On a taujs-created host the SPA fallback is confined to
+the mounted subtree, with an ordinary 404 outside it. Caller-supplied static registrations
+compose with the mount as normal Fastify nested routes; host-root static remains available
+via `staticAssets: false` plus a caller registration. In development, requests delegated to
+Vite are projected between the mount and public path spaces (pathname only, query preserved
+byte-exact), so module URLs and the HMR pathname compose correctly under a prefix. HMR
+socket origin and port under supervisors, and reverse-proxy host admission for the
+introspection endpoints, remain separate follow-ups.

--- a/.changeset/rfc-0012-non-root-base-paths.md
+++ b/.changeset/rfc-0012-non-root-base-paths.md
@@ -21,8 +21,9 @@ rejected, never silently normalised; explicit `publicBasePath: ''` alongside a n
 mount is rejected as unsupported. On a taujs-created host the SPA fallback is confined to
 the mounted subtree, with an ordinary 404 outside it. Caller-supplied static registrations
 compose with the mount as normal Fastify nested routes; host-root static remains available
-via `staticAssets: false` plus a caller registration. In development, requests delegated to
-Vite are projected between the mount and public path spaces (pathname only, query preserved
-byte-exact), so module URLs and the HMR pathname compose correctly under a prefix. HMR
+via `staticAssets: false` plus a caller registration. In development the shared Vite base
+derives from `publicBasePath`, carrying module URLs and the HMR pathname; Vite's middleware
+mode natively accepts both public-prefixed and proxy-stripped request paths, so taujs owns
+only the base derivation and the confinement of dev delegation to the mounted subtree. HMR
 socket origin and port under supervisors, and reverse-proxy host admission for the
 introspection endpoints, remain separate follow-ups.

--- a/packages/server/src/SSRServer.ts
+++ b/packages/server/src/SSRServer.ts
@@ -183,6 +183,11 @@ const installOwnedScope = async (scope: FastifyInstance, opts: SSRServerOptions,
       logger,
       devNet: opts.devNet,
       viteConfig: devViteConfig,
+      // RFC 0012 (PR 2): reception stays single-sourced from Fastify - the register-time
+      // prefix IS `scope.prefix` on the encapsulated registration; emission is the validated
+      // coordinate threaded from createServer.
+      mountPrefix: scope.prefix || '',
+      publicBasePath,
     });
 
     // RFC 0010: τjs creates the Vite server, so τjs closes it. Guarded because `onClose` can be

--- a/packages/server/src/test/DevAddressing.test.ts
+++ b/packages/server/src/test/DevAddressing.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment node
+/**
+ * RFC 0012 PR 2 acceptance - development addressing: the shared dev Vite base and the
+ * mount-domain confinement of the delegator, proven on SEPARATE strip and preserve real
+ * development boots (real Vite, real caller-owned host - the delegator's guarded arm; the
+ * owned-scope arm shares the same hook and `scope.prefix` sourcing).
+ *
+ * There is deliberately NO request-path rewriting to test: pinned Vite (7.3.6) middleware
+ * mode natively accepts BOTH public-prefixed and proxy-stripped request paths - its
+ * baseMiddleware answers a base mismatch with a plain `next()` into its own transform and
+ * static middlewares registered immediately after (dist/node/chunks/config.js, base
+ * mismatch fallthrough and middleware stack assembly). τjs owns exactly two dev
+ * transformations: the derived `base` (emission) and the mount-domain guard (confinement).
+ * These boots PIN that middleware contract: if a future Vite stops accepting stripped
+ * paths, the strip cells fail and the question comes back for review.
+ *
+ * Mutation standard: reverting the dev `base` derivation fails the page-HTML cells;
+ * reverting the mount-domain guard fails the out-of-mount cell (verified on disk).
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import fastify from 'fastify';
+
+import { CALLER_CSP, OWNER, PATHS, closeAll, developmentFixture, taujsConfig } from './support/hostOwnership';
+
+import type { FastifyInstance } from 'fastify';
+import type { TaujsConfig } from '../Config';
+
+afterEach(closeAll);
+
+// Real development boots. NODE_ENV is snapshotted at module evaluation (System.ts), so each
+// boot re-imports createServer under development, mirroring HostOwnershipDevelopment.test.ts.
+const loadDevelopmentCreateServer = async () => {
+  const original = process.env.NODE_ENV;
+  process.env.NODE_ENV = 'development';
+  vi.resetModules();
+
+  try {
+    return (await import('../CreateServer')).createServer;
+  } finally {
+    process.env.NODE_ENV = original;
+  }
+};
+
+const buildCallerHost = (): FastifyInstance => {
+  const app = fastify({ logger: false });
+
+  app.decorate('authenticate', async () => undefined);
+  app.addHook('onRequest', (_request, reply, done) => {
+    reply.header('Content-Security-Policy', CALLER_CSP);
+    done();
+  });
+  app.get(PATHS.callerBefore, async () => ({ owner: OWNER.callerBefore }));
+  app.setNotFoundHandler(async (_request, reply) => reply.status(404).type('application/json').send({ owner: OWNER.callerNotFound }));
+
+  return app;
+};
+
+const withServer = (server: NonNullable<TaujsConfig['server']>): TaujsConfig => ({ ...taujsConfig(), server });
+
+describe('RFC 0012 PR 2 - STRIP development evidence (mount "", publicBasePath "/pub")', () => {
+  it('serves stripped module URLs natively, emits public-space HTML, and falls through to the host', async () => {
+    const createServer = await loadDevelopmentCreateServer();
+    const { clientRoot } = await developmentFixture();
+    const app = buildCallerHost();
+
+    await createServer({ config: withServer({ publicBasePath: '/pub' }), fastify: app, clientRoot });
+
+    try {
+      // A STRIPPED module request arrives in root space; Vite (base '/pub/') accepts it
+      // natively - middleware mode falls a base mismatch through to its own transform
+      // middleware. This cell PINS that contract.
+      const module = await app.inject({ method: 'GET', url: '/app/entry-client.ts' });
+      expect(module.statusCode).toBe(200);
+      expect(String(module.headers['content-type'])).toContain('javascript');
+
+      // A query-carrying module request serves identically - nothing rewrites the URL.
+      const withQuery = await app.inject({ method: 'GET', url: '/app/entry-client.ts?import' });
+      expect(withQuery.statusCode).toBe(200);
+
+      // The served page emits PUBLIC-space URLs: Vite's own client via the derived base,
+      // and the τjs-generated bootstrap via publicBasePath.
+      const page = await app.inject({ method: 'GET', url: PATHS.taujsPage });
+      expect(page.statusCode).toBe(200);
+      expect(page.body).toContain('src="/pub/@vite/client"');
+      expect(page.body).toContain('src="/pub/app/entry-client.ts"');
+
+      // Fallthrough: a miss leaves Vite via next() and the CALLER's not-found answers -
+      // the delegation never captures the host.
+      const miss = await app.inject({ method: 'GET', url: '/no-such-page' });
+      expect(miss.statusCode).toBe(404);
+      expect(miss.body).toContain(OWNER.callerNotFound);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('RFC 0012 PR 2 - PRESERVE development evidence (mountPrefix "/mnt")', () => {
+  it('serves mount-space module URLs, emits mounted HTML, and confines the delegator to the subtree', async () => {
+    const createServer = await loadDevelopmentCreateServer();
+    const { clientRoot } = await developmentFixture();
+    const app = buildCallerHost();
+
+    await createServer({ config: withServer({ mountPrefix: '/mnt' }), fastify: app, clientRoot });
+
+    try {
+      // A PRESERVED module request arrives in mount space; Vite's base is '/mnt/', so its
+      // baseMiddleware strips and serves - the designed path.
+      const module = await app.inject({ method: 'GET', url: '/mnt/app/entry-client.ts' });
+      expect(module.statusCode).toBe(200);
+      expect(String(module.headers['content-type'])).toContain('javascript');
+
+      // The mounted page emits mount-space URLs throughout.
+      const page = await app.inject({ method: 'GET', url: `/mnt${PATHS.taujsPage}` });
+      expect(page.statusCode).toBe(200);
+      expect(page.body).toContain('src="/mnt/@vite/client"');
+      expect(page.body).toContain('src="/mnt/app/entry-client.ts"');
+
+      // MOUNT-DOMAIN GUARD: the same module URL OUTSIDE the mount never reaches Vite - the
+      // caller's own not-found answers. Reverting the guard serves JavaScript here (Vite
+      // would accept the stripped spelling natively), which is exactly the leak the guard
+      // exists to stop.
+      const outside = await app.inject({ method: 'GET', url: '/app/entry-client.ts' });
+      expect(outside.statusCode).toBe(404);
+      expect(outside.body).toContain(OWNER.callerNotFound);
+
+      // A miss INSIDE the mount still falls through to the caller.
+      const insideMiss = await app.inject({ method: 'GET', url: '/mnt/no-such-page' });
+      expect(insideMiss.statusCode).toBe(404);
+      expect(insideMiss.body).toContain(OWNER.callerNotFound);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/server/src/utils/DevServer.ts
+++ b/packages/server/src/utils/DevServer.ts
@@ -57,10 +57,27 @@ export type SetupDevServerOptions = {
    * `server.*` the fragment carries.
    */
   viteConfig?: InlineConfig;
+  /**
+   * RFC 0012 (PR 2): the installation's RECEPTION coordinate, single-sourced from Fastify
+   * (`scope.prefix` of the one τjs registration). When non-empty, the delegator's domain is
+   * CONFINED to the mounted subtree - outside the subtree is not τjs's to answer (the dev
+   * face of the frozen ownership contract). No request rewriting happens: pinned Vite's
+   * middleware mode natively accepts BOTH public-prefixed and proxy-stripped request paths
+   * (base mismatch → plain `next()` into its own transform/static middlewares).
+   */
+  mountPrefix?: string;
+  /**
+   * RFC 0012 (PR 2): the installation's validated EMISSION coordinate. Derives the shared dev
+   * Vite `base` (`publicBasePath + '/'`), which carries dev module URLs and the HMR socket
+   * PATHNAME.
+   */
+  publicBasePath?: string;
 };
 
 export const setupDevServer = async (options: SetupDevServerOptions): Promise<ViteDevServer> => {
   const { app, clientRoot: baseClientRoot, alias, declarativeAlias, projectRoot, debug, devNet, viteConfig } = options;
+  const mountPrefix = options.mountPrefix ?? '';
+  const publicBasePath = options.publicBasePath ?? '';
 
   const logger =
     options.logger ??
@@ -167,6 +184,11 @@ export const setupDevServer = async (options: SetupDevServerOptions): Promise<Vi
       alias: resolvedAlias,
     },
     root: baseClientRoot,
+    // RFC 0012 (PR 2): the shared dev base derives from the installation's emission coordinate,
+    // carrying dev module URLs AND the HMR socket PATHNAME with it. `''` yields `'/'` - Vite's
+    // own default, byte-compatible. A framework invariant like `root`: the engine already
+    // protects `base` from user layers in both profiles, and that ruling is unchanged.
+    base: `${publicBasePath}/`,
     // MERGE, never replace. Writing this object whole discarded every declared `server.*` field,
     // `allowedHosts` among them - so development behind a proxy presenting a non-localhost `Host`
     // was unreachable, with no supported way to allow it.
@@ -203,6 +225,18 @@ export const setupDevServer = async (options: SetupDevServerOptions): Promise<Vi
     // Classification is only meaningful on the caller-owned root delegator; the created-host path
     // stays exactly as it was, including never reading the request's route identity.
     if (callerOwnedRootDelegator && !request.is404 && selectedRouteFrom(request) === null) return;
+
+    // RFC 0012 (PR 2): when mounted, the delegator's DOMAIN is the mounted subtree - an
+    // out-of-mount URL is not τjs's to answer (frozen ownership contract), so it never
+    // reaches Vite and falls straight through to the host's own handling. No request
+    // rewriting: Vite's middleware mode accepts both public-prefixed and proxy-stripped
+    // paths natively, so mount-space URLs are delegated AS RECEIVED.
+    if (mountPrefix !== '') {
+      const rawUrl = request.raw.url ?? '';
+      const queryIndex = rawUrl.indexOf('?');
+      const pathname = queryIndex === -1 ? rawUrl : rawUrl.slice(0, queryIndex);
+      if (!(pathname === mountPrefix || pathname.startsWith(`${mountPrefix}/`))) return;
+    }
 
     await new Promise<void>((resolve) => {
       viteDevServer.middlewares(request.raw, reply.raw, () => {


### PR DESCRIPTION
Completes the non-root base-path feature (RFC 0012). PR 1 made a mounted τjs installation
routable and its emitted URLs correct in production; this PR does the same for development,
and it is deliberately small: **one derived value and one guard**. 

## What this adds

**The shared development Vite base derives from `publicBasePath`.**
The single dev Vite server now runs with `base: publicBasePath + '/'` (the root default
yields `'/'`, Vite's own default - byte-identical behaviour). This one value carries every
Vite-generated URL with it: `/@vite/client`, transformed module specifiers, and the HMR
socket *pathname*. Combined with PR 1's emission seams, a page served from a mounted or
proxied dev installation references only URLs a browser can actually reach.

**The delegator is confined to the mounted subtree.**
τjs's dev delegation hook hands unrouted requests to Vite. On a mounted installation an
out-of-mount URL is not τjs's to answer - and Vite would happily serve its stripped
spelling natively - so the hook now returns early for any pathname outside `mountPrefix`,
letting the host's own handling answer. This is the development face of the ownership
contract frozen in the RFC: one mounted installation never claims unrelated host URLs.

Reception stays single-sourced from Fastify: the guard reads the same `scope.prefix` the
mount registration created. No HMR socket work (origin, port and attachment remain with
`hmr-under-port-virtualisation`), and no new routing abstraction.

## What this deliberately does NOT add

No request rewriting. Vite's middleware mode **natively accepts both public-prefixed and proxy-stripped request paths** - its `baseMiddleware` answers a base mismatch with a plain `next()` into Vite's own
transform and static middlewares registered immediately after in the same stack. The strip and
preserve boot suites now PIN that middleware contract: if a future Vite stops accepting
stripped paths, those cells fail and the question returns for review.

## Evidence

`packages/server/src/test/DevAddressing.test.ts` - two REAL development boots (real Vite,
real caller-owned Fastify host), strip and preserve proven separately:

- **Strip** (`mountPrefix: ''`, `publicBasePath: '/pub'`): stripped module URLs serve
  (query-carrying included); the served page emits `/pub/@vite/client` and the `/pub/...`
  bootstrap; misses fall through to the caller's own not-found.
- **Preserve** (`mountPrefix: '/mnt'`): mount-space module URLs serve; the page emits
  `/mnt/...` throughout; an out-of-mount module URL gets the caller's 404, never Vite
  (reverting the guard serves JavaScript there - mutation-verified on disk); in-mount
  misses still fall through to the caller.

Mutation standard: reverting the base derivation fails the page-HTML cells; reverting the
guard fails the out-of-mount cell. Full workspace green on the combined head (typecheck +
tests, all packages, all fixtures including the real-browser playground suites).

## Release

Carries the completed-feature changeset (`@taujs/server` minor) describing the WHOLE
capability - PR 1 deliberately has none, so no partial feature can ever be described or
released from `main`. Ruled merge sequence: review both PRs, merge this into
`feat/rfc-0012-mount-emission`, run the final full check on that combined head, then merge
the completed PR 1 branch once into `main`.
