### PR TITLE
docs: reconcile public CSR language with the declared-route contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # τjs &nbsp;[ taujs ]
 
-> τjs is an orchestration layer built on Fastify, Vite, and React / Vue / Solid. Developer-first with declarative configuration for building modern web apps with per-route control over CSR, SSR, and Streaming SSR.
+> τjs is an orchestration layer built on Fastify, Vite, and React / Vue / Solid. Developer-first with declarative configuration for building modern web apps: per-route control over SSR and Streaming SSR, with CSR by omission of a route.
 
 [![@taujs/create-taujs](https://img.shields.io/npm/v/@taujs/create-taujs?label=%40taujs%2Fcreate-taujs)](https://www.npmjs.com/package/@taujs/create-taujs)
 [![@taujs/server](https://img.shields.io/npm/v/@taujs/server?label=%40taujs%2Fserver)](https://www.npmjs.com/package/@taujs/server)
@@ -15,14 +15,14 @@
 
 ## Packages
 
-| Package                                        | Description                                                                                                                                       |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`@taujs/create-taujs`](packages/create-taujs) | Scaffolder for a new τjs application.                                                                                                             |
-| [`@taujs/server`](packages/server)             | Fastify plugin & render orchestration - CSR / SSR / Streaming SSR for SPA, MPA, and build‑time micro‑frontends (MFE). Vite HMR + tsx in dev.      |
-| [`@taujs/react`](packages/react)               | React renderer: CSR, SSR, Streaming SSR. Standalone and runtime‑agnostic.                                                                         |
-| [`@taujs/vue`](packages/vue)                   | Vue renderer: CSR, SSR, Streaming SSR. Standalone and runtime‑agnostic.                                                                           |
-| [`@taujs/solid`](packages/solid)               | Solid renderer: CSR, SSR and Streaming SSR. Standalone and runtime‑agnostic.                                                                      |
-| [`@taujs/mcp`](packages/mcp)                   | MCP server for AI agents: reads the dev‑emitted request graph and live request episodes (filesystem‑only stdio adapter). Wired by the scaffolder. |
+| Package                                        | Description                                                                                                                                                                  |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`@taujs/create-taujs`](packages/create-taujs) | Scaffolder for a new τjs application.                                                                                                                                        |
+| [`@taujs/server`](packages/server)             | Fastify plugin & render orchestration - SSR / Streaming SSR per declared route, CSR by omission - for SPA, MPA, and build‑time micro‑frontends (MFE). Vite HMR + tsx in dev. |
+| [`@taujs/react`](packages/react)               | React renderer: CSR, SSR, Streaming SSR. Standalone and runtime‑agnostic.                                                                                                    |
+| [`@taujs/vue`](packages/vue)                   | Vue renderer: CSR, SSR, Streaming SSR. Standalone and runtime‑agnostic.                                                                                                      |
+| [`@taujs/solid`](packages/solid)               | Solid renderer: CSR, SSR and Streaming SSR. Standalone and runtime‑agnostic.                                                                                                 |
+| [`@taujs/mcp`](packages/mcp)                   | MCP server for AI agents: reads the dev‑emitted request graph and live request episodes (filesystem‑only stdio adapter). Wired by the scaffolder.                            |
 
 Current versions are shown by the badges above.
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -12,11 +12,10 @@ This package is part of the τjs [ taujs ] orchestration system, authored by Joh
 
 ## CSR; SSR; Streaming SSR; Hydration; Fastify + React 19
 
-Supports rendering modes:
+Rendering:
 
-- Client-side rendering (CSR)
-- Server-side rendering (SSR)
-- Streaming SSR
+- Server-side rendering (SSR) and Streaming SSR, chosen per declared route
+- Client-side rendering (CSR) by omission: when no declared τjs route matches a URL, it remains outside server orchestration; what answers it depends on host ownership
 
 Supported application structure and composition:
 
@@ -24,7 +23,7 @@ Supported application structure and composition:
 - Multi-page Application (MPA)
 - Build-time Micro-Frontends (MFE), with server orchestration and delivery
 
-Assemble independent frontends at build time incorporating flexible per-route SPA-MPA hybrid with CSR, SSR, and Streaming SSR, rendering options.
+Assemble independent frontends at build time in a flexible SPA-MPA hybrid: SSR or Streaming SSR per declared route, CSR by omission.
 
 Fastify Plugin for integration with τjs [ taujs ] template https://github.com/aoede3/taujs
 

--- a/website/src/content/docs/guides/app-shell-pattern.md
+++ b/website/src/content/docs/guides/app-shell-pattern.md
@@ -353,7 +353,7 @@ If you already have a SPA with an `App` component and client-side routing, the f
 
 At this point:
 
-- Runtime behaviour is basically unchanged (still one shell, still CSR/SSR depending on what you choose).
+- Runtime behaviour is basically unchanged (still one shell with client-side navigation; the shell itself now renders on the server).
 - You get τjs’s SSR/streaming/CSP/static-asset plumbing.
 - There is still **one deployment unit**.
 

--- a/website/src/content/docs/guides/architecture.md
+++ b/website/src/content/docs/guides/architecture.md
@@ -168,22 +168,23 @@ not load several application bundles into one browser runtime, negotiate shared 
 runtime or preserve in-memory state across application boundaries.
 
 Navigation between applications is a full document navigation. Navigation within one application
-shell can remain client-side. This makes the URL boundary the composition seam and avoids a runtime
+can remain client-side. This makes the URL boundary the composition seam and avoids a runtime
 federation layer. See [Micro-Frontends](/guides/micro-frontend) for build, routing and transition
 patterns.
 
-## Application shells and undeclared screens
+## Undeclared screens and the SPA fallback
 
 A client-routed screen does not need its own τjs data contract. It needs a server route or fallback
-that delivers the application shell:
+that delivers the application document:
 
-- a τjs-created host provides an implicit shell for unmatched document-like URLs;
+- a τjs-created host provides an implicit SPA fallback document for unmatched document-like URLs;
 - a caller-owned host requires an explicit terminal `/*` page when the application should own
   those URLs.
 
-The shell loads the client bundle and the client router can take over. This is how τjs supports
-incremental adoption without pretending every client screen has declared request orchestration. See
-[App Shell Architecture](/guides/app-shell-pattern) for the complete pattern.
+That document loads the client bundle and the client router can take over. This is how τjs supports
+incremental adoption without pretending every client screen has declared request orchestration.
+For the separate single-application composition pattern using shared browser-side chrome, routing
+and state, see [App Shell Architecture](/guides/app-shell-pattern).
 
 ## Failure and cancellation boundaries
 

--- a/website/src/content/docs/guides/getting-started.mdx
+++ b/website/src/content/docs/guides/getting-started.mdx
@@ -80,11 +80,11 @@ A route can also declare head metadata, critical data, deferred data, authentica
 
 ## Undeclared routes stay client-rendered
 
-Client-side rendering is not a third value of `attr.render`. A URL known to the client router but absent from `taujs.config.ts` stays client-rendered once the application shell has loaded.
+Client-side rendering is not a third value of `attr.render`. It happens by omission: a URL known to the client router but absent from `taujs.config.ts` stays client-rendered once the application has loaded in the browser.
 
-For a direct request to such a URL, something must still serve that shell:
+For a direct request to such a URL, something must still serve the application document:
 
-- a Fastify instance created by τjs supplies the application-shell fallback
+- a Fastify instance created by τjs supplies the SPA fallback document
 - a Fastify instance supplied by the caller requires an explicit terminal `/*` τjs route when τjs should own unmatched document URLs
 
 See [Request Contracts & Data](/guides/request-contracts/#undeclared-urls-and-client-routing) and [Host Ownership](/guides/host-ownership/) for the full boundary.
@@ -103,7 +103,7 @@ The [Architecture](/guides/architecture/) guide explains the ownership boundarie
 
 The scaffold lets τjs create Fastify, then calls `app.listen()` from the server entry. You can instead pass an existing Fastify instance to `createServer`. In that form, the caller owns the host and τjs installs its declared routes and facilities inside an encapsulated scope.
 
-That distinction affects the application shell, host-wide CSP, request identity and not-found handling. Read [Host Ownership](/guides/host-ownership/) before embedding τjs into an existing server.
+That distinction affects the SPA fallback document, host-wide CSP, request identity and not-found handling. Read [Host Ownership](/guides/host-ownership/) before embedding τjs into an existing server.
 
 ## Development and production
 

--- a/website/src/content/docs/guides/host-ownership.md
+++ b/website/src/content/docs/guides/host-ownership.md
@@ -9,7 +9,7 @@ When `fastify` is omitted, τjs creates the instance and installs its whole-serv
 encapsulated scope. There is no separate ownership option or flag.
 
 ```ts
-// τjs creates Fastify: whole-server shell, CSP and request identity
+// τjs creates Fastify: whole-server SPA fallback, CSP and request identity
 const { app, net } = await createServer({ config });
 
 // You own Fastify: τjs installs into an encapsulated application scope
@@ -45,7 +45,7 @@ that matches the application:
 | Auth | τjs routes | τjs routes |
 | Page errors | τjs root handler | τjs scoped handler |
 | Host route errors | τjs | You |
-| Not-found and shell | Implicit τjs shell | You, unless you declare `/*` |
+| Not-found and SPA fallback | Implicit τjs fallback document | You, unless you declare `/*` |
 | Static facilities, decorators | τjs root | τjs scope |
 | Logging | Resolved τjs logger | Your `fastify.log` lineage |
 | Listening and shutdown | You | You |
@@ -60,13 +60,13 @@ unchanged. The hook is not registered in production.
 
 ## Using a caller-owned Fastify instance
 
-### Application shell and unmatched URLs
+### SPA fallback and unmatched URLs
 
 On a caller-owned host, URLs that match no Fastify route reach the host's not-found handler. τjs does
-not install an implicit application shell in the caller's root scope.
+not install its implicit SPA fallback document in the caller's root scope.
 
-To send client-routed URLs to a τjs application shell, declare a terminal wildcard page. It is an
-ordinary Fastify route compiled from the τjs application contract:
+To keep client-routed URLs inside a τjs application, declare a terminal wildcard page route. It
+is an ordinary Fastify route compiled from the τjs application contract:
 
 ```ts
 routes: [
@@ -75,10 +75,12 @@ routes: [
 ];
 ```
 
-The wildcard is the server route. Child URLs can remain client-routed inside the shell. See
-[App Shell Architecture](/guides/app-shell-pattern) for the complete pattern.
+The wildcard is the server route. Child URLs can remain client-routed inside the application.
+For the separate single-application composition pattern using shared browser-side chrome,
+routing and state, see [App Shell Architecture](/guides/app-shell-pattern).
 
-The two shell forms have different asset behaviour. The implicit shell on a τjs-created host
+The implicit fallback and the explicit wildcard have different asset behaviour. The implicit SPA
+fallback document on a τjs-created host
 delegates asset-like misses such as `/logo.png` to a 404. An explicit `/*` owns and renders every
 URL it matches. Use narrower page patterns or a separate asset prefix when missing asset-like URLs
 must remain 404 responses.

--- a/website/src/content/docs/guides/incremental-migration.md
+++ b/website/src/content/docs/guides/incremental-migration.md
@@ -94,10 +94,11 @@ export default defineConfig({
 
 At this stage, route components may continue calling their existing APIs after hydration. You do not need to introduce `serviceData()`, a service registry or streaming merely to adopt the host.
 
-URLs omitted from `taujs.config.ts` can remain client-routed, but an undeclared screen still needs an
-HTTP shell owner. A τjs-created host supplies its implicit shell fallback. A caller-owned Fastify host
-needs a declared terminal wildcard for the application, such as `/products/*`, when τjs should serve
-those unmatched client URLs. See [Host Ownership](/guides/host-ownership/#application-shell-and-unmatched-urls).
+URLs omitted from `taujs.config.ts` can remain client-routed, but an undeclared screen's document
+still needs an HTTP owner. A τjs-created host supplies its implicit SPA fallback document. A
+caller-owned Fastify host needs a declared terminal wildcard for the application, such as
+`/products/*`, when τjs should serve those unmatched client URLs. See
+[Host Ownership](/guides/host-ownership/#spa-fallback-and-unmatched-urls).
 
 The renderer contribution owns its framework compiler. Do not also add `pluginReact()`, `pluginVue()` or `pluginSolid()` to the app's `plugins` array. Ordinary, unrelated Vite plugins remain supported there.
 
@@ -125,8 +126,8 @@ visibility. Move only that initial read to `attr.data`:
 The renderer consumes the resolved initial state through its SSR store. Polling, mutations, user-triggered refreshes and other post-hydration work can continue through the existing client query library and explicit API endpoints.
 
 You are moving ownership of the **initial response**, not replacing the application's client data
-layer. Routes you leave undeclared remain outside the request-contract model and can continue as
-client-routed URLs behind the application shell.
+layer. Routes you leave undeclared remain outside the request-contract model and stay
+client-rendered by omission.
 
 ### 4. Mediate service access when it pays off
 

--- a/website/src/content/docs/guides/logging-telemetry.md
+++ b/website/src/content/docs/guides/logging-telemetry.md
@@ -134,7 +134,7 @@ request-correlation identity makes no such claim.
 ### Response scope
 
 A τjs-created host installs the request-identity lifecycle at its root, including its implicit
-shell and not-found path. A caller-owned host installs it inside the encapsulated τjs scope. Host
+SPA fallback and not-found path. A caller-owned host installs it inside the encapsulated τjs scope. Host
 routes then retain their own logging and do not receive a τjs `x-request-id` response header.
 
 Every τjs-owned response echoes the canonical identity:

--- a/website/src/content/docs/guides/micro-frontend.md
+++ b/website/src/content/docs/guides/micro-frontend.md
@@ -150,17 +150,17 @@ output behaviour.
 ### Within one application
 
 Undeclared URLs stay with the client router. A URL omitted from `taujs.config.ts` is not a
-server-owned request contract; once the application's shell is served, its client router can own
+server-owned request contract; once the application's document is served, its client router can own
 that URL.
 
-The shell still needs an HTTP owner:
+That document still needs an HTTP owner:
 
-- a τjs-created host provides the implicit application-shell fallback
+- a τjs-created host provides the implicit SPA fallback document
 - a caller-owned Fastify host needs a declared terminal wildcard such as `/app/*` for τjs to own
   unmatched client URLs
 
 See [Request Contracts & Data](/guides/request-contracts/#undeclared-urls-and-client-routing) and
-[Host Ownership](/guides/host-ownership/#application-shell-and-unmatched-urls).
+[Host Ownership](/guides/host-ownership/#spa-fallback-and-unmatched-urls).
 
 ### Between applications
 

--- a/website/src/content/docs/guides/request-contracts.md
+++ b/website/src/content/docs/guides/request-contracts.md
@@ -111,14 +111,14 @@ source.
 ## Undeclared URLs and client routing
 
 Not every client-routed screen needs its own τjs route declaration. A document-like URL that has no
-matching page contract can still receive the application shell, load the client bundle and let the
-client router take over. The shell owner depends on who created Fastify:
+matching page contract can still receive the SPA fallback document, load the client bundle and let
+the client router take over. The fallback owner depends on who created Fastify:
 
-- **τjs-created Fastify:** the implicit application-shell fallback serves unmatched document-like
+- **τjs-created Fastify:** the implicit SPA fallback document serves unmatched document-like
   URLs with status 200. The child URL can remain client-routed without a separate τjs contract.
-- **Caller-owned Fastify:** unmatched URLs belong to the caller. To preserve the same shell
-  behaviour, declare an explicit terminal `/*` page route for the application. Without it, the
-  caller's not-found response wins.
+- **Caller-owned Fastify:** unmatched URLs belong to the caller. To keep them in the
+  application, declare an explicit terminal `/*` page route. Without it, the caller's
+  not-found response wins.
 
 ```ts
 routes: [
@@ -128,11 +128,12 @@ routes: [
 ```
 
 The wildcard is the server route; individual child URLs can still be owned by the client router
-inside that shell. A wildcard-enabled caller `@fastify/static` mount also claims `GET /*` and will
+inside the application. A wildcard-enabled caller `@fastify/static` mount also claims `GET /*` and will
 collide at boot, so configure that mount with `wildcard: false` or use non-overlapping patterns.
 
-See [Host Ownership](/guides/host-ownership) for the owner split and
-[App Shell Architecture](/guides/app-shell-pattern) for the full routing pattern.
+See [Host Ownership](/guides/host-ownership) for the owner split. For the separate
+single-application composition pattern using shared browser-side chrome, routing and state,
+see [App Shell Architecture](/guides/app-shell-pattern).
 
 ## Client fetching remains part of the model
 
@@ -158,7 +159,7 @@ deferred registry, ordering and hydration seed belong to that response and that 
 coordinate with a second application.
 
 Navigation across τjs micro-frontend boundaries remains a full document navigation. The destination
-application creates its own request contract and data scope. Within an application shell, the
+application creates its own request contract and data scope. Within one application, the
 client router can own subsequent navigation and UI-local fetching. See
 [Micro-Frontends](/guides/micro-frontend) for where to place those boundaries.
 

--- a/website/src/content/docs/guides/static-assets.md
+++ b/website/src/content/docs/guides/static-assets.md
@@ -36,7 +36,7 @@ In production the default registration uses:
 ```
 
 `wildcard: false` matters. Static files receive concrete Fastify routes instead of a catch-all
-`GET /*`, so τjs can also register an explicit terminal application-shell route.
+`GET /*`, so τjs can also register an explicit terminal wildcard page route.
 
 On a τjs-created host the facility is installed at the created root. On a supplied Fastify instance
 it is encapsulated with the τjs applications. A caller's own static routes remain the caller's
@@ -142,13 +142,13 @@ A supplied host may register its own `@fastify/static` before τjs. That works w
 not collide.
 
 The caller plugin's own default is `wildcard: true`, which claims `GET /*`. If a τjs application also
-declares `/*` as its shell route, Fastify correctly fails with `FST_ERR_DUPLICATED_ROUTE`. Registration
+declares `/*` as its terminal wildcard page route, Fastify correctly fails with `FST_ERR_DUPLICATED_ROUTE`. Registration
 order cannot resolve two owners of the same method and path.
 
 Use one of these arrangements:
 
 ```ts
-// Concrete file routes can coexist with a τjs terminal shell route.
+// Concrete file routes can coexist with a τjs terminal wildcard route.
 await fastify.register(fastifyStatic, {
   root: path.resolve("dist/client"),
   prefix: "/",
@@ -164,7 +164,7 @@ await fastify.register(fastifyStatic, {
 });
 ```
 
-See [Host Ownership](/guides/host-ownership/#application-shell-and-unmatched-urls) for shell and
+See [Host Ownership](/guides/host-ownership/#spa-fallback-and-unmatched-urls) for fallback and
 not-found behaviour.
 
 ## Public directories
@@ -291,7 +291,7 @@ const clientRoot = path.resolve(process.cwd(), "dist/client");
 
 Or omit `clientRoot` when the process starts from the project root and use the environment defaults.
 
-### Asset returns the application shell
+### Asset returns the wildcard page
 
 Check whether a terminal wildcard page owns the asset URL. An explicit `/*` page renders every URL it
 matches, including asset-like misses. Use a narrower page prefix and a separate asset prefix when
@@ -305,7 +305,7 @@ separate the prefixes.
 
 ### Wrong MIME type
 
-First confirm the response came from the static route rather than a shell or not-found handler. If a
+First confirm the response came from the static route rather than a wildcard page, the SPA fallback document or a not-found handler. If a
 real file needs an override, set the header in that mount's `setHeaders` callback.
 
 ### Files are missing
@@ -322,6 +322,6 @@ other configured applications before deployment.
 
 Related guides:
 
-- [Host Ownership](/guides/host-ownership/) for Fastify scope and shell ownership
+- [Host Ownership](/guides/host-ownership/) for Fastify scope and fallback ownership
 - [Build & Deployment](/guides/build-deployment/) for output and selective builds
 - [Micro-Frontends](/guides/micro-frontend/) for per-application artefacts

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -158,8 +158,8 @@ console - each a separate application with its own renderer root, module graph a
 and each free to choose its own renderer framework. Independently developed applications can share
 one server and one operational model without first standardising on a component framework.
 
-Each URL belongs to exactly one application. Left undeclared within the application shell, it
-remains client-rendered.
+Each URL belongs to exactly one application. Left undeclared, it remains client-rendered by
+omission.
 
 Applications compose through routes and assembled build output rather than runtime module
 federation. They can be built selectively, while the deployed server artefact receives the bundles

--- a/website/src/content/docs/reference/platformatic-watt.md
+++ b/website/src/content/docs/reference/platformatic-watt.md
@@ -23,7 +23,7 @@ This page describes the **τjs-supported and recommended integration shape**: τ
 
 - Route matching and request handling
 - Declaring page-level data dependencies
-- Choosing rendering strategy (CSR / SSR / streaming)
+- Choosing rendering strategy per declared route (SSR / streaming)
 - Cancelling work when the client disconnects
 - Coordinating initial render data deterministically
 

--- a/website/src/content/docs/reference/taujs-config.md
+++ b/website/src/content/docs/reference/taujs-config.md
@@ -410,7 +410,7 @@ Route paths therefore use Fastify route syntax, not regular expressions. An exac
 
 Who answers an unmatched URL depends on who owns the host, including in the example above, since supplying an instance is itself an ownership decision:
 
-- **τjs created the Fastify instance** - unmatched document URLs continue through the τjs application-shell fallback.
+- **τjs created the Fastify instance** - unmatched document URLs continue through the τjs SPA fallback document.
 - **You supplied the Fastify instance** - your own not-found policy owns unmatched URLs, unless you declare an explicit τjs terminal wildcard page (`path: '/*'`).
 
 See [Host Ownership](/guides/host-ownership/) for the full split and the embedded-host migration notes.


### PR DESCRIPTION
CSR is not a value of attr.render: it happens by omission. When no declared τjs route matches a URL, it remains outside server orchestration, and what answers it depends on host ownership. The public surfaces described CSR as a per-route server mode and used 'application shell' for several different things; they now follow one vocabulary:

- CSR by omission, for URLs no declared route matches
- SPA fallback document, for what a τjs-created host serves unmatched document-like URLs
- terminal wildcard page route, for the /* routing/ownership mechanism
- App Shell, only for the optional composition pattern of the App Shell Architecture guide - a wildcard route is machinery an App Shell uses, not itself the pattern
- streaming shell / lifecycle senses untouched

Surfaces: root README (tagline + packages-table row), @taujs/server README, and the website pages getting-started, architecture, host-ownership (section anchor renamed to spa-fallback-and-unmatched-urls, all three inbound links updated), request-contracts, incremental-migration, micro-frontend, static-assets, logging-telemetry, the homepage, the taujs-config and platformatic-watt references, and the app-shell guide's step-1 summary. App Shell Architecture cross-links are qualified as the separate composition pattern rather than equated with the wildcard.

Renderer CSR claims and every streaming shell reference are deliberately unchanged: the renderers do support CSR (hydrateApp's CSR fallback is a data condition), and the streaming shell is a render-lifecycle term. Documentation only, no changeset.