### PR TITLE
test(fixtures): bring renderer-composition into workspace typechecking

### DIFF
--- a/fixtures/renderer-composition/package.json
+++ b/fixtures/renderer-composition/package.json
@@ -5,7 +5,8 @@
   "description": "Real-Vite composition proof: React and Solid compile together with no cross-contamination (RFC 0006)",
   "type": "module",
   "scripts": {
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsc"
   },
   "devDependencies": {
     "@taujs/react": "workspace:*",

--- a/fixtures/renderer-composition/test/support/built-server.ts
+++ b/fixtures/renderer-composition/test/support/built-server.ts
@@ -49,7 +49,10 @@ export const externalImportsOfBuiltServer = (): string[] => {
 
   for (const source of sources) {
     for (const [, specifier] of source.matchAll(/(?:from|require\(|import\()\s*["']([^"']+)["']/g)) {
-      if (!specifier.startsWith('.')) specifiers.add(specifier);
+      // The group always participates in a match, so this is never undefined at runtime - but the
+      // type says otherwise and a silent `undefined` here would drop a real external import from
+      // the assertion rather than fail it.
+      if (specifier !== undefined && !specifier.startsWith('.')) specifiers.add(specifier);
     }
   }
 

--- a/fixtures/renderer-composition/tsconfig.json
+++ b/fixtures/renderer-composition/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@taujs/server-internal/ownership": ["../../packages/server/src/utils/OwnershipPrepass.ts"]
+    }
+  },
+  "include": ["test/**/*", "vitest.config.ts", "../../packages/server/src/fastify.d.ts"]
+}


### PR DESCRIPTION
The package holds the three-renderer streaming legs and the composition, dev, classifier and build suites, but declared no typecheck script and had no package-root tsconfig, so pnpm -r typecheck skipped it entirely - the suites treated as the three-renderer proof were the least statically checked code in the repository.

Adds a package-root tsconfig extending tsconfig.base.json and a matching typecheck script. The config is deliberately MINIMAL rather than a copy of the playground configs: these are Node-run .ts tests whose .tsx content is written into temporary fixtures as strings, never a compiler input, so it inherits the ES2022/Node/Vitest environment and adds neither jsx nor the DOM lib - verified unnecessary rather than assumed, and DOM globals would mask accidental browser-only usage in tests that run in Node. It mirrors vitest.config.ts's test-only ownership alias through paths, and includes packages/server/src/fastify.d.ts so the server source that alias pulls in sees its real module-augmentation environment.

One genuine finding, in test/support/built-server.ts: a capture group destructured from matchAll is string | undefined under noUncheckedIndexedAccess and had .startsWith() called on it unguarded. Guarded explicitly - a silent undefined there would drop a real external import from the assertion instead of failing it. No any, no suppression comment.

The three streaming-*/tsconfig.json files are deliberately untouched: those directories hold built .js and HTML for the build fixtures, not TypeScript sources.

Verified: fixture typecheck clean, and a deliberate type error fails it (mutation proof); pnpm -r typecheck reaches the package; renderer-composition 7 files / 53 tests still pass; full pnpm check exit 0.

Private fixture, publishes nothing, so no changeset.