### PR TITLE
fix(server): SSR episodes classify from the socket - not the send handoff

### DIFF
--- a/.changeset/ssr-terminal-lifecycle.md
+++ b/.changeset/ssr-terminal-lifecycle.md
@@ -1,0 +1,10 @@
+---
+'@taujs/server': patch
+---
+
+fix(server): SSR episodes classify from the response lifecycle - `finish` on a healthy socket
+records `complete`, `finish` on a socket already destroyed or errored records `aborted`, a close
+before any terminal records `aborted` at the current stage, and a mid-delivery disconnect now logs
+a warning. Previously `sent` was recorded when `reply.send()` returned, so a partially delivered
+SSR response was recorded as a successful 200 with no disconnect log. Detection covers socket
+failure observed by the time `finish` runs; a failure the server never observes is not claimed.

--- a/packages/server/src/test/SsrResponseLifecycle.test.ts
+++ b/packages/server/src/test/SsrResponseLifecycle.test.ts
@@ -1,0 +1,340 @@
+// @vitest-environment node
+//
+// The SSR response terminal, on a real listener.
+//
+// `reply.send()` QUEUES a response and returns; it says nothing about what the response then does.
+// Recording delivery from that return classified an abandoned response as a successful 200 - a
+// client that received 130,896 of 12,582,912 bytes before disconnecting was recorded `complete`,
+// with no disconnect log anywhere in the record. Delivery itself was always correct; only the
+// RECORD was wrong.
+//
+// `finish` is not delivery either, and that was MEASURED here rather than assumed: on this buffered
+// arm the response emits `finish` even after the peer has reset, so a `finish`/`writableFinished`
+// discriminator classifies the abandoned response `complete`. What the peer did is visible only on
+// the SOCKET, so the arm captures it when its listeners install and classifies from it - destroyed
+// or errored at `finish` records `aborted`, healthy records `complete`.
+//
+// Cell 12 is the load-bearing control: a 12 MiB body read to completion by a THROTTLED client must
+// stay `complete`, or the socket check would merely be trading one wrong answer for another. Cell
+// 14 is the second: a client that FINs its write side and keeps reading is not a disconnect.
+//
+// Honest limitation, stated because the cells cannot cover it: this detects socket failure observed
+// by the time `finish` runs. A reset observed only afterwards is not retroactively classifiable,
+// and an abandonment further downstream - a proxy timing out behind us - is unswept.
+//
+// Everything here needs a real socket, one per leg (`agent: false` - a shared keep-alive socket
+// contaminates the trace). `inject()` cannot produce a mid-delivery disconnect, and a mocked reply
+// emits no response lifecycle at all - the unit-level half is in
+// `utils/test/HandleRenderRecorder.test.ts`.
+
+import http from 'node:http';
+import net from 'node:net';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import fastify from 'fastify';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createServer } from '../CreateServer';
+import { createDevIntrospection } from '../core/introspection/DevIntrospection';
+import { testRenderer } from './support/renderer';
+
+import type { FastifyInstance } from 'fastify';
+
+const PATHS = {
+  /** An ordinary SSR page, read to completion. */
+  ok: '/ssr-ok',
+  /** Its `data` is large enough that a client can leave mid-delivery - the measured shape. */
+  large: '/ssr-large',
+} as const;
+
+/** The measured body size: 12 MiB of data, serialised into the inline snapshot. */
+const LARGE_BYTES = 12 * 1024 * 1024;
+/** The measured disconnect point: the client reads roughly one buffer, then destroys the socket. */
+const ABORT_AFTER_BYTES = 64 * 1024;
+
+const DISCONNECT_WARNING = 'Client disconnected before the SSR response finished';
+
+const RENDER_MODULE = [
+  "const tag = Symbol.for('taujs.render-contract/v1');",
+  "const brand = (fn) => Object.defineProperty(fn, tag, { value: { key: 'test', contractVersion: 'v1' } });",
+  'export const renderSSR = brand(async () => ({ headContent: \'<meta name="probe" content="ssr">\', appHtml: \'<main>ssr</main>\' }));',
+  'export const renderStream = brand(() => ({ abort() {}, done: Promise.resolve() }));',
+].join('\n');
+
+const fixture = async (): Promise<{ root: string; clientRoot: string }> => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'taujs-ssr-lifecycle-'));
+  const clientRoot = path.join(root, 'client');
+  const appRoot = path.join(clientRoot, 'app');
+  const ssrRoot = path.join(root, 'ssr', 'app');
+
+  await mkdir(path.join(appRoot, '.vite'), { recursive: true });
+  await mkdir(path.join(appRoot, 'assets'), { recursive: true });
+  await mkdir(path.join(ssrRoot, '.vite'), { recursive: true });
+  await writeFile(path.join(root, 'package.json'), '{"type":"module"}\n');
+  await writeFile(path.join(appRoot, 'index.html'), '<!doctype html><html><head><!--ssr-head--></head><body><div id="app"><!--ssr-html--></div></body></html>');
+  await writeFile(path.join(appRoot, '.vite', 'manifest.json'), JSON.stringify({ 'entry-client.ts': { file: 'assets/client.js' } }));
+  await writeFile(path.join(appRoot, 'assets', 'client.js'), 'export const marker = "ssr-lifecycle";\n');
+  await writeFile(path.join(ssrRoot, '.vite', 'ssr-manifest.json'), '{}');
+  await writeFile(path.join(ssrRoot, 'entry-server.js'), RENDER_MODULE);
+
+  return { root, clientRoot };
+};
+
+const config = {
+  apps: [
+    {
+      appId: 'ssr-lifecycle',
+      entryPoint: 'app',
+      renderer: testRenderer(),
+      routes: [
+        { path: PATHS.ok, attr: { render: 'ssr' as const } },
+        // Built server-side rather than shipped in the fixture: the point is a body no socket
+        // buffer can absorb, so the client is demonstrably still reading when it leaves.
+        { path: PATHS.large, attr: { render: 'ssr' as const, data: async () => ({ blob: 'x'.repeat(LARGE_BYTES) }) } },
+      ],
+    },
+  ],
+} as never;
+
+type Wire = { status: number; body: string; errored: string | null };
+
+const read = (port: number, url: string, options: { abortAfterBytes?: number; slowRead?: boolean } = {}): Promise<Wire> =>
+  new Promise((resolve) => {
+    let body = '';
+    let aborted = false;
+
+    // `agent: false` - one socket per leg. A shared keep-alive socket carries one leg's reset into
+    // the next leg's trace, which is exactly how a socket-based discriminator would be mismeasured.
+    const request = http.get({ host: '127.0.0.1', port, path: url, agent: false }, (response) => {
+      const settle = (errored: string | null) => resolve({ status: response.statusCode ?? 0, body, errored });
+
+      response.setEncoding('utf8');
+      response.on('data', (chunk) => {
+        body += chunk;
+
+        if (options.abortAfterBytes && body.length >= options.abortAfterBytes && !aborted) {
+          aborted = true;
+          request.destroy();
+        }
+
+        // A client slow enough to force the server to wait on backpressure, which is what makes the
+        // large-body control a real control rather than a fast path that never stresses the socket.
+        if (options.slowRead) {
+          response.pause();
+          setTimeout(() => response.resume(), 2);
+        }
+      });
+      response.on('aborted', () => settle('aborted'));
+      response.on('error', (error) => settle(String(error.message)));
+      response.on('end', () => settle(null));
+    });
+
+    request.on('error', (error) => resolve({ status: 0, body, errored: String(error.message) }));
+  });
+
+/**
+ * A client that HALF-CLOSES: it sends the request, FINs its own write side, and keeps reading to
+ * the end. A raw socket is required - `http.request` will not half-close mid-exchange - and the
+ * point is that a FIN is not a disconnect: the peer is still there, still reading.
+ */
+const halfCloseRead = (port: number, url: string): Promise<Wire> =>
+  new Promise((resolve) => {
+    let raw = '';
+    const socket = net.connect(port, '127.0.0.1', () => {
+      socket.write(`GET ${url} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n`);
+    });
+
+    socket.setEncoding('utf8');
+    // FIN only once the response has started, so the request is demonstrably in flight rather than
+    // racing the server's parser.
+    socket.once('data', () => socket.end());
+    socket.on('data', (chunk) => {
+      raw += chunk;
+    });
+    socket.on('error', (error) => resolve({ status: 0, body: raw, errored: String(error.message) }));
+    socket.on('close', () => {
+      const split = raw.indexOf('\r\n\r\n');
+      const head = split === -1 ? raw : raw.slice(0, split);
+      const body = split === -1 ? '' : raw.slice(split + 4);
+
+      resolve({ status: Number(/^HTTP\/1\.\d (\d{3})/.exec(head)?.[1] ?? 0), body, errored: null });
+    });
+  });
+
+type TerminalCall = { terminal: 'sent' | 'aborted' | 'failed'; event: Record<string, unknown> };
+type Warning = { meta: Record<string, unknown>; message: string };
+
+type Host = {
+  port: number;
+  introspection: ReturnType<typeof createDevIntrospection>;
+  /** Terminal CALLS, so the latch is proved rather than the assembler's tolerance of a second one. */
+  terminals: TerminalCall[];
+  warnings: Warning[];
+  close: () => Promise<void>;
+};
+
+const open: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  await Promise.all(open.splice(0).map((close) => close()));
+});
+
+const boot = async (): Promise<Host> => {
+  const { root, clientRoot } = await fixture();
+  const app: FastifyInstance = fastify({ logger: false });
+  const introspection = createDevIntrospection({});
+  const terminals: TerminalCall[] = [];
+  const warnings: Warning[] = [];
+
+  for (const terminal of ['sent', 'failed', 'aborted'] as const) {
+    const original = introspection.recorder[terminal].bind(introspection.recorder);
+
+    (introspection.recorder as unknown as Record<string, unknown>)[terminal] = (event: Record<string, unknown>) => {
+      terminals.push({ terminal, event });
+
+      return original(event as never);
+    };
+  }
+
+  // An explicit logger is also what keeps the boot summaries out of the test output.
+  const logger = {
+    debug() {},
+    info() {},
+    warn(meta?: unknown, message?: string) {
+      warnings.push({ meta: (meta ?? {}) as Record<string, unknown>, message: message ?? '' });
+    },
+    error() {},
+  };
+
+  // The recorder rides the request context, which the τjs scope creates in its own `onRequest`; a
+  // ROOT `preHandler` therefore runs late enough to attach one.
+  app.addHook('preHandler', (request, _reply, done) => {
+    const context = (request as unknown as { taujsRequestContext?: { requestId: string; recorder?: unknown } }).taujsRequestContext;
+
+    if (context) {
+      context.recorder = introspection.recorder;
+      introspection.recorder.requestStart({ requestId: context.requestId, url: request.url, method: request.method });
+    }
+
+    done();
+  });
+
+  const close = async () => {
+    await app.close();
+    await rm(root, { recursive: true, force: true });
+  };
+
+  // Registered BEFORE anything that can throw, so a failure in `createServer` or `listen` cannot
+  // leak the Fastify instance and the temp directory for the rest of the run.
+  open.push(close);
+
+  await createServer({ config, fastify: app, clientRoot, logger });
+  await app.listen({ port: 0, host: '127.0.0.1' });
+
+  const address = app.server.address();
+
+  return { port: typeof address === 'object' && address !== null ? address.port : 0, introspection, terminals, warnings, close };
+};
+
+const episodesFor = (host: Host, url: string) => host.introspection.getEpisodes().filter((episode) => episode.url.pathname === url);
+
+const disconnectWarningsFor = (host: Host, url: string): Warning[] =>
+  host.warnings.filter((warning) => warning.message === DISCONNECT_WARNING && warning.meta.url === url);
+
+describe('SSR response lifecycle: the terminal is the socket, not the handoff (real listener)', () => {
+  it('11 (control): an ordinary SSR response read to completion records complete/200', { timeout: 30_000 }, async () => {
+    const host = await boot();
+    const wire = await read(host.port, PATHS.ok);
+
+    expect(wire.status).toBe(200);
+    expect(wire.body).toContain('<meta name="probe" content="ssr">');
+    expect(wire.body).toContain('<main>ssr</main>');
+    expect(wire.body).toContain('__INITIAL_DATA__');
+    expect(wire.errored).toBeNull();
+
+    await vi.waitFor(() => expect(episodesFor(host, PATHS.ok)).toHaveLength(1), { timeout: 5000 });
+
+    const episode = episodesFor(host, PATHS.ok)[0]!;
+
+    expect({ mode: episode.mode, outcome: episode.outcome, status: episode.status }).toEqual({ mode: 'ssr', outcome: 'complete', status: 200 });
+
+    // The ordinary close that follows a delivered response must not reclassify it, and must not log
+    // a disconnect. EVENT ORDERING plus the latch owns that - there is no `writableFinished` read.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(host.terminals.map((call) => call.terminal)).toEqual(['sent']);
+    expect(disconnectWarningsFor(host, PATHS.ok)).toHaveLength(0);
+    expect(episodesFor(host, PATHS.ok)[0]!.outcome).toBe('complete');
+  });
+
+  it('12 (the false-positive control): a 12 MiB body read to completion by a slow client stays complete', { timeout: 60_000 }, async () => {
+    const host = await boot();
+    const wire = await read(host.port, PATHS.large, { slowRead: true });
+
+    // EXACT, not "most of it". This leg is the one that would break if the socket check were
+    // over-eager: the same body and the same backpressure as the abandoned leg, but a client that
+    // stays. A discriminator that cannot keep this `complete` is not a fix.
+    expect(wire.status).toBe(200);
+    expect(wire.errored).toBeNull();
+    expect(wire.body.length).toBeGreaterThan(LARGE_BYTES);
+
+    await vi.waitFor(() => expect(episodesFor(host, PATHS.large)).toHaveLength(1), { timeout: 15_000 });
+
+    expect(episodesFor(host, PATHS.large)[0]!.outcome).toBe('complete');
+    expect(host.terminals.map((call) => call.terminal)).toEqual(['sent']);
+    expect(disconnectWarningsFor(host, PATHS.large)).toHaveLength(0);
+  });
+
+  it('13 (the defect): a client that RSTs mid-delivery records aborted, not complete', { timeout: 30_000 }, async () => {
+    const host = await boot();
+    const wire = await read(host.port, PATHS.large, { abortAfterBytes: ABORT_AFTER_BYTES });
+
+    // PARTIAL DELIVERY, measured rather than assumed: the client got some of the page and then
+    // left. This is the exact shape that used to be recorded as a successful 200.
+    expect(wire.errored).not.toBeNull();
+    expect(wire.body.length).toBeGreaterThanOrEqual(ABORT_AFTER_BYTES);
+    expect(wire.body.length).toBeLessThan(LARGE_BYTES);
+
+    await vi.waitFor(() => expect(episodesFor(host, PATHS.large)).toHaveLength(1), { timeout: 8000 });
+
+    const episode = episodesFor(host, PATHS.large)[0]!;
+
+    expect(episode.outcome).toBe('aborted');
+    expect(episode.outcome).not.toBe('complete');
+
+    // Stage preservation: the peer left after `reply.send()` handed off, so the phase is `send`.
+    // The pre-render/render/post-render arms keep the phases they already record.
+    expect(host.terminals.map((call) => call.terminal)).toEqual(['aborted']);
+    expect(host.terminals[0]!.event).toMatchObject({ phase: 'send' });
+
+    // The second half of the measured defect: the abandoned response produced no disconnect log at
+    // all, so nothing in the record hinted at it.
+    expect(disconnectWarningsFor(host, PATHS.large)).toHaveLength(1);
+
+    // Nothing arrives later to reclassify it or to add a second terminal.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(host.terminals.map((call) => call.terminal)).toEqual(['aborted']);
+    expect(episodesFor(host, PATHS.large)).toHaveLength(1);
+    expect(episodesFor(host, PATHS.large)[0]!.outcome).toBe('aborted');
+  });
+
+  it('14 (the half-close control): a client that FINs its write side and reads on stays complete', { timeout: 30_000 }, async () => {
+    const host = await boot();
+    const wire = await halfCloseRead(host.port, PATHS.ok);
+
+    // A FIN is not a disconnect. The peer has finished SENDING and is still reading, and it
+    // receives the whole response - so classifying it as abandoned would be a false positive of
+    // exactly the kind the socket check has to avoid.
+    expect(wire.status).toBe(200);
+    expect(wire.body).toContain('<main>ssr</main>');
+    expect(wire.body).toContain('__INITIAL_DATA__');
+    expect(wire.body.trimEnd().endsWith('</html>')).toBe(true);
+
+    await vi.waitFor(() => expect(episodesFor(host, PATHS.ok)).toHaveLength(1), { timeout: 8000 });
+
+    expect(episodesFor(host, PATHS.ok)[0]!.outcome).toBe('complete');
+    expect(host.terminals.map((call) => call.terminal)).toEqual(['sent']);
+    expect(disconnectWarningsFor(host, PATHS.ok)).toHaveLength(0);
+  });
+});

