### PR TITLE
docs(server): document introspection redaction, and assert the guarantee it actually makes

### DIFF
--- a/packages/server/src/core/introspection/test/DevEndpointsFiles.test.ts
+++ b/packages/server/src/core/introspection/test/DevEndpointsFiles.test.ts
@@ -371,10 +371,19 @@ describe('dev files lifecycle (spec 03 §5)', () => {
         await stat(path.join(dir, 'node_modules', '.taujs', 'episodes.ndjson'));
       });
       const ndjson = await readFile(path.join(dir, 'node_modules', '.taujs', 'episodes.ndjson'), 'utf8');
-      expect(ndjson).toContain('"pathname":"/reset"');
-      expect(ndjson).toContain('"queryKeys":["ref"]');
-      expect(ndjson).not.toContain('abc');
-      expect(ndjson).not.toContain('token=');
+
+      // Assert the STRUCTURE the recorder guarantees, not the absence of a substring. The system
+      // performs no value sweep: `sanitiseUrl` stores a pathname, the surviving query key names
+      // and a flag, so the value never enters the buffer in the first place. A sweep across the
+      // whole serialised document was a weaker proxy that also read every random identifier in
+      // it - a UUID containing `abc` failed while redaction was working perfectly.
+      const record = JSON.parse(
+        ndjson
+          .split('\n')
+          .filter(Boolean)
+          .find((line) => line.includes('file-t1'))!,
+      );
+      expect(record.url).toEqual({ pathname: '/reset', queryKeys: ['ref'], queryValuesRedacted: true });
 
       await app.close();
       await expect(stat(devJsonPath)).rejects.toThrow();

--- a/packages/server/src/core/introspection/test/DevIntrospection.test.ts
+++ b/packages/server/src/core/introspection/test/DevIntrospection.test.ts
@@ -119,9 +119,9 @@ describe('URL hygiene (spec 03 §2, acceptance #4)', () => {
     dev.recorder.sent({ requestId: T, status: 200, mode: 'fallthrough' });
 
     const [episode] = dev.getEpisodes();
+    // The record shape is the guarantee. A serialised substring sweep adds nothing here and
+    // reads every random identifier too: `bootId` is a UUID, and `abc` is all hex.
     expect(episode!.url).toEqual({ pathname: '/reset', queryKeys: ['ref'], queryValuesRedacted: true });
-    expect(JSON.stringify(episode)).not.toContain('abc');
-    expect(JSON.stringify(episode)).not.toContain('token');
   });
 });
 
