### PR TITLE
feat(server): declared host admission for development introspection

### DIFF
--- a/.changeset/introspection-allowed-hosts.md
+++ b/.changeset/introspection-allowed-hosts.md
@@ -1,0 +1,26 @@
+---
+'@taujs/server': minor
+---
+
+feat(server): declared host admission for the development introspection surface
+
+Adds `introspection.allowedHosts?: string[]` (post-freeze ruling 2026-08-08 on the
+introspection security model), so development behind a reverse proxy that presents a
+non-localhost `Host` can admit the proxy's hostname to the `/__taujs/*` overlay endpoints
+and the hydration beacon. Without a declaration the behaviour is unchanged: localhost-only.
+
+Entries are exact DNS hostnames - no wildcards, IP literals, schemes, ports or paths - and
+matching is case-insensitive, ignoring the request port; subdomains are never implied.
+Invalid entries are rejected at `createServer` entry in EVERY mode, before any host state
+exists, so a shared configuration cannot hide a typo in production. `localhost`,
+`*.localhost` and IP-literal hosts remain admitted intrinsically.
+
+The admission extends only the `Host` check. The remote-address guard
+(`introspection.allowNonLoopback`), the per-boot token and production absence are unchanged,
+and neither flag implies the other: a same-host gateway needs only `allowedHosts`, a proxy
+on another machine needs both. Behind a rewriting proxy τjs sees only the declared upstream
+hostname and reads no forwarding headers, so browser-facing host validation belongs to the
+proxy - a non-empty declaration shouts exactly that in the boot summary, and the first
+refusal of an undeclared hostname logs a warning naming the field instead of failing
+silently. Declare the hostname as seen at the τjs hop: a rewriting proxy substitutes its
+upstream name (behind a Platformatic gateway, `web.plt.local`, not the public host).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 | [`@taujs/server`](packages/server)             | Fastify plugin & render orchestration - CSR / SSR / Streaming SSR for SPA, MPA, and build‑time micro‑frontends (MFE). Vite HMR + tsx in dev.      |
 | [`@taujs/react`](packages/react)               | React renderer: CSR, SSR, Streaming SSR. Standalone and runtime‑agnostic.                                                                         |
 | [`@taujs/vue`](packages/vue)                   | Vue renderer: CSR, SSR, Streaming SSR. Standalone and runtime‑agnostic.                                                                           |
-| [`@taujs/solid`](packages/solid)               | Solid renderer: CSR, SSR and Streaming SSR. Standalone or integrated with τjs.                                                                    |
+| [`@taujs/solid`](packages/solid)               | Solid renderer: CSR, SSR and Streaming SSR. Standalone and runtime‑agnostic.                                                                      |
 | [`@taujs/mcp`](packages/mcp)                   | MCP server for AI agents: reads the dev‑emitted request graph and live request episodes (filesystem‑only stdio adapter). Wired by the scaffolder. |
 
 Current versions are shown by the badges above.

--- a/packages/server/src/CreateServer.ts
+++ b/packages/server/src/CreateServer.ts
@@ -5,7 +5,14 @@ import { performance } from 'node:perf_hooks';
 import Fastify from 'fastify';
 import pc from 'picocolors';
 
-import { extractBuildConfigs, extractPathCoordinates, extractRoutes, extractSecurity, resolveHmrTransport } from './core/config/Setup';
+import {
+  extractBuildConfigs,
+  extractPathCoordinates,
+  extractRoutes,
+  extractSecurity,
+  resolveHmrTransport,
+  resolveIntrospectionAllowedHosts,
+} from './core/config/Setup';
 import { REGEX } from './core/constants';
 import { normaliseError } from './core/errors/AppError';
 
@@ -87,6 +94,12 @@ export const createServer = async (opts: CreateServerOptions): Promise<CreateSer
   // deployment sharing one configuration must still boot.
   const hmrTransport = resolveHmrTransport(opts.config, callerOwnedHost, isDevelopment);
 
+  // Post-freeze ruling 2026-08-08 (introspection host admission): resolved at FUNCTION ENTRY in
+  // EVERY mode for the same reason the coordinates above are - an invalid declaration must fail
+  // before any host state exists, and production must reject the typo a shared configuration
+  // would otherwise hide, even though the surface it admits is structurally dev-absent.
+  const introspectionAllowedHosts = resolveIntrospectionAllowedHosts(opts.config);
+
   // SC-09 ruling 4: on a τjs-created host, request identity aligns at Fastify construction - the
   // one place τjs legitimately owns that policy. A single valid inbound `x-request-id` becomes
   // `req.id`; anything else gets a UUID (repeated headers arrive as an array and fail the string
@@ -158,6 +171,16 @@ export const createServer = async (opts: CreateServerOptions): Promise<CreateSer
     logger.warn({ component: 'introspection' }, 'τjs introspection overlay exposed to non-loopback clients. For trusted dev networks only.');
   }
 
