### PR TITLE
docs(website): align guides with current code

### DIFF
--- a/.changeset/vue-throwing-read-streamed-caveat.md
+++ b/.changeset/vue-throwing-read-streamed-caveat.md
@@ -1,0 +1,20 @@
+---
+'@taujs/vue': patch
+---
+
+docs(vue): document what the throwing deferred read does to a streamed response
+
+`useDeferredData()` described a rejection only as reaching Vue's native error channel, and its
+caveat described the client-side consequence as a hydration mismatch. On a streamed response the
+outcome is different: if the read reaches its deadline after the response has begun, the response
+ends before `__INITIAL_DATA__`, the deferred envelope, the bootstrap script and the terminal event
+are written, so the page cannot hydrate at all.
+
+Both the renderer reference and the `useDeferredData` JSDoc now say so, and the neighbouring
+`useDeferredDataResult` JSDoc was rewritten in the same register while the file was open. Both
+ship in the published declarations, so the corrections reach editor tooltips as well as the
+documentation site.
+
+No runtime, type or behavioural change: `useDeferredDataResult()` remains the read to prefer for
+any entry that may fail, because it resolves to a complete, failed or aborted result and lets the
+response finish normally.

--- a/packages/vue/src/SSRDeferredData.ts
+++ b/packages/vue/src/SSRDeferredData.ts
@@ -270,32 +270,33 @@ const holderOrThrow = (accessor: string, key: string): DeferredHolder => {
 };
 
 /**
- * THROWING read - a renderer-native SECONDARY API. Returns a promise an async `setup()` awaits;
- * a rejection reaches Vue's native error channel (`onErrorCaptured`, then
- * `app.config.errorHandler`).
+ * Returns the deferred value, or rejects through Vue's native error channel
+ * (`onErrorCaptured`, then `app.config.errorHandler`).
  *
- * SERVER CAVEAT, recorded and not worked around: Vue SSR renders each subtree exactly once, so a
- * boundary that catches the error has already emitted its markup and emits an EMPTY node - it
- * cannot substitute fallback UI into the response, and the same component re-renders its caught
- * fallback on the client, which is a hydration mismatch by construction. Prefer
- * {@link useDeferredDataResult} for any entry that can fail.
+ * Streamed SSR caveat: Vue renders each server subtree once, so a captured rejection cannot
+ * replace markup that has already been emitted. If this read reaches its deadline after the
+ * response begins, the response ends before `__INITIAL_DATA__`, the deferred envelope, the
+ * bootstrap script and the terminal event are written, so the page cannot hydrate.
  *
- * Must be called SYNCHRONOUSLY in `setup()` (before the first `await`): it injects.
+ * Use {@link useDeferredDataResult} for entries that may fail. It resolves to a complete,
+ * failed or aborted result and allows the response to finish normally.
+ *
+ * Call synchronously in `setup()` before the first `await`, because it uses injection.
  */
 export function useDeferredData<T extends Record<string, unknown> = Record<string, unknown>>(key: string): Promise<T> {
   return holderOrThrow('useDeferredData', key).resource(key) as Promise<T>;
 }
 
 /**
- * RESULT read - the PRIMARY Vue accessor and its server-completing consumed-rejection path
- * (decision 13).
+ * Returns the deferred outcome. This is the read to prefer in Vue: the promise never rejects for
+ * a declared key, so the application branches on `complete`, `failed` or `aborted` and renders
+ * the branch it chooses.
  *
- * The returned promise never rejects for a declared key: the application branches on
- * `complete` / `failed` / `aborted` and renders the branch it wants, so a handled failure fallback
- * COMPLETES THE RESPONSE and server and client render the identical branch from the identical
- * detail-free outcome. `failed` and `aborted` carry no value, message, stack or cause.
+ * Because a handled failure renders as ordinary markup, the response finishes normally and server
+ * and client render the identical branch from the identical outcome. `failed` and `aborted` carry
+ * no value, message, stack or cause.
  *
- * Must be called SYNCHRONOUSLY in `setup()` (before the first `await`): it injects.
+ * Call synchronously in `setup()` before the first `await`, because it uses injection.
  */
 export function useDeferredDataResult<T extends Record<string, unknown> = Record<string, unknown>>(key: string): Promise<DeferredResult<T>> {
   return holderOrThrow('useDeferredDataResult', key).result(key) as Promise<DeferredResult<T>>;

--- a/website/src/content/docs/guides/content-security-policy.md
+++ b/website/src/content/docs/guides/content-security-policy.md
@@ -50,15 +50,16 @@ const nonce = crypto.randomBytes(16).toString('base64');
 // Sets header
 Content-Security-Policy: script-src 'self' 'nonce-abc123...'
 
-// Passes to renderer
-renderStream(res, callbacks, data, location, modules, meta, nonce);
+// Passes to the renderer, in the render options
+renderStream(writable, callbacks, data, location, modules, meta, signal, { cspNonce, ... });
 ```
 
 ### Automatic Application
 
 The nonce is automatically applied to:
 
-- React's `renderToPipeableStream` (via nonce option)
+- the renderer's own script output - React's `renderToPipeableStream` nonce option, Vue's
+  injected scripts, Solid's hydration script
 - `window.__INITIAL_DATA__` script
 - Client bootstrap script
 

--- a/website/src/content/docs/renderers/vue.mdx
+++ b/website/src/content/docs/renderers/vue.mdx
@@ -219,7 +219,7 @@ const outcome = await deferred.result("reviews");
 `createDeferredAccessor<D>()` returns two reads, and both must be called synchronously in `setup()` before the first `await`:
 
 - `deferred.result(key)` returns `Promise<DeferredResult<T>>` - a promise that never rejects for a declared key, resolving to `{ status: 'complete', value }`, `{ status: 'failed' }` or `{ status: 'aborted' }`. This is the **primary Vue read**: a handled failure branch completes the response, and server and client render the identical branch from the identical detail-free outcome.
-- `deferred.data(key)` returns `Promise<T>` and rejects with a `DeferredDataError` (carrying `key` and `outcome`) when the value never arrived. The rejection follows Vue's native error channel (`onErrorCaptured`, `app.config.errorHandler`).
+- `deferred.data(key)` returns `Promise<T>` and rejects with a `DeferredDataError` (carrying `key` and `outcome`) when the value never arrived. The rejection follows Vue's native error channel (`onErrorCaptured`, `app.config.errorHandler`). **During streamed SSR this can leave the response incomplete.** Vue renders each server subtree exactly once, so a boundary that catches the rejection has already emitted its markup: it cannot substitute fallback UI into the response, and a rejection or deadline after the head has been emitted aborts the transfer. At a deferred deadline, `window.__INITIAL_DATA__`, the deferred envelope, the bootstrap script and the terminal event are all absent, so the page cannot hydrate. Use `deferred.result(key)` for any entry that can fail.
 
 The untyped forms `useDeferredData(key)` and `useDeferredDataResult(key)` are exported for cases where no route type is to hand; prefer the typed façade.
 


### PR DESCRIPTION
docs: correct the CSP guide's renderer call illustration
docs(vue): document the streamed consequence of the throwing deferred read