@@ -206,6 +206,52 @@ describe('logs annex tee (spec 03 §3)', () => {
     expect(meta.nested.password).toBeUndefined();
     expect(meta.nested.keep).toHaveLength(200);
     expect(JSON.stringify(logs)).not.toContain('sensitive');
+  });
+
+  // Pin the documented default: case-insensitive substring matching intentionally favours
+  // over-redaction.
+  it('matches deny keys as case-insensitive substrings, over-redacting by design', () => {
+    const dev = createDevIntrospection();
+    const wrapped = dev.wrapRequestLogger(mkBase(), T);
+
+    wrapped.info(
+      {
+        // Genuinely sensitive - these spellings must drop, including all-lowercase
+        // concatenations.
+        authToken: 'a',
+        API_KEY: 'b',
+        Authorization: 'c',
+        usertoken: 'd',
+        // Innocent, and dropped anyway: the documented cost of the conservative rule.
+        monkeyId: 'e',
+        authorName: 'f',
+        // Unrelated to any deny key - the rule is not a blanket drop.
+        userId: 'g',
+        totalCount: 'h',
+      },
+      'meta',
+    );
+
+    const meta = dev.getLogs(T)[0]!.meta as Record<string, unknown>;
+
+    for (const dropped of ['authToken', 'API_KEY', 'Authorization', 'usertoken', 'monkeyId', 'authorName']) {
+      expect(meta[dropped], dropped).toBeUndefined();
+    }
+    expect(meta.userId).toBe('g');
+    expect(meta.totalCount).toBe('h');
+  });
+
+  it('replaceDefaultDenyKeys hands the whole policy to the caller', () => {
+    const dev = createDevIntrospection({ denyKeys: ['classified'], replaceDefaultDenyKeys: true });
+    const wrapped = dev.wrapRequestLogger(mkBase(), T);
+
+    wrapped.info({ classified: 'x', password: 'y', monkeyId: 'z' }, 'meta');
+
+    const meta = dev.getLogs(T)[0]!.meta as Record<string, unknown>;
+    expect(meta.classified).toBeUndefined();
+    // The defaults are gone entirely, including the ones that protect.
+    expect(meta.password).toBe('y');
+    expect(meta.monkeyId).toBe('z');
   });
 
   it('child loggers stay teed to the same requestId', () => {

--- a/website/src/content/docs/reference/mcp.md
+++ b/website/src/content/docs/reference/mcp.md
@@ -88,7 +88,7 @@ There is deliberately no `enabled` flag: dev-on / prod-absent is structural.
 
 Do not enable `allowNonLoopback` for `@taujs/mcp`. The adapter is filesystem-only and never touches the HTTP overlay endpoints, so the flag grants it no capability. It exists solely for reaching the browser overlay (`/__taujs/*`) from another device on a trusted development network; Host validation and the per-boot token remain enforced either way.
 
-`redaction`, by contrast, is directly MCP-relevant: it controls what reaches the emitted episode and log files the adapter serves.
+`redaction`, by contrast, is directly MCP-relevant: it controls what reaches the emitted episode and log files the adapter serves. Key names are matched as case-insensitive substrings, which deliberately over-redacts - see [`introspection.redaction`](/reference/taujs-config/#introspectionredaction) for the exact rule and how to take ownership of the list.
 
 ## When to Use It
 

--- a/website/src/content/docs/reference/taujs-config.md
+++ b/website/src/content/docs/reference/taujs-config.md
@@ -290,6 +290,53 @@ Rules:
 Undeclared hostnames keep answering `403 invalid_host`; the first such refusal logs a
 warning naming this field, so a proxied topology fails visibly rather than silently.
 
+### `introspection.redaction`
+
+What τjs withholds from the development introspection record - the episodes, observations and
+log annex written under `node_modules/.taujs/` and served to the overlay. Redaction here is
+**structural**: τjs never scans values looking for things that resemble secrets.
+
+Two rules apply, and both are unconditional:
+
+- **Query values are never captured, for any key.** A URL is stored as its pathname, the
+  surviving query key names, and a flag - never as a raw string. For `/reset?token=abc&ref=x`
+  the record is `{ pathname: "/reset", queryKeys: ["ref"], queryValuesRedacted: true }`. The
+  value `abc` never enters the buffer, and `token` is absent from `queryKeys` because its key
+  name matched the denylist.
+- **Metadata fields are dropped by key name**, along with the whole subtree beneath them. A
+  matched key is not partially serialised; it is absent.
+
+```typescript
+introspection: {
+  redaction: {
+    denyKeys: ['internalRef'],        // extends the defaults
+    replaceDefaultDenyKeys: false,    // true discards the defaults entirely
+  },
+}
+```
+
+**The matching rule, stated exactly.** A key is dropped when its name, lowercased, **contains**
+any denylist entry as a substring. Default entries: `password`, `token`, `secret`, `ssn`,
+`auth`, `cookie`, `session`, `key`.
+
+**This deliberately over-redacts.** Because `key`, `auth` and `session` are short, innocent
+fields disappear too - `monkeyId` and `keyboardLayout` match `key`, `authorName` matches
+`auth`, `sessionCount` matches `session`. If a legitimate field is missing from the overlay,
+this rule is why.
+
+**It is a conservative heuristic on key names, not secret detection.** Substring matching
+intentionally favours over-redaction, but the default list is not exhaustive and values are
+never inspected. The denylist does not remove an unmatched metadata field, or secrets embedded
+directly in log or error messages. Avoid putting secrets in introspection-visible metadata or
+messages, and add project-specific deny keys where needed.
+
+**If the defaults do not suit you, take ownership of the list.** `denyKeys` adds entries;
+`replaceDefaultDenyKeys: true` discards τjs's defaults so only your entries apply - including
+the defaults that protect, so choose the replacement list deliberately.
+
+The whole surface is development-only. In production the introspection module is never loaded,
+nothing is written, and there is nothing to redact.
+
 ## App Configuration
 
 Define frontend applications with their entry points and routes.


### PR DESCRIPTION
Two halves of one complaint: the redaction rule was undocumented, and the tests that guarded it asserted something the system does not do.

Documentation. Nothing on the site described how keys are matched, so a developer whose legitimate field vanished from the overlay had no way to find out why. The configuration reference now states the rule exactly - key names are matched case-insensitively as substrings, so `monkeyId` and `keyboardLayout` match `key`, `authorName` matches `auth` - alongside the two unconditional structural rules (query values are never captured for any key; a matched key drops its whole subtree) and the `denyKeys` / `replaceDefaultDenyKeys` surface. The MCP reference, which already called redaction MCP-relevant, links to it.

It is documented as what it is: a conservative heuristic on key names, not secret detection. The default list is not exhaustive, values are never inspected, and a secret interpolated into a log message is not a key at all - so the page tells readers to avoid writing secrets to introspection-visible logs and to extend `denyKeys` for domain-specific names, rather than implying the defaults are a guarantee.

Tests. Two suites asserted redaction by sweeping a serialised document for a substring, for a guarantee the system implements structurally: `sanitiseUrl` stores a pathname, the surviving query key names and a flag, so the value never enters the buffer at all. The sweeps also read every random identifier in the record - `bootId` is a UUID and `abc` is all hex, so a boot could fail the assertion while redaction worked perfectly, which is what was observed once during an RFC 0010 review run. Both now assert the record shape, on disk and in memory. Seeding a longer sentinel would have stopped the flake without making either test any better.

Two cells added in `DevIntrospection` pin the documented behaviour so the trade-off is enforced rather than incidental: substring matching drops these sensitive spellings including all-lowercase concatenations, and drops the innocent `monkeyId` too; and `replaceDefaultDenyKeys` hands the whole policy to the caller, defaults included.

The matcher redesign is parked. Word-boundary matching was measured against a corpus of real key names before deciding: it keeps `monkeyId`, but it stops matching `Authorization`, `apikey`, `sessionid` and every all-lowercase concatenation such as `usertoken`. For a development record written to disk, leak-by-default is the worse failure, so the conservative rule stays and the cost is documented instead.

No product change: the matcher, the defaults and the config surface are untouched. Documentation and tests only, so no changeset.