+  // Post-freeze ruling 2026-08-08: admitting extra hostnames shouts for the same reason -
+  // wording FROZEN at review; the resolved hosts travel as structured metadata, never
+  // interpolated text. Development-only, like the surface the declaration admits.
+  if (isDevelopment && introspectionAllowedHosts.size > 0) {
+    logger.warn(
+      { component: 'introspection', allowedHosts: [...introspectionAllowedHosts] },
+      'τjs introspection overlay admits additional hostnames. Ensure any rewriting proxy validates the browser-facing Host; otherwise use a trusted development network only.',
+    );
+  }
+
   const report = verifyContracts(
     app,
     routes,
@@ -203,6 +226,7 @@ export const createServer = async (opts: CreateServerOptions): Promise<CreateSer
       security,
       devNet: { host: net.host, hmrPort: net.hmrPort },
       taujsConfig: opts.config,
+      introspectionAllowedHosts,
       // RFC 0010: the single caller-root exception, and the only value that reaches the plugin from
       // the caller's instance. Vite must observe development URLs Fastify did not route, which only
       // a root-level hook sees. Withheld unless the caller owns the host AND we are in development,

--- a/packages/server/src/SSRServer.ts
+++ b/packages/server/src/SSRServer.ts
@@ -214,7 +214,13 @@ const installOwnedScope = async (scope: FastifyInstance, opts: SSRServerOptions,
 
       scope.decorate('taujsIntrospection', introspection);
       registerDevFiles(scope, introspection, logger);
-      registerIntrospectionEndpoints(scope, { introspection, taujsConfig: opts.taujsConfig, serviceRegistry, logger });
+      registerIntrospectionEndpoints(scope, {
+        introspection,
+        taujsConfig: opts.taujsConfig,
+        allowedHosts: opts.introspectionAllowedHosts,
+        serviceRegistry,
+        logger,
+      });
     } catch (err) {
       logger.warn({ component: 'introspection', error: (err as Error)?.message ?? String(err) }, 'Episode recording unavailable (non-fatal)');
     }

--- a/packages/server/src/core/config/Setup.ts
+++ b/packages/server/src/core/config/Setup.ts
@@ -1,3 +1,5 @@
+import { isIP } from 'node:net';
+
 import { RENDERTYPE } from '../constants';
 import { now } from '../telemetry/Telemetry';
 
@@ -96,6 +98,81 @@ export const resolveHmrTransport = (config: Pick<CoreTaujsConfig, 'server'>, cal
   }
 
   return declared;
+};
+
+/**
+ * Post-freeze ruling 2026-08-08 (docs/introspection/decisions.md): the exact-DNS-hostname
+ * grammar for `introspection.allowedHosts`. Dot-separated labels of `[a-z0-9-]` with no
+ * leading/trailing hyphen - which structurally excludes schemes, ports, paths, leading dots,
+ * wildcards and whitespace. Deliberately ASCII-only: an internationalised name is declared in
+ * its punycode form, the same spelling the guard's `URL`-parsed request hostname carries.
+ */
+const INTROSPECTION_HOSTNAME = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/;
+
+/**
+ * Post-freeze ruling 2026-08-08: validate and resolve the introspection host admissions.
+ * Exact DNS hostnames only; comparison is case-insensitive (DNS semantics, not value
+ * normalisation), so entries resolve ONCE to a lowercase exact-match set here and the guard
+ * never re-derives it. Called at `createServer` FUNCTION ENTRY in EVERY mode - the surface
+ * this admits is structurally dev-absent, but a shared configuration must not hide a typo in
+ * production. IP literals are rejected as not-DNS-hostnames: the guard admits them
+ * intrinsically, so a declared one is a misunderstanding worth surfacing, not extending.
+ */
+const ipLiteralEntryError = (entry: string): Error =>
+  new Error(`introspection.allowedHosts: '${entry}' is an IP literal, not a DNS hostname - IP literals are admitted intrinsically; remove the entry.`);
+
+export const resolveIntrospectionAllowedHosts = (config: Pick<CoreTaujsConfig, 'introspection'>): ReadonlySet<string> => {
+  const declared = config.introspection?.allowedHosts;
+  if (declared === undefined) return new Set();
+
+  if (!Array.isArray(declared)) throw new Error('introspection.allowedHosts must be an array of exact DNS hostnames');
+
+  const resolved = new Set<string>();
+
+  for (const entry of declared) {
+    if (typeof entry !== 'string') throw new Error('introspection.allowedHosts: entries must be strings (exact DNS hostnames)');
+
+    const hostname = entry.toLowerCase();
+
+    // IP detection FIRST, and decided against the SAME parser the guard compares with
+    // (final-review amendment 2026-08-08): `isIP` on the bracket-stripped form catches
+    // dotted-quads and bare/bracketed IPv6 before the grammar can misreport them with a
+    // spelling complaint, and the URL canonicalisation below catches the WHATWG IPv4
+    // spellings (`127.1`, decimal, octal, hex) the request side collapses to a dotted-quad.
+    // Every IP form receives the intrinsic remedy, never the grammar error.
+    const bare = hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+    if (isIP(bare) !== 0) throw ipLiteralEntryError(entry);
+
+    if (!INTROSPECTION_HOSTNAME.test(hostname)) {
+      throw new Error(
+        `introspection.allowedHosts: '${entry}' is not an exact DNS hostname. Expected dot-separated labels of [a-z0-9-] - ` +
+          `no scheme, port, path, leading dot, wildcard or whitespace. Values are rejected, never normalised.`,
+      );
+    }
+
+    // The guard compares URL-parsed request hostnames, so an entry this parser does not read
+    // back verbatim can never match a request: either an IPv4 spelling in disguise (remedy)
+    // or not a parseable host at all (out-of-range numeric labels, for example).
+    let canonical: string;
+    try {
+      canonical = new URL(`http://${hostname}`).hostname;
+    } catch {
+      throw new Error(`introspection.allowedHosts: '${entry}' is not a hostname the URL host parser accepts. Values are rejected, never normalised.`);
+    }
+
+    if (isIP(canonical) !== 0) throw ipLiteralEntryError(entry);
+
+    if (canonical !== hostname) {
+      throw new Error(
+        `introspection.allowedHosts: '${entry}' does not survive URL host parsing verbatim (it parses as '${canonical}') so it could never match a ` +
+          `request. Declare the parsed spelling instead. Values are rejected, never normalised.`,
+      );
+    }
+
+    resolved.add(hostname);
+  }
+
+  return resolved;
 };
 
 /**

--- a/packages/server/src/core/config/types.ts
+++ b/packages/server/src/core/config/types.ts
@@ -287,6 +287,17 @@ export type CoreAppConfig = {
 export type CoreIntrospectionConfig = {
   /** Relaxes ONLY the overlay remote-address check; shouts in the boot summary when enabled. */
   allowNonLoopback?: boolean;