--- a/packages/server/src/utils/HandleRender.ts
+++ b/packages/server/src/utils/HandleRender.ts
@@ -158,6 +158,19 @@ export const handleRender = async (
   let finaliseStreamingResponse:
     ((arm: 'complete' | 'failed' | 'aborted', info?: { error?: unknown; phase?: 'render' | 'send' | 'stream' }) => void) | undefined;
 
+  /**
+   * The SSR response-terminal coordinator, hoisted for the same reason: the outer catch must not
+   * become a SECOND terminal owner. Set once the SSR branch installs it; `undefined` on the
+   * streaming path, and `undefined` on the SSR path for a throw that happens BEFORE the branch is
+   * reached, which is why the outer catch still keeps its direct arm.
+   */
+  let finaliseSsrResponse:
+    | ((
+        arm: 'complete' | 'failed' | 'aborted',
+        info?: { error?: unknown; kind?: string; phase?: 'pre-render' | 'render' | 'post-render' | 'send'; disconnect?: boolean },
+      ) => void)
+    | undefined;
+
   try {
     const url = req.url ? new URL(req.url, `http://${req.headers.host}`).pathname : '/';
 
@@ -349,17 +362,111 @@ export const handleRender = async (
       const ac = new AbortController();
       const onAborted = () => ac.abort('client_aborted');
 
+      /**
+       * The ONE SSR response-terminal coordinator - parallel in REACH to the streaming one, not in
+       * complexity. Cancellation OBSERVATIONS stay plural (request abort, response close, a
+       * τjs-observed failure); the terminal OWNER is singular and latched:
+       *
+       *   finish, captured socket healthy  -> sent(reply.raw.statusCode, ssr) -> complete
+       *   finish, captured socket dead     -> aborted('send') + warning        -> aborted
+       *   τjs-observed failure             -> failed(error)                    -> failed
+       *   close while the latch is open    -> aborted(current stage) + warning -> aborted
+       *
+       * `reply.send()` merely QUEUES a response, so recording delivery from its return classified
+       * an abandoned response as a successful 200. `finish` is not delivery either: it means the
+       * payload was handed to the operating system for transmission, NOT that the client received
+       * it (Node's documented `ServerResponse` contract), and on this BUFFERED arm it fires even
+       * after the peer has reset - measured. So the SOCKET is the discriminator, not the event.
+       */
+      let ssrFinalised = false;
+      /** How far the SSR arm got, so an abort keeps the phase it already reported. */
+      let ssrStage: 'pre-render' | 'render' | 'post-render' | 'send' = 'pre-render';
+
+      const finaliseSsrOnce = (
+        arm: 'complete' | 'failed' | 'aborted',
+        info: { error?: unknown; kind?: string; phase?: 'pre-render' | 'render' | 'post-render' | 'send'; disconnect?: boolean } = {},
+      ): void => {
+        if (ssrFinalised) return;
+        ssrFinalised = true;
+
+        // Release-first ordering, mirroring the streaming coordinator. `deferred` is created only
+        // in the streaming branch, so this is a deliberate no-op here; it keeps the outer catch's
+        // rewiring honest rather than making the ordering a streaming-only property.
+        try {
+          deferred?.release();
+        } catch {}
+
+        try {
+          if (arm === 'complete') {
+            recorder?.sent({ requestId, status: reply.raw.statusCode ?? 200, mode: 'ssr' });
+          } else if (arm === 'failed') {
+            // Each failing site keeps the kind it records today - 'send' for a send failure, the
+            // AppError kind (or 'internal') for a throw reaching the outer catch. Only the OWNER
+            // moved; the recorded classification did not.
+            recorder?.failed({
+              requestId,
+              error: {
+                kind: info.kind ?? (AppError.isAppError(info.error) ? (info.error as { kind: string }).kind : 'internal'),
+                message: safeErrorMessage(info.error),
+              },
+            });
+          } else {
+            recorder?.aborted({ requestId, phase: info.phase ?? ssrStage });
+          }
+        } catch {}
+
+        // Classification FIRST, warning second: a throwing logger must never prevent the terminal.
+        // The latch makes the warning exactly-once, and `disconnect` confines it to socket-observed
+        // aborts - the signal-abort sites keep their own existing log lines.
+        if (arm === 'aborted' && info.disconnect) {
+          try {
+            logger.warn({ url: req.url, phase: info.phase ?? ssrStage }, 'Client disconnected before the SSR response finished');
+          } catch {}
+        }
+      };
+
+      finaliseSsrResponse = finaliseSsrOnce;
+
+      // The response socket, captured HERE and never re-read: by `finish` time `reply.raw.socket`
+      // already reads null (measured), so the reference has to be taken as the listeners install.
+      const sock = reply.raw.socket;
+
       req.raw.on('aborted', onAborted);
       reply.raw.on('close', () => {
         if (!reply.raw.writableEnded) ac.abort('socket_closed');
+
+        // No guard: a close that follows a healthy `finish` is latched out by event ordering, and
+        // that ordering plus the latch is what owns normal finish-then-close. `writableFinished` is
+        // deliberately absent everywhere in this arm - it is measurably unsound in BOTH directions
+        // (true on a real mid-delivery reset, false on a healthy `inject()` response).
+        finaliseSsrOnce('aborted', { phase: ssrStage, disconnect: true });
       });
-      reply.raw.on('finish', () => req.raw.off('aborted', onAborted));
+      reply.raw.on('finish', () => {
+        req.raw.off('aborted', onAborted);
+
+        // The peer's departure is only visible on the SOCKET, so that is what decides the arm. An
+        // ABSENT socket is not by itself evidence of failure - it classifies `complete`, and a
+        // response already dead when the listeners attached is owned by the check below.
+        //
+        // HONEST LIMITATION: this detects socket failure OBSERVED BY THE TIME `finish` RUNS. A reset
+        // observed only after a healthy `finish` cannot be classified retroactively without claiming
+        // knowledge the server did not have, and an abandonment further downstream - a proxy timing
+        // out behind us - is not detectable here at all. Neither is claimed.
+        if (sock && (sock.destroyed || sock.errored)) finaliseSsrOnce('aborted', { phase: 'send', disconnect: true });
+        else finaliseSsrOnce('complete');
+      });
+
+      // A client can leave BEFORE this point: an awaiting host hook sits in front of the handler,
+      // and in development so does Vite's own module loading. `close` has then ALREADY been
+      // emitted, so the listeners above can never fire and nothing would classify the response. An
+      // event that already happened has to be observed by asking, not by listening.
+      if (reply.raw.destroyed) finaliseSsrOnce('aborted', { phase: ssrStage, disconnect: true });
 
       ctx.signal = ac.signal; // R1-01: propagate into the data context before fetching
 
       if (ac.signal.aborted) {
         logger.warn({ url: req.url }, 'SSR skipped; already aborted');
-        recorder?.aborted({ requestId, phase: 'pre-render' });
+        finaliseSsrOnce('aborted', { phase: 'pre-render' });
         return;
       }
 
@@ -370,13 +477,14 @@ export const handleRender = async (
       const headResolution = await resolveHeadData(ac.signal);
       if (headResolution.aborted) {
         logger.warn({ url: req.url }, 'SSR skipped; client disconnected during head data');
-        recorder?.aborted({ requestId, phase: 'pre-render' });
+        finaliseSsrOnce('aborted', { phase: 'pre-render' });
         return;
       }
 
       let headContent = '';
       let appHtml = '';
       try {
+        ssrStage = 'render';
         // RFC 0004: `headData` is present only when the route's head RESOLVED to a value -
         // conditional spread so no-head (and degraded) routes show no observable key.
         const res = await renderSSR(initialDataResolved, req.url!, attr?.meta, ac.signal, {
@@ -389,12 +497,13 @@ export const handleRender = async (
         });
         headContent = res.headContent;
         appHtml = res.appHtml;
+        ssrStage = 'post-render';
 
         logger.debug?.('ssr', {}, 'ssr data resolved');
 
         if (ac.signal.aborted) {
           logger.warn({}, 'SSR completed but client disconnected');
-          recorder?.aborted({ requestId, phase: 'post-render' });
+          finaliseSsrOnce('aborted', { phase: 'post-render' });
           return;
         }
       } catch (err) {
@@ -410,7 +519,7 @@ export const handleRender = async (
             },
             'SSR aborted mid-render (client disconnected)',
           );
-          recorder?.aborted({ requestId, phase: 'render' });
+          finaliseSsrOnce('aborted', { phase: 'render' });
           return;
         }
 
@@ -448,7 +557,9 @@ export const handleRender = async (
 
       try {
         const sendResult = reply.status(200).header('Content-Type', 'text/html').send(fullHtml);
-        recorder?.sent({ requestId, status: 200, mode: 'ssr' });
+        // HANDOFF, not delivery: `send()` queues the response and returns. Only the stage advances
+        // here - the terminal belongs to `finish` (or to a `close` that beats it).
+        ssrStage = 'send';
         return sendResult;
       } catch (err) {
         const msg = String((err as any)?.message ?? err ?? '');
@@ -457,10 +568,10 @@ export const handleRender = async (
 
         if (!benign) {
           logger.error({ url: req.url, error: safeNormaliseError(err) }, 'SSR send failed');
-          recorder?.failed({ requestId, error: { kind: 'send', message: msg } });
+          finaliseSsrOnce('failed', { error: err, kind: 'send' });
         } else {
           logger.warn({ url: req.url, reason: msg }, 'SSR send aborted (benign)');
-          recorder?.aborted({ requestId, phase: 'send' });
+          finaliseSsrOnce('aborted', { phase: 'send' });
         }
 
         return;
@@ -945,11 +1056,15 @@ export const handleRender = async (
     // RFC 0007: release FIRST, before any telemetry - a throwing recorder or logger must never
     // strand a started registry (this is the terminal a synchronous `renderStream` throw reaches).
     //
-    // ONE TERMINAL OWNER: when the streaming coordinator exists it owns both the release and the
-    // classification, and it is latched, so an error escaping to here cannot record a second
-    // terminal. The SSR path has no coordinator and keeps its own release plus telemetry.
+    // ONE TERMINAL OWNER: each strategy installs a latched coordinator that owns both the release
+    // and the classification, so an error escaping to here routes through whichever one exists and
+    // cannot record a second terminal - a render failure whose 500 response later emits `finish`
+    // stays `failed`. The final arm still covers a throw that happened BEFORE either branch was
+    // reached, which has no coordinator to route through.
     if (finaliseStreamingResponse) {
       finaliseStreamingResponse('failed', { error: err });
+    } else if (finaliseSsrResponse) {
+      finaliseSsrResponse('failed', { error: err });
     } else {
       try {
         deferred?.release();

--- a/packages/server/src/utils/test/HandleRenderRecorder.test.ts
+++ b/packages/server/src/utils/test/HandleRenderRecorder.test.ts
@@ -41,6 +41,12 @@ const mkReply = (): any => {
   const raw = new PassThrough() as any;
   raw.writeHead = vi.fn();
   raw.headersSent = false;
+  // A real `reply.raw` is a `ServerResponse`, and the response terminal reads its status at
+  // `finish`. Fastify sets it; the mock declares the same default so cells can change it.
+  raw.statusCode = 200;
+  // ...and it carries the SOCKET the terminal classifies from, captured when the SSR arm installs
+  // its listeners. The mock declares a healthy one; the cells that need a dead peer kill it.
+  raw.socket = { destroyed: false, errored: null };
   const reply: any = {
     raw,
     sent: [] as unknown[],
@@ -96,12 +102,69 @@ const runSSR = async (recorder?: EpisodeRecorder) => {
   return reply;
 };
 
+/**
+ * The response LIFECYCLE, driven by hand. `mkReply().raw` is a `PassThrough`, so it emits nothing
+ * on its own, and an SSR episode is finalised by the response's own events rather than by
+ * `reply.send()` returning - `send()` queues a response and says nothing about its delivery.
+ */
+const emitFinish = (reply: any): Promise<void> =>
+  new Promise<void>((resolve) => {
+    reply.raw.on('finish', () => resolve());
+    reply.raw.end();
+  });
+
+/** Premature termination: the socket closes with the response still unfinished. */
+const emitClose = (reply: any): void => {
+  reply.raw.emit('close');
+};
+
+type TerminalCall = { terminal: 'sent' | 'aborted' | 'failed'; event: Record<string, unknown> };
+
+/**
+ * Terminal CALLS, not merely finalised episodes: the assembler drops a second terminal silently, so
+ * counting the calls is what proves the LATCH rather than the assembler's tolerance. Same idiom as
+ * `test/StreamingTransport.test.ts`.
+ */
+const watchTerminals = (recorder: EpisodeRecorder): TerminalCall[] => {
+  const calls: TerminalCall[] = [];
+
+  for (const terminal of ['sent', 'aborted', 'failed'] as const) {
+    const original = recorder[terminal].bind(recorder);
+
+    (recorder as unknown as Record<string, unknown>)[terminal] = (event: Record<string, unknown>) => {
+      calls.push({ terminal, event });
+
+      return original(event as never);
+    };
+  }
+
+  return calls;
+};
+
+const DISCONNECT_WARNING = 'Client disconnected before the SSR response finished';
+
+const warningsFor = (logger: any, message: string): unknown[] => logger.warn.mock.calls.filter((call: unknown[]) => call[1] === message);
+
+/** One SSR request with its request-context logger exposed, so response-terminal logs are readable. */
+const ssrHarness = (recorder?: EpisodeRecorder, renderModule: unknown = renderSSRModule) => {
+  const logger = mkLogger();
+  const req = mkReq('/product/42', recorder);
+  req.taujsRequestContext.logger = logger;
+  const reply = mkReply();
+
+  return { req, reply, logger, run: () => handleRender(req, reply, ssrRoute as any, configs, {} as any, maps(renderModule), { logger: mkLogger() }) };
+};
+
 describe('handleRender recorder events (P0B-02 hook sites)', () => {
-  it('SSR happy path: routeMatched → dataFetch → sent(ssr, 200)', async () => {
+  it('SSR happy path: routeMatched → dataFetch → response finish → sent(ssr, 200)', async () => {
     const dev = createDevIntrospection();
     dev.recorder.requestStart({ requestId: T, url: '/product/42?ref=mail', method: 'GET' });
 
-    await runSSR(dev.recorder);
+    const reply = await runSSR(dev.recorder);
+    // REWRITTEN, not relocated: the assertions below are the original ones. What changed is the
+    // moment the episode finalises - the delivery terminal is the response's own `finish`, which a
+    // mocked reply only produces when it is driven.
+    await emitFinish(reply);
 
     const [episode] = dev.getEpisodes();
     expect(episode).toMatchObject({
@@ -153,6 +216,191 @@ describe('handleRender recorder events (P0B-02 hook sites)', () => {
 
     const [episode] = dev.getEpisodes();
     expect(episode).toMatchObject({ route: null, mode: 'fallthrough', outcome: 'complete', status: 200 });
+  });
+});
+
+// The first observable SSR terminal wins. `finish` is NOT delivery - it means the payload was
+// handed to the operating system, not that the client received it, and on this buffered arm it
+// fires even after the peer has reset (measured). So the terminal classifies from the SOCKET
+// captured when the listeners installed: dead socket at `finish` records `aborted`, healthy or
+// absent records `complete`. A `close` while the latch is open records `aborted` at the current
+// stage; a τjs-observed failure records `failed`. `writableFinished` appears nowhere - event
+// ordering plus the latch owns normal finish-then-close.
+//
+// These cells drive the lifecycle by hand. The real-socket half is in
+// `test/SsrResponseLifecycle.test.ts`; a healthy `inject()` producing no false disconnect is
+// guarded by `test/HostOwnership.test.ts`.
+describe('SSR response terminal: the first observable terminal wins', () => {
+  it('1: reply.send() returning does NOT record a terminal', async () => {
+    const dev = createDevIntrospection();
+    dev.recorder.requestStart({ requestId: T, url: '/product/42', method: 'GET' });
+    const terminals = watchTerminals(dev.recorder);
+    const harness = ssrHarness(dev.recorder);
+
+    await harness.run();
+
+    // The handler has handed a complete document to `send()` and returned. Nothing about the
+    // RESPONSE has been observed yet, so the episode has no terminal at all - this is precisely the
+    // moment that used to be recorded as a successful 200.
+    expect(harness.reply.sent).toHaveLength(1);
+    expect(terminals).toEqual([]);
+    expect(dev.getEpisodes()).toEqual([]);
+  });
+
+  it('2: finish on a HEALTHY captured socket records exactly one sent, using the final raw status', async () => {
+    const dev = createDevIntrospection();
+    dev.recorder.requestStart({ requestId: T, url: '/product/42', method: 'GET' });
+    const terminals = watchTerminals(dev.recorder);
+    const harness = ssrHarness(dev.recorder);
+
+    await harness.run();
+    // What the response actually carried, not what the handler asked for: a host hook may render an
+    // SSR page under a different status (a soft 404 is the ordinary case), and the record has to
+    // describe the wire.
+    harness.reply.raw.statusCode = 404;
+    await emitFinish(harness.reply);
+
+    expect(terminals.map((call) => call.terminal)).toEqual(['sent']);
+    expect(terminals[0]!.event).toMatchObject({ requestId: T, status: 404, mode: 'ssr' });
+    expect(dev.getEpisodes()[0]).toMatchObject({ outcome: 'complete', status: 404, mode: 'ssr' });
+  });
+
+  it('3: finish on a DESTROYED captured socket records one aborted at send plus one warning', async () => {
+    const dev = createDevIntrospection();
+    dev.recorder.requestStart({ requestId: T, url: '/product/42', method: 'GET' });
+    const terminals = watchTerminals(dev.recorder);
+    const harness = ssrHarness(dev.recorder);
+
+    await harness.run();
+    // The peer left while the payload was still going out. `finish` fires anyway - that is Node's
+    // contract, and it is why the socket rather than the event decides the arm.
+    harness.reply.raw.socket.destroyed = true;
+    await emitFinish(harness.reply);
+
+    expect(terminals.map((call) => call.terminal)).toEqual(['aborted']);
+    expect(terminals[0]!.event).toMatchObject({ requestId: T, phase: 'send' });
+    expect(dev.getEpisodes()[0]).toMatchObject({ outcome: 'aborted' });
+    expect(warningsFor(harness.logger, DISCONNECT_WARNING)).toHaveLength(1);
+  });
+
+  it('3b: finish on an ERRORED captured socket is classified the same way', async () => {
+    const dev = createDevIntrospection();
+    dev.recorder.requestStart({ requestId: T, url: '/product/42', method: 'GET' });
+    const terminals = watchTerminals(dev.recorder);
+    const harness = ssrHarness(dev.recorder);
+
+    await harness.run();
+    // The measured shape leaves ECONNRESET on the socket in the same tick as `finish`; a socket
+    // that errored is as dead as one already destroyed.
+    harness.reply.raw.socket.errored = Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' });
+    await emitFinish(harness.reply);
+
+    expect(terminals.map((call) => call.terminal)).toEqual(['aborted']);
+    expect(terminals[0]!.event).toMatchObject({ phase: 'send' });
+    expect(warningsFor(harness.logger, DISCONNECT_WARNING)).toHaveLength(1);
+  });
+
+  it('4: a close while the latch is open records one aborted at the CURRENT stage, and a later finish is latched out', async () => {
+    const dev = createDevIntrospection();
+    dev.recorder.requestStart({ requestId: T, url: '/product/42', method: 'GET' });
+    const terminals = watchTerminals(dev.recorder);
+    const harness = ssrHarness(dev.recorder);
+
+    await harness.run();
+    emitClose(harness.reply);
+    await emitFinish(harness.reply);
+
+    // The stage is `send` because the close arrived after the handoff; the phase is preserved
+    // rather than blanket-reported, so the earlier arms keep the phases they already record. The
+    // measured defect was TWO-fold - the episode said `complete`, and nothing else in the record
+    // hinted that the response had been abandoned - so the warning is part of the cell.
+    expect(terminals.map((call) => call.terminal)).toEqual(['aborted']);
+    expect(terminals[0]!.event).toMatchObject({ requestId: T, phase: 'send' });
+    expect(dev.getEpisodes()[0]).toMatchObject({ outcome: 'aborted' });
+    expect(warningsFor(harness.logger, DISCONNECT_WARNING)).toHaveLength(1);
+  });
+
+  it('5: finish followed by close remains complete - no aborted terminal, no warning', async () => {
+    const dev = createDevIntrospection();
+    dev.recorder.requestStart({ requestId: T, url: '/product/42', method: 'GET' });
+    const terminals = watchTerminals(dev.recorder);
+    const harness = ssrHarness(dev.recorder);
+
+    await harness.run();
+    await emitFinish(harness.reply);
+    emitClose(harness.reply);
+
+    // Every response closes eventually. EVENT ORDERING plus the latch is what stops the ordinary
+    // close that follows a successful delivery from reclassifying it - there is no
+    // `writableFinished` guard here, because that read is unsound in both directions.
+    expect(terminals.map((call) => call.terminal)).toEqual(['sent']);
+    expect(dev.getEpisodes()[0]).toMatchObject({ outcome: 'complete' });
+    expect(warningsFor(harness.logger, DISCONNECT_WARNING)).toHaveLength(0);
+  });
+
+  it('6: a response already destroyed when the listeners attach records one aborted plus one warning', async () => {
+    const dev = createDevIntrospection();
+    dev.recorder.requestStart({ requestId: T, url: '/product/42', method: 'GET' });
+    const terminals = watchTerminals(dev.recorder);
+    const harness = ssrHarness(dev.recorder);
+
+    // The client left while a host hook - or, in development, Vite's module loading - was still
+    // awaiting in front of the handler. `close` has already been emitted, so no listener attached
+    // afterwards can ever fire: the event has to be observed by asking, not by listening.
+    harness.reply.raw.destroy();
+    await harness.run();
+
+    expect(terminals.map((call) => call.terminal)).toEqual(['aborted']);
+    expect(terminals[0]!.event).toMatchObject({ phase: 'pre-render' });
+    expect(dev.getEpisodes()[0]).toMatchObject({ outcome: 'aborted' });
+    expect(warningsFor(harness.logger, DISCONNECT_WARNING)).toHaveLength(1);
+  });
+
+  it('7: a close followed by a signal-abort branch still records exactly ONE aborted terminal', async () => {
+    const dev = createDevIntrospection();
+    dev.recorder.requestStart({ requestId: T, url: '/product/42', method: 'GET' });
+    const terminals = watchTerminals(dev.recorder);
+    let harness: ReturnType<typeof ssrHarness>;
+
+    // The socket closes DURING the render, so the close arm classifies at stage `render` and the
+    // post-render signal check then reaches its own abort site. Two observations, one owner.
+    const closingModule = {
+      renderSSR: vi.fn(async () => {
+        emitClose(harness.reply);
+        return { headContent: '', appHtml: '<div>app</div>' };
+      }),
+    };
+
+    harness = ssrHarness(dev.recorder, closingModule);
+    await harness.run();
+
+    expect(terminals.map((call) => call.terminal)).toEqual(['aborted']);
+    expect(terminals[0]!.event).toMatchObject({ phase: 'render' });
+    expect(dev.getEpisodes()[0]).toMatchObject({ outcome: 'aborted' });
+
+    // The signal-abort site keeps its own log line - only the TERMINAL is latched, not the arm's
+    // existing diagnostics.
+    expect(warningsFor(harness.logger, 'SSR completed but client disconnected')).toHaveLength(1);
+    expect(warningsFor(harness.logger, DISCONNECT_WARNING)).toHaveLength(1);
+  });
+
+  it('8: a render failure followed by finish and close records exactly ONE failed terminal', async () => {
+    const dev = createDevIntrospection();
+    dev.recorder.requestStart({ requestId: T, url: '/product/42', method: 'GET' });
+    const terminals = watchTerminals(dev.recorder);
+    const failingModule = { renderSSR: vi.fn(async () => Promise.reject(new Error('render exploded'))) };
+    const harness = ssrHarness(dev.recorder, failingModule);
+
+    await expect(harness.run()).rejects.toThrow();
+    // Fastify's error response finishes normally afterwards. The latch is what stops that `finish`
+    // from adding a `sent` on top of a failure the outer catch already owns.
+    await emitFinish(harness.reply);
+    emitClose(harness.reply);
+
+    expect(terminals.map((call) => call.terminal)).toEqual(['failed']);
+    expect(dev.getEpisodes()[0]).toMatchObject({ outcome: 'failed' });
+    expect(dev.getEpisodes()[0]!.error!.message).toContain('render exploded');
+    expect(warningsFor(harness.logger, DISCONNECT_WARNING)).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
`reply.send()` queues a response and returns, so recording `sent` at that moment classified an abandoned delivery as a successful 200 - measured, a client that received 130,925 of 12,583,188 bytes before resetting, with no disconnect log anywhere in the record.

`finish` is not delivery either. On the buffered SSR arm it fires even after the peer has reset (`writableFinished` true), and under `inject()` it fires with `writableFinished` false on a healthy response - unsound in both directions, so that read appears nowhere. The response socket is captured when the SSR listeners install and decides the arm: destroyed or errored at `finish` records `aborted` at stage `send` plus a disconnect warning, healthy or absent records `complete` with `reply.raw.statusCode`. Event ordering plus the latch owns normal finish-then-close.

All seven SSR terminal sites route through one hoisted, latched `finaliseSsrResponse`, including the outer catch, so a render failure whose 500 response later emits `finish` stays `failed`. The SSR stage is tracked (`pre-render` -> `render` -> `post-render` -> `send`) and a close while the latch is open records `aborted` at the current stage, so the existing phases are byte-preserved and the SC-07 episode vocabulary is unchanged.

Detection covers socket failure observed by the time `finish` runs. A reset observed only after a healthy `finish`, or an abandonment further downstream such as a proxy timing out behind us, is not detectable here and is not claimed.