+  /**
+   * Extends ONLY the overlay Host admission with exact DNS hostnames (post-freeze ruling
+   * 2026-08-08) - for development behind a reverse proxy that presents a non-localhost `Host`.
+   * Declare the hostname as seen AT the τjs hop: a rewriting proxy substitutes its own
+   * upstream name for the browser-facing one. Exact matches only - no wildcards, IP literals
+   * or boolean escape; localhost forms and IP literals stay admitted intrinsically. Behind a
+   * rewriting proxy, browser-facing host validation is the PROXY's job - τjs reads no
+   * forwarding headers. Independent of `allowNonLoopback` (a cross-machine proxy needs both);
+   * neither implies the other. Shouts in the boot summary when non-empty.
+   */
+  allowedHosts?: string[];
   redaction?: {
     /** Extends the default denylist (password, token, secret, ssn, auth, cookie, session, key). */
     denyKeys?: string[];

--- a/packages/server/src/core/introspection/DevEndpoints.ts
+++ b/packages/server/src/core/introspection/DevEndpoints.ts
@@ -19,25 +19,39 @@ const isLoopback = (address: string | undefined): boolean => !!address && (addre
 // Host validation neutralises DNS rebinding: an attack needs a DNS *name* resolving to the
 // dev machine, so names other than localhost are rejected while IP-literal hosts (the
 // phone-on-LAN case behind allowNonLoopback) pass — an IP literal cannot be rebound.
-const isAllowedHost = (hostHeader: string | undefined): boolean => {
-  if (!hostHeader) return false;
+//
+// Post-freeze ruling 2026-08-08: declared admissions (`introspection.allowedHosts`, resolved
+// and validated at createServer entry) EXTEND the intrinsic set for development behind a
+// Host-rewriting proxy. Exact matching preserves the direct-listener rebinding guard; behind
+// such a proxy τjs sees only the declared upstream name, so browser-facing host admission is
+// DELEGATED to the proxy — τjs reads no forwarding headers.
+const parseHostname = (hostHeader: string | undefined): string | undefined => {
+  if (!hostHeader) return undefined;
 
-  let hostname: string;
   try {
-    hostname = new URL(`http://${hostHeader}`).hostname;
+    // URL parsing case-folds the hostname and drops the port, so the declared lowercase set
+    // compares against a canonical form without any per-site handling here.
+    return new URL(`http://${hostHeader}`).hostname;
   } catch {
-    return false;
+    return undefined;
   }
+};
 
+const isAllowedHost = (hostname: string, allowedHosts: ReadonlySet<string>): boolean => {
   const bare = hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
 
-  return bare === 'localhost' || bare.endsWith('.localhost') || isIP(bare) !== 0;
+  return bare === 'localhost' || bare.endsWith('.localhost') || isIP(bare) !== 0 || allowedHosts.has(bare);
 };
 
 export type IntrospectionEndpointsOptions = {
   introspection: DevIntrospection;
   serviceRegistry?: ServiceRegistry;
   taujsConfig?: CoreTaujsConfig;
+  /**
+   * Resolved lowercase exact-match host admissions (post-freeze ruling 2026-08-08), validated
+   * at `createServer` entry and never re-derived here. Intrinsic admissions always apply.
+   */
+  allowedHosts?: ReadonlySet<string>;
   logger: Logs;
 };
 
@@ -48,10 +62,38 @@ export type IntrospectionEndpointsOptions = {
 export const registerIntrospectionEndpoints = (app: FastifyInstance, options: IntrospectionEndpointsOptions): void => {
   const { introspection, taujsConfig, serviceRegistry, logger } = options;
   const allowNonLoopback = taujsConfig?.introspection?.allowNonLoopback === true;
+  const allowedHosts = options.allowedHosts ?? new Set<string>();
+
+  // The measured failure mode (RFC 0012 leg D2) is a proxied development topology whose
+  // beacons die silently, so the FIRST undeclared-hostname refusal warns; repeats log at
+  // debug (one boolean latch per boot - flood-safe by construction). The hostname is
+  // attacker-influenced text, so it travels as structured metadata, never interpolated into
+  // the message. Malformed or missing Host values stay debug-only and never consume the latch.
+  let undeclaredHostWarned = false;
 
   const guard = async (req: FastifyRequest, reply: FastifyReply): Promise<FastifyReply | undefined> => {
     if (!allowNonLoopback && !isLoopback(req.socket.remoteAddress)) return reply.code(403).send({ error: 'loopback_only' });
-    if (!isAllowedHost(req.headers.host)) return reply.code(403).send({ error: 'invalid_host' });
+
+    const hostname = parseHostname(req.headers.host);
+
+    if (hostname === undefined) {
+      logger.debug?.({ component: 'introspection' }, 'τjs introspection rejected a malformed or missing Host');
+      return reply.code(403).send({ error: 'invalid_host' });
+    }
+
+    if (!isAllowedHost(hostname, allowedHosts)) {
+      if (!undeclaredHostWarned) {
+        undeclaredHostWarned = true;
+        logger.warn(
+          { component: 'introspection', host: hostname },
+          'τjs introspection rejected an undeclared Host. If this is a trusted development proxy, declare it in introspection.allowedHosts.',
+        );
+      } else {
+        logger.debug?.({ component: 'introspection', host: hostname }, 'τjs introspection rejected an undeclared Host');
+      }
+      return reply.code(403).send({ error: 'invalid_host' });
+    }
+
     if (req.headers['x-taujs-token'] !== introspection.token) return reply.code(403).send({ error: 'invalid_token' });
     return undefined;
   };

--- a/packages/server/src/core/introspection/test/DevEndpointsFiles.test.ts
+++ b/packages/server/src/core/introspection/test/DevEndpointsFiles.test.ts
@@ -23,11 +23,11 @@ const mkLogger = (): any => {
   return l;
 };
 
-const buildApp = async (opts?: { taujsConfig?: CoreTaujsConfig; introspection?: DevIntrospection }) => {
+const buildApp = async (opts?: { taujsConfig?: CoreTaujsConfig; introspection?: DevIntrospection; allowedHosts?: ReadonlySet<string> }) => {
   const introspection = opts?.introspection ?? createDevIntrospection();
   const app = fastify();
   const logger = mkLogger();
-  registerIntrospectionEndpoints(app, { introspection, taujsConfig: opts?.taujsConfig ?? config, logger });
+  registerIntrospectionEndpoints(app, { introspection, taujsConfig: opts?.taujsConfig ?? config, allowedHosts: opts?.allowedHosts, logger });
   return { app, introspection, logger };
 };
 
@@ -111,6 +111,97 @@ describe('overlay endpoint guard stack (spec 03 §6, guard order)', () => {
       });
       expect(res.statusCode, host).toBe(200);
     }
+  });
+});
+
+// Post-freeze ruling 2026-08-08 (docs/introspection/decisions.md): declared host admissions
+// for proxied development. The set arrives resolved (lowercase, validated at createServer
+// entry); these cells prove exact-match semantics, guard independence, and the warn-once
+// rejection logging at the point of measured failure.
+describe('declared host admissions (post-freeze ruling 2026-08-08)', () => {
+  const DECLARED = new Set(['web.plt.local']);
+
+  const injectHost = (app: any, introspection: DevIntrospection, host: string, extra: Record<string, unknown> = {}) =>
+    app.inject({
+      method: 'GET',
+      url: '/__taujs/observations',
+      remoteAddress: LOOPBACK,
+      headers: { host, 'x-taujs-token': introspection.token },
+      ...extra,
+    });
+
+  it('admits a declared hostname - case-insensitively and ignoring the request port', async () => {
+    const { app, introspection } = await buildApp({ allowedHosts: DECLARED });
+
+    for (const host of ['web.plt.local', 'Web.PLT.Local', 'web.plt.local:3042']) {
+      const res = await injectHost(app, introspection, host);
+      expect(res.statusCode, host).toBe(200);
+    }
+  });
+
+  it('never implies subdomains, and an undeclared host still answers 403 invalid_host', async () => {
+    const { app, introspection } = await buildApp({ allowedHosts: DECLARED });
+
+    for (const host of ['api.web.plt.local', 'plt.local', 'evil.example.com']) {
+      const res = await injectHost(app, introspection, host);
+      expect(res.statusCode, host).toBe(403);
+      expect(res.json(), host).toEqual({ error: 'invalid_host' });
+    }
+  });
+
+  it('host admission relaxes ONLY the Host guard: token and remote-address checks still apply', async () => {
+    const { app, introspection } = await buildApp({ allowedHosts: DECLARED });
+
+    const badToken = await app.inject({
+      method: 'GET',
+      url: '/__taujs/observations',
+      remoteAddress: LOOPBACK,
+      headers: { host: 'web.plt.local', 'x-taujs-token': 'wrong' },
+    });
+    expect(badToken.statusCode).toBe(403);
+    expect(badToken.json()).toEqual({ error: 'invalid_token' });
+
+    const nonLoopback = await app.inject({
+      method: 'GET',
+      url: '/__taujs/observations',
+      remoteAddress: '192.168.1.20',
+      headers: { host: 'web.plt.local', 'x-taujs-token': introspection.token },
+    });
+    expect(nonLoopback.statusCode).toBe(403);
+    expect(nonLoopback.json()).toEqual({ error: 'loopback_only' });
+  });
+
+  it('warns ONCE per boot on an undeclared hostname - exact message, hostname as metadata - then debug', async () => {
+    const { app, introspection, logger } = await buildApp({ allowedHosts: DECLARED });
+
+    await injectHost(app, introspection, 'other.plt.local:3042');
+    await injectHost(app, introspection, 'other.plt.local:3042');
+    await injectHost(app, introspection, 'another.example.com');
+
+    const rejectionWarns = logger.warn.mock.calls.filter((c: unknown[]) => String(c[1]).includes('rejected an undeclared Host'));
+    expect(rejectionWarns).toHaveLength(1);
+    expect(rejectionWarns[0][0]).toEqual({ component: 'introspection', host: 'other.plt.local' });
+    expect(rejectionWarns[0][1]).toBe(
+      'τjs introspection rejected an undeclared Host. If this is a trusted development proxy, declare it in introspection.allowedHosts.',
+    );
+
+    const rejectionDebugs = logger.debug.mock.calls.filter((c: unknown[]) => String(c[1]).includes('rejected an undeclared Host'));
+    expect(rejectionDebugs).toHaveLength(2);
+  });
+
+  it('a malformed Host stays debug-only and never consumes the warn latch', async () => {
+    const { app, introspection, logger } = await buildApp({ allowedHosts: DECLARED });
+
+    const malformed = await injectHost(app, introspection, 'not a host');
+    expect(malformed.statusCode).toBe(403);
+    expect(malformed.json()).toEqual({ error: 'invalid_host' });
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.debug.mock.calls.some((c: unknown[]) => String(c[1]).includes('malformed or missing Host'))).toBe(true);
+
+    await injectHost(app, introspection, 'undeclared.example.com');
+    const rejectionWarns = logger.warn.mock.calls.filter((c: unknown[]) => String(c[1]).includes('rejected an undeclared Host'));
+    expect(rejectionWarns).toHaveLength(1);
+    expect(rejectionWarns[0][0]).toEqual({ component: 'introspection', host: 'undeclared.example.com' });
   });
 });
 

--- a/packages/server/src/test/Config.test.ts
+++ b/packages/server/src/test/Config.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { describe, it, expect, vi } from 'vitest';
 
-import { resolveHmrTransport } from '../core/config/Setup';
+import { resolveHmrTransport, resolveIntrospectionAllowedHosts } from '../core/config/Setup';
 
 vi.mock('./core/services/DataServices', () => {
   return {
@@ -128,5 +128,55 @@ describe('resolveHmrTransport (RFC 0013)', () => {
       expect(() => resolveHmrTransport(cfg('attatched'), false, mode)).toThrow(/is not a valid transport/);
       expect(() => resolveHmrTransport(cfg(true), true, mode)).toThrow(/is not a valid transport/);
     }
+  });
+});
+
+// Post-freeze ruling 2026-08-08 (docs/introspection/decisions.md): exact DNS hostnames only,
+// resolved once to a lowercase exact-match set. Validation is mode-independent by construction
+// (the resolver never consults the runtime mode); the boot-time before-host-mutation half of
+// that contract is proved in CreateServerEmission.test.ts against createServer itself.
+describe('resolveIntrospectionAllowedHosts (post-freeze ruling 2026-08-08)', () => {
+  const cfg = (allowedHosts?: unknown) => ({ introspection: allowedHosts === undefined ? {} : { allowedHosts } }) as any;
+
+  it('resolves to an empty set when undeclared, when introspection is absent, and for an explicit empty list', () => {
+    expect(resolveIntrospectionAllowedHosts({} as any).size).toBe(0);
+    expect(resolveIntrospectionAllowedHosts(cfg()).size).toBe(0);
+    expect(resolveIntrospectionAllowedHosts(cfg([])).size).toBe(0);
+  });
+
+  it('resolves entries to a lowercase exact-match set (case-insensitive comparison, DNS semantics)', () => {
+    const resolved = resolveIntrospectionAllowedHosts(cfg(['Web.PLT.Local', 'intranet']));
+
+    expect([...resolved].sort()).toEqual(['intranet', 'web.plt.local']);
+  });
+
+  it('REJECTS leading-dot and wildcard declarations - subdomain admission is never implied', () => {
+    expect(() => resolveIntrospectionAllowedHosts(cfg(['.plt.local']))).toThrow(/not an exact DNS hostname/);
+    expect(() => resolveIntrospectionAllowedHosts(cfg(['*.plt.local']))).toThrow(/not an exact DNS hostname/);
+  });
+
+  it('REJECTS scheme, path, port and whitespace-bearing declarations', () => {
+    for (const entry of ['http://web.plt.local', 'web.plt.local/admin', 'web.plt.local:3042', 'web.plt local', ' web.plt.local', '']) {
+      expect(() => resolveIntrospectionAllowedHosts(cfg([entry])), entry).toThrow(/not an exact DNS hostname/);
+    }
+  });
+
+  it('REJECTS every IP-literal form with the intrinsic remedy - dotted-quad, bare and bracketed IPv6, and WHATWG IPv4 spellings', () => {
+    // IP detection is decided against the URL host parser the guard compares with: shorthand,
+    // decimal, octal and hex IPv4 spellings all canonicalise to dotted-quads on the request
+    // side, so they are IP literals here too - remedy, never the grammar complaint.
+    for (const entry of ['192.168.1.5', '::1', '[::1]', '127.1', '2130706433', '0177.0.0.1', '0x7f000001']) {
+      expect(() => resolveIntrospectionAllowedHosts(cfg([entry])), entry).toThrow(/admitted intrinsically/);
+    }
+  });
+
+  it('REJECTS a grammar-passing value the URL host parser cannot read back (out-of-range numeric label)', () => {
+    expect(() => resolveIntrospectionAllowedHosts(cfg(['99999999999999999999']))).toThrow(/not a hostname the URL host parser accepts/);
+  });
+
+  it('REJECTS non-array declarations and non-string entries', () => {
+    expect(() => resolveIntrospectionAllowedHosts(cfg(true))).toThrow(/must be an array/);
+    expect(() => resolveIntrospectionAllowedHosts(cfg('web.plt.local'))).toThrow(/must be an array/);
+    expect(() => resolveIntrospectionAllowedHosts(cfg([42]))).toThrow(/entries must be strings/);
   });
 });

--- a/packages/server/src/test/CreateServerEmission.test.ts
+++ b/packages/server/src/test/CreateServerEmission.test.ts
@@ -10,6 +10,17 @@ import type { TaujsConfig } from '../Config';
 const hoisted = vi.hoisted(() => ({
   emitGraphEvaluations: 0,
   registerBootGraphEmission: vi.fn(),
+  fastifyFactoryCalls: 0,
+}));
+
+// Counter proves the before-host-mutation criterion on the τjs-created arm directly: an
+// invalid configuration must fail before the Fastify factory is ever invoked, not merely
+// before registrations land on an already-created instance.
+vi.mock('fastify', () => ({
+  default: vi.fn(() => {
+    hoisted.fastifyFactoryCalls += 1;
+    return { register: vi.fn(async () => undefined), addHook: vi.fn(), log: undefined };
+  }),
 }));
 
 vi.mock('../core/introspection/EmitGraph', () => {
@@ -55,6 +66,7 @@ async function bootWith(nodeEnv: string) {
 beforeEach(() => {
   hoisted.emitGraphEvaluations = 0;
   hoisted.registerBootGraphEmission.mockClear();
+  hoisted.fastifyFactoryCalls = 0;
   console.log = vi.fn();
 });
 
@@ -102,6 +114,65 @@ describe('createServer — graph emission wiring (structural gate)', () => {
     });
 
     await expect(bootWith('development')).resolves.toBeTruthy();
+  });
+
+  // Post-freeze ruling 2026-08-08: the admission shout wording is FROZEN at review; these cells
+  // test the exact message, development-only emission, and absence when the list is empty.
+  it('introspection.allowedHosts shouts the exact frozen warning in dev, never in prod, never when empty', async () => {
+    const shoutText =
+      'τjs introspection overlay admits additional hostnames. Ensure any rewriting proxy validates the browser-facing Host; otherwise use a trusted development network only.';
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const declared = { ...config, introspection: { allowedHosts: ['web.plt.local'] } };
+
+    try {
+      process.env.NODE_ENV = 'development';
+      vi.resetModules();
+      let { createServer } = await import('../CreateServer');
+      await createServer({ config: declared, fastify: mkApp() });
+      expect(warnSpy.mock.calls.some((c) => c.join(' ').includes(shoutText))).toBe(true);
+
+      warnSpy.mockClear();
+      await createServer({ config: { ...config, introspection: { allowedHosts: [] } }, fastify: mkApp() });
+      expect(warnSpy.mock.calls.some((c) => c.join(' ').includes(shoutText))).toBe(false);
+
+      warnSpy.mockClear();
+      process.env.NODE_ENV = 'production';
+      vi.resetModules();
+      ({ createServer } = await import('../CreateServer'));
+      await createServer({ config: declared, fastify: mkApp() });
+      expect(warnSpy.mock.calls.some((c) => c.join(' ').includes(shoutText))).toBe(false);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('an invalid introspection.allowedHosts fails in EVERY mode BEFORE any host mutation', async () => {
+    for (const mode of ['development', 'production']) {
+      process.env.NODE_ENV = mode;
+      vi.resetModules();
+      const { createServer } = await import('../CreateServer');
+      const app = mkApp();
+
+      await expect(createServer({ config: { ...config, introspection: { allowedHosts: ['web.plt.local:3042'] } }, fastify: app }), mode).rejects.toThrow(
+        /not an exact DNS hostname/,
+      );
+      // The caller-supplied host was never touched: validation precedes registration entirely.
+      expect(app.register, mode).not.toHaveBeenCalled();
+      expect(app.addHook, mode).not.toHaveBeenCalled();
+    }
+  });
+
+  it('an invalid introspection.allowedHosts on a τjs-CREATED host fails BEFORE Fastify creation, in every mode', async () => {
+    for (const mode of ['development', 'production']) {
+      process.env.NODE_ENV = mode;
+      vi.resetModules();
+      const { createServer } = await import('../CreateServer');
+
+      await expect(createServer({ config: { ...config, introspection: { allowedHosts: ['.plt.local'] } } }), mode).rejects.toThrow(/not an exact DNS hostname/);
+      // The factory counter is the stronger half of the before-host-mutation contract: no
+      // Fastify instance ever existed, so there was nothing to mutate.
+      expect(hoisted.fastifyFactoryCalls, mode).toBe(0);
+    }
   });
 
   it('allowNonLoopback shouts the exact boot-summary warning in dev, and never in prod', async () => {

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -61,6 +61,12 @@ export type SSRServerOptions = {
    * full `TaujsConfig` (`CreateServer` forwards `opts.config`, a `TaujsConfig`).
    */
   taujsConfig?: CoreTaujsConfig & { vite?: TaujsViteOverride };
+  /**
+   * Post-freeze ruling 2026-08-08: resolved introspection host admissions (lowercase
+   * exact-match set), validated at `createServer` entry (`resolveIntrospectionAllowedHosts`)
+   * and threaded like the coordinates above so registration never re-derives it.
+   */
+  introspectionAllowedHosts?: ReadonlySet<string>;
 };
 
 export type GenericPlugin = FastifyPluginCallback<Record<string, unknown>> | FastifyPluginAsync<Record<string, unknown>>;

--- a/website/src/content/docs/reference/taujs-config.md
+++ b/website/src/content/docs/reference/taujs-config.md
@@ -51,6 +51,7 @@ export default defineConfig({
 type TaujsConfig = {
   server?: ServerConfig;
   security?: SecurityConfig;
+  introspection?: IntrospectionConfig; // Development only
   apps: AppConfig[];
   alias?: Record<string, string>;
   vite?: TaujsViteOverride;
@@ -63,6 +64,17 @@ type ServerConfig = {
   mountPrefix?: string; // Default: '' (root)
   publicBasePath?: string; // Default: mountPrefix
   hmrTransport?: 'fixed-port' | 'attached'; // Default: 'fixed-port'
+};
+
+// Development only - the surface is structurally absent from a production build,
+// so there is no `enabled` flag to turn it off.
+type IntrospectionConfig = {
+  allowNonLoopback?: boolean; // Relaxes ONLY the remote-address check
+  allowedHosts?: string[]; // Extends ONLY the Host admission; exact DNS hostnames
+  redaction?: {
+    denyKeys?: string[]; // Extends the default denylist
+    replaceDefaultDenyKeys?: boolean;
+  };
 };
 
 type AppConfig = {

--- a/website/src/content/docs/reference/taujs-config.md
+++ b/website/src/content/docs/reference/taujs-config.md
@@ -181,9 +181,9 @@ configuration stays proxy-owned; τjs reads no forwarding headers
 
 **Development.** The shared dev Vite `base` follows `publicBasePath`, so dev module URLs
 and the HMR socket pathname compose with the prefix, and dev delegation is confined to the
-mounted subtree. Two adjacent concerns remain separate limitations: HMR socket origin and
-port under process supervisors, and reverse-proxy host admission for the `/__taujs/*`
-introspection endpoints.
+mounted subtree. Two adjacent concerns have their own declared surfaces: `server.hmrTransport`
+carries the HMR socket where a second port cannot be reached, and `introspection.allowedHosts`
+admits a proxy's hostname for the `/__taujs/*` introspection endpoints.
 
 ### `server.hmrTransport`
 
@@ -233,6 +233,50 @@ host must:
 > `Host`, and Vite's WebSocket admission depends on those headers - its host and token checks
 > do not survive that rewriting. The protections that apply to a direct connection do not
 > project through such a proxy. Use this on development networks you trust.
+
+## Development Introspection
+
+The development introspection surface (the `/__taujs/*` overlay endpoints and the hydration
+beacon) is guarded independently of page serving: requests must arrive from a loopback
+address, present a local `Host` and carry the per-boot token. Each opt-in below relaxes
+exactly the guard it names, and neither implies the other.
+
+### `introspection.allowedHosts`
+
+Extends the introspection `Host` admission with exact DNS hostnames, for development behind
+a reverse proxy that presents a non-localhost `Host`. Development only; without a
+declaration the behaviour stays localhost-only.
+
+```typescript
+export default defineConfig({
+  introspection: {
+    allowedHosts: ['web.plt.local'],
+  },
+});
+```
+
+Rules:
+
+- **Exact hostnames only.** No wildcards, IP literals, schemes, ports or paths - invalid
+  entries are rejected at startup, in production too, so a shared configuration cannot hide
+  a typo. Matching is case-insensitive and ignores the request port; subdomains are never
+  implied. `localhost`, `*.localhost` and IP-literal hosts stay admitted without any
+  declaration.
+- **Declare the hostname as seen at the τjs hop.** A rewriting proxy substitutes its own
+  upstream name for the browser-facing one - behind a Platformatic gateway, for example,
+  the arriving `Host` is the internal service name (`web.plt.local`), not the public host.
+- **A rewriting proxy owns browser-facing host validation.** Exact matching preserves the
+  DNS-rebinding guard for direct connections, but τjs never sees the original hostname
+  behind a rewriting proxy and reads no forwarding headers (`Forwarded`,
+  `X-Forwarded-Host`). Ensure the proxy validates the browser-facing host, or use a trusted
+  development network only - the boot summary repeats this whenever the list is non-empty.
+- **Independent of `allowNonLoopback`.** `allowedHosts` relaxes only the `Host` check;
+  `introspection.allowNonLoopback: true` relaxes only the remote-address check. A same-host
+  gateway needs only `allowedHosts`; a proxy on another machine needs both. The per-boot
+  token is always required.
+
+Undeclared hostnames keep answering `403 invalid_host`; the first such refusal logs a
+warning naming this field, so a proxied topology fails visibly rather than silently.
 
 ## App Configuration
 


### PR DESCRIPTION
## Declared host admission for the development introspection surface

Development behind a reverse proxy has worked for pages and modules since 0.23.0
(`vite.server.allowedHosts`), but the `/__taujs/*` introspection surface had no admission
surface at all: every request presenting a proxied `Host` answered `403 invalid_host`, so
hydration beacons and the episodes/graph/observations endpoints died silently in exactly the
supervised topologies the host-neutrality work targets. Measured in RFC 0012 Phase 1 leg D2.

Adds `introspection.allowedHosts?: string[]`.

```ts
export default defineConfig({
  introspection: {
    allowedHosts: ['web.plt.local'],
  },
});
```

### What it does, and what it deliberately does not

- **Exact DNS hostnames only** - no wildcards, no boolean escape, no schemes, ports or paths.
  Matching is case-insensitive and ignores the request port; subdomains are never implied.
  Entries resolve once to a lowercase exact-match set at `createServer` entry, validated in
  every mode (production too, so a shared configuration cannot hide a typo). `localhost`,
  `*.localhost` and IP literals stay admitted intrinsically.
- **It is not a reuse of `vite.server.allowedHosts`.** Vite's value is `string[] | true` with
  dot-wildcard semantics; honouring it here would import exactly the escapes this surface
  rejects, and reinterpreting the same key more strictly would give one declaration two
  meanings. Admitting a host for pages is also a different disclosure decision from admitting
  it for the observability surface.
- **It relaxes only the `Host` guard.** The remote-address check (`allowNonLoopback`), the
  per-boot token and production absence are unchanged, and neither flag implies the other: a
  same-host gateway needs only `allowedHosts`, a proxy on another machine needs both.
- **The security boundary is stated rather than implied.** Exact matching preserves the
  DNS-rebinding guard for direct connections. Behind a Host-rewriting proxy τjs only ever sees
  the declared upstream name, so validating the browser-facing host is the proxy's job - τjs
  reads no forwarding headers (`Forwarded`, `X-Forwarded-Host`). A non-empty declaration says
  exactly that in the boot summary.
- **Silence is fixed where the failure happens**, not predicted from another subsystem's
  configuration: the first undeclared-hostname refusal warns once per boot naming the field,
  with the parsed hostname as structured metadata; repeats and malformed `Host` values stay at
  debug.

### Evidence

15 unit cells cover resolver validation (grammar, every IP-literal form including IPv6 and the
WHATWG IPv4 spellings that canonicalise to dotted-quads, parser-unreadable numerics), guard
admission (case, port, subdomain, unknown host, token and loopback independence, warn-once
latch, malformed-Host latch immunity) and boot behaviour (frozen shout dev-only and absent when
empty; invalid configuration failing in both modes on both host arms - no `register`/`addHook`
on a supplied host, and the Fastify factory never invoked on a τjs-created one).

Topology evidence was run against a pack verified fresh from this branch, on the certified
Platformatic preserve arrangement (gateway -> `useHttp` worker, prefix preserved, mode A):

- **Declared:** a real Chromium through the Gateway emits the page's own beacon to
  `/app/__taujs/beacon` - 204 at the client hop, `client: { hydrated: true }` recorded on the
  episode, and `episodes`/`graph`/`observations` all 200.
- **Mutation control:** reverting only the declaration returns all four to `403 invalid_host`
  and removes the boot shout. Four genuine rejections produced exactly one warn line.
- **Rebinding control:** a host declared to Vite but withheld from introspection reaches the
  τjs guard and gets `403 invalid_host`; a host declared to neither is stopped earlier by
  Vite's own check (defence in depth, recorded as such).
- RFC 0012's dependency-blocked introspection end-to-end cell is unblocked and re-run: PASS.

Full workspace green: build, typecheck, format, exports and tests (`pnpm check` exit 0; server
71 files / 1100 tests).

### Commits

1. `feat(server)` - the field, resolver, guard extension, logging, cells, reference docs and a
   minor changeset.
2. `docs` - an unrelated one-line README correction, included deliberately: the `@taujs/solid`
   package-table row still carried its original wording while the react and vue rows had
   settled on "Standalone and runtime-agnostic".
3. `docs` - the reference page's Type Definitions excerpt never listed `introspection` at all,
   so the page documented a field its own type block implied did not exist. The excerpt now
   carries `IntrospectionConfig` with the three fields the type actually has.
