### PR TITLE
fix: followup sweep - released vocabulary, server README, and three small corrections

### DIFF
--- a/.changeset/tidy-mcp-note-vocabulary.md
+++ b/.changeset/tidy-mcp-note-vocabulary.md
@@ -1,0 +1,5 @@
+---
+'@taujs/mcp': patch
+---
+
+The taujs_doctor fallthrough note no longer classifies a wildcard route as the app-shell pattern; it states the mechanism only. Tool output text; no behaviour change.

--- a/.changeset/tidy-shells-vocabulary.md
+++ b/.changeset/tidy-shells-vocabulary.md
@@ -1,0 +1,5 @@
+---
+'@taujs/server': patch
+---
+
+Ownership boot line and request-graph wording: the created host's implicit document is now called the SPA fallback rather than a shell, and the wildcard warning no longer classifies a terminal wildcard route as the app-shell pattern. Log and introspection text only; no behaviour change.

--- a/fixtures/renderer-composition/test/support/built-server.ts
+++ b/fixtures/renderer-composition/test/support/built-server.ts
@@ -50,9 +50,10 @@ export const externalImportsOfBuiltServer = (): string[] => {
   for (const source of sources) {
     for (const [, specifier] of source.matchAll(/(?:from|require\(|import\()\s*["']([^"']+)["']/g)) {
       // The group always participates in a match, so this is never undefined at runtime - but the
-      // type says otherwise and a silent `undefined` here would drop a real external import from
-      // the assertion rather than fail it.
-      if (specifier !== undefined && !specifier.startsWith('.')) specifiers.add(specifier);
+      // type says otherwise, and silently skipping it would drop a real external import from the
+      // assertion rather than fail it. So the impossible case fails loudly instead.
+      if (specifier === undefined) throw new Error('matchAll capture group missing - the import-specifier regex no longer captures what it matches');
+      if (!specifier.startsWith('.')) specifiers.add(specifier);
     }
   }
 

--- a/packages/mcp/src/test/RuntimeTools.test.ts
+++ b/packages/mcp/src/test/RuntimeTools.test.ts
@@ -172,4 +172,39 @@ describe('runtime tools (active boot)', () => {
     expect(result.failedEpisodes.items[0].error.message).toContain('999');
     expect(result.failedEpisodes.source).toContain('observed');
   });
+
+  it('taujs_doctor states the unreachable-fallthrough note without classifying the wildcard as a pattern', async () => {
+    // A terminal wildcard is a routing/ownership mechanism; the note must not brand it
+    // "app-shell pattern" (vocabulary ruling, decisions.md 2026-08-09).
+    const wildcardConfig: CoreTaujsConfig = {
+      apps: [{ appId: 'wildcard-app', entryPoint: '', routes: [{ path: '/*', attr: { render: 'ssr', meta: {} } }] }],
+    };
+    const root = await mkdtemp(path.join(tmpdir(), 'taujs-mcp-wildcard-'));
+    const dir = path.join(root, 'node_modules', '.taujs');
+    const dev = createDevIntrospection();
+    await writeTaujsArtifact(dir, 'graph.json', JSON.stringify(createRequestGraph(wildcardConfig, { source: 'boot', emittedAt: '2026-07-10T11:00:00.000Z' })));
+    await writeTaujsArtifact(dir, 'episodes.ndjson', '\n');
+    await writeTaujsArtifact(dir, 'logs.ndjson', '\n');
+    await writeTaujsArtifact(dir, 'observations.json', JSON.stringify(dev.getObservations()));
+    const devJson: DevJson = {
+      bootId: dev.bootId,
+      token: 'tok',
+      pid: process.pid,
+      startedAt: '2026-07-10T11:00:00.000Z',
+      host: '127.0.0.1',
+      port: 5173,
+      graph: path.join(dir, 'graph.json'),
+      episodes: path.join(dir, 'episodes.ndjson'),
+      logs: path.join(dir, 'logs.ndjson'),
+      observations: path.join(dir, 'observations.json'),
+    };
+    await writeTaujsArtifact(dir, 'dev.json', JSON.stringify(devJson));
+
+    const tools = new Map(allTools(root).map((t) => [t.name, t.handler]));
+    const result = tools.get('taujs_doctor')!({}) as any;
+
+    expect(result.fallthrough.reachable).toBe(false);
+    expect(result.fallthrough.note).toBe('A wildcard route makes fallthrough unreachable.');
+    expect(result.fallthrough.note).not.toContain('app-shell');
+  });
 });

--- a/packages/mcp/src/tools/runtime.ts
+++ b/packages/mcp/src/tools/runtime.ts
@@ -159,7 +159,7 @@ export const runtimeTools = (root: string): ToolDefinition[] => [
         warnings,
         fallthrough: {
           ...graph.fallthrough,
-          note: graph.fallthrough.reachable ? undefined : 'A wildcard route makes fallthrough unreachable (app-shell pattern).',
+          note: graph.fallthrough.reachable ? undefined : 'A wildcard route makes fallthrough unreachable.',
         },
         defaultedRenders: { source: 'declared', routeIds: defaultedRenders },
         failedEpisodes: {

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -10,7 +10,13 @@ This package is part of the τjs [ taujs ] orchestration system, authored by Joh
 
 `pnpm add @taujs/server`
 
-## CSR; SSR; Streaming SSR; Hydration; Fastify + React 19
+## SSR; Streaming SSR; CSR; Hydration; Fastify
+
+Fastify plugin and render orchestration for React, Vue and Solid applications. The renderer ships separately - pair this package with one of:
+
+- `@taujs/react`
+- `@taujs/vue`
+- `@taujs/solid`
 
 Rendering:
 
@@ -25,71 +31,29 @@ Supported application structure and composition:
 
 Assemble independent frontends at build time in a flexible SPA-MPA hybrid: SSR or Streaming SSR per declared route, CSR by omission.
 
-Fastify Plugin for integration with τjs [ taujs ] template https://github.com/aoede3/taujs
-
-- Production: Fastify, React
-- Development: Fastify, React, tsx, Vite
-
+- Production: Fastify
+- Development: Fastify, tsx, Vite
 - TypeScript-first
-- ESM-only focus
+- ESM-only
 
 ## τjs - DX Developer Experience
 
 Integrated Vite HMR run alongside tsx (TS eXecute) providing fast responsive dev reload times for universal backend / frontend changes
 
 - Fastify https://fastify.dev/
-- React https://reactjs.org/
 - tsx https://tsx.is/
-- Vite https://vitejs.dev/guide/ssr#building-for-production
-
-- ESBuild https://esbuild.github.io/
-- Rollup https://rollupjs.org/
-- ESM https://nodejs.org/api/esm.html
-
-## Development / CI
-
-`npm install --legacy-peer-deps`
+- Vite https://vitejs.dev/
 
 ## Usage
 
-### Fastify
+Scaffold a complete project with `npm create @taujs/taujs`, or start from the documentation:
 
-https://github.com/aoede3/taujs/blob/main/src/server/index.ts
-
-Not utilising τjs [ taujs ] template? Add in your own ts `alias` object for your own particular directory setup e.g. `alias: { object }`
-
-### React 'entry-client.tsx'
-
-https://github.com/aoede3/taujs/blob/main/src/client/entry-client.tsx
-
-### React 'entry-server.tsx'
-
-Extended pipe object with callbacks to @taujs/server enabling additional manipulation of HEAD content from client code
-
-https://github.com/aoede3/taujs/blob/main/src/client/entry-server.tsx
-
-### index.html
-
-https://github.com/aoede3/taujs/blob/main/src/client/index.html
-
-### client.d.ts
-
-https://github.com/aoede3/taujs/blob/main/src/client/client.d.ts
+- Getting started: https://taujs.dev/guides/getting-started/
+- Application contract and configuration: https://taujs.dev/reference/taujs-config/
+- Host ownership (bring your own Fastify): https://taujs.dev/guides/host-ownership/
+- Renderers: https://taujs.dev/renderers/react/ | https://taujs.dev/renderers/vue/ | https://taujs.dev/renderers/solid/
 
 ### Routes
-
-τjs app paths are registered as native Fastify routes:
-
-1. Fastify serving index.html to client browser for client routing
-2. Internal service calls to API to provide data for streaming/hydration
-3. Fastify serving API calls via HTTP in the more traditional sense of client/server
-
-In ensuring a particular 'route' receives data for hydration there are two options:
-
-1. Internal service call returning data as per your architecture
-2. An HTTP call from your app passing resolved data to @taujs/server
-
-In supporting Option 1. there is a registry of services. More detail in 'Service Registry'.
 
 Each route path uses Fastify route syntax. Configure router behaviour on the Fastify instance passed to createServer; τjs does not maintain a parallel matcher or duplicate Fastify router options.
 
@@ -97,12 +61,6 @@ Known stale path-to-regexp forms fail at startup rather than registering with di
 Auth and route CSP apply only to the Fastify-selected τjs route. Dotted values are valid page-route
 parameters; asset-like URLs 404 only when no static or declared page route owns them.
 
-https://github.com/aoede3/taujs/blob/main/src/shared/routes/Routes.ts
-
 ### Service Registry
 
-In supporting internal calls via τjs a registry of available services and methods can provide linkage to your own architectural setup and developmental patterns
-
-https://github.com/aoede3/taujs/blob/main/src/server/services/ServiceRegistry.ts
-
-https://github.com/aoede3/taujs/blob/main/src/server/services/ServiceExample.ts
+Internal service calls resolve route data through a registry of services and methods, linking the render pipeline to your own architecture. See https://taujs.dev/guides/services/

--- a/packages/server/src/CreateServer.ts
+++ b/packages/server/src/CreateServer.ts
@@ -150,10 +150,10 @@ export const createServer = async (opts: CreateServerOptions): Promise<CreateSer
   // the thesis this process is on. Without it a caller cannot tell from the logs why their 404s,
   // CSP or correlation headers changed.
   //
-  // RFC 0010 Q5: a caller-owned host gets no τjs not-found shell, so the line reports whether the
+  // RFC 0010 Q5: a caller-owned host gets no τjs SPA fallback, so the line reports whether the
   // opt-in - a declared terminal `/*` page - is in force. RFC 0012: a mounted created host's
-  // shell is confined to its subtree, so the created arm is mount-aware rather than claiming a
-  // whole-server shell unconditionally.
+  // SPA fallback is confined to its subtree, so the created arm is mount-aware rather than
+  // claiming a whole-server fallback unconditionally.
   const terminalWildcard = routes.some((route) => route.path === '/*');
   const mounted = mountPrefix !== '';
 
@@ -164,7 +164,7 @@ export const createServer = async (opts: CreateServerOptions): Promise<CreateSer
           : "No terminal '/*' τjs page declared: your routes and not-found policy own all remaining GET paths"
       }`
     : `${CONTENT.TAG} [ownership] Fastify created by τjs - ${
-        mounted ? 'shell confined to the mounted subtree, an ordinary 404 outside it' : 'whole-server shell'
+        mounted ? 'SPA fallback confined to the mounted subtree, an ordinary 404 outside it' : 'whole-server SPA fallback'
       }, CSP and request identity`;
 
   logger.info({ component: 'ownership', callerOwnedHost, mounted, terminalWildcard }, ownershipMessage);
@@ -220,7 +220,7 @@ export const createServer = async (opts: CreateServerOptions): Promise<CreateSer
     // RFC 0012: the mount is Fastify's own scope-prefix primitive on the one τjs registration.
     // `mounted` flips the plugin to its encapsulated form on a τjs-created host too - fastify-plugin
     // ignores `prefix` when it breaks encapsulation, and an encapsulated prefixed scope is also what
-    // CONFINES the created-host shell to the mounted subtree (prefix-keyed not-found).
+    // CONFINES the created-host SPA fallback to the mounted subtree (prefix-keyed not-found).
     await app.register(ssrServerPlugin({ callerOwnedHost, mounted: mountPrefix !== '' }), {
       prefix: mountPrefix || undefined,
       publicBasePath,

--- a/packages/server/src/core/introspection/RequestGraph.ts
+++ b/packages/server/src/core/introspection/RequestGraph.ts
@@ -261,7 +261,7 @@ export function createRequestGraph(config: CoreTaujsConfig, options: CreateReque
       severity: 'info',
       source: 'graph',
       routeId: wildcardRoute.id,
-      message: `Route "${wildcardRoute.path}" matches all page URLs (app-shell pattern); fallthrough is unreachable`,
+      message: `Route "${wildcardRoute.path}" matches all page URLs; fallthrough is unreachable`,
     });
   }
 

--- a/packages/server/src/core/introspection/test/RequestGraph.test.ts
+++ b/packages/server/src/core/introspection/test/RequestGraph.test.ts
@@ -84,7 +84,7 @@ const fixtureMultiApp: CoreTaujsConfig = {
   security: { csp: { defaultMode: 'merge', reporting: { endpoint: '/csp-report' } } },
 };
 
-// (c) app-shell wildcard: fallthrough unreachable.
+// (c) terminal wildcard: fallthrough unreachable.
 const fixtureAppShell: CoreTaujsConfig = {
   apps: [
     {
@@ -170,7 +170,7 @@ describe('createRequestGraph — fixture snapshots (spec 02 schema v1)', () => {
     expect(versionAgnostic(createRequestGraph(fixtureMultiApp, { ...OPTS, source: 'build' }))).toMatchSnapshot();
   });
 
-  it('(c) app-shell wildcard: fallthrough unreachable', () => {
+  it('(c) terminal wildcard: fallthrough unreachable', () => {
     expect(versionAgnostic(createRequestGraph(fixtureAppShell, OPTS))).toMatchSnapshot();
   });
 

--- a/packages/server/src/core/introspection/test/__snapshots__/RequestGraph.test.ts.snap
+++ b/packages/server/src/core/introspection/test/__snapshots__/RequestGraph.test.ts.snap
@@ -468,7 +468,7 @@ exports[`createRequestGraph — fixture snapshots (spec 02 schema v1) > (b) with
 }
 `;
 
-exports[`createRequestGraph — fixture snapshots (spec 02 schema v1) > (c) app-shell wildcard: fallthrough unreachable 1`] = `
+exports[`createRequestGraph — fixture snapshots (spec 02 schema v1) > (c) terminal wildcard: fallthrough unreachable 1`] = `
 {
   "apps": [
     {
@@ -550,7 +550,7 @@ exports[`createRequestGraph — fixture snapshots (spec 02 schema v1) > (c) app-
   "warnings": [
     {
       "code": "fallthrough.unreachable",
-      "message": "Route "/*" matches all page URLs (app-shell pattern); fallthrough is unreachable",
+      "message": "Route "/*" matches all page URLs; fallthrough is unreachable",
       "routeId": "shell:/*",
       "severity": "info",
       "source": "graph",
@@ -727,7 +727,7 @@ exports[`createRequestGraph — fixture snapshots (spec 02 schema v1) > (d) ever
     },
     {
       "code": "fallthrough.unreachable",
-      "message": "Route "*" matches all page URLs (app-shell pattern); fallthrough is unreachable",
+      "message": "Route "*" matches all page URLs; fallthrough is unreachable",
       "routeId": "alpha:*",
       "severity": "info",
       "source": "graph",

--- a/packages/server/src/test/MountAddressing.test.ts
+++ b/packages/server/src/test/MountAddressing.test.ts
@@ -252,7 +252,7 @@ describe('RFC 0012 - created-host confinement (cells 6, frozen ownership contrac
     await host.close();
   });
 
-  it('keeps the unmounted created host byte-compatible: whole-server shell at the root', async () => {
+  it('keeps the unmounted created host byte-compatible: whole-server SPA fallback at the root', async () => {
     const host = await createCreatedHost();
     const { app } = await host.activate(createServer as never, withAddressing({}, [ROOT_ROUTE]));
 

--- a/packages/server/src/test/OwnershipBootLine.test.ts
+++ b/packages/server/src/test/OwnershipBootLine.test.ts
@@ -118,7 +118,7 @@ describe('ownership boot line - caller-owned host states the terminal wildcard (
 
 describe('ownership boot line - created host is mount-aware (RFC 0012)', () => {
   it('is unchanged when unmounted, whether or not a wildcard is declared', async () => {
-    const expected = `${CONTENT.TAG} [ownership] Fastify created by τjs - whole-server shell, CSP and request identity`;
+    const expected = `${CONTENT.TAG} [ownership] Fastify created by τjs - whole-server SPA fallback, CSP and request identity`;
 
     const [plainMeta, plainMessage] = await ownershipRecord(configWith([ROOT_ROUTE]), { callerOwned: false });
     expect(plainMessage).toBe(expected);
@@ -131,15 +131,15 @@ describe('ownership boot line - created host is mount-aware (RFC 0012)', () => {
     expect(wildcardMeta).toEqual({ component: 'ownership', callerOwnedHost: false, mounted: false, terminalWildcard: true });
   });
 
-  it('states the confinement when mounted, rather than claiming a whole-server shell', async () => {
+  it('states the confinement when mounted, rather than claiming a whole-server SPA fallback', async () => {
     // MountAddressing.test.ts proves the runtime behaviour this describes: inside the subtree the
     // shell serves, outside it the host answers an ordinary 404.
     const [meta, message] = await ownershipRecord(configWith([ROOT_ROUTE], { mountPrefix: '/app' }), { callerOwned: false });
 
     expect(message).toBe(
-      `${CONTENT.TAG} [ownership] Fastify created by τjs - shell confined to the mounted subtree, an ordinary 404 outside it, CSP and request identity`,
+      `${CONTENT.TAG} [ownership] Fastify created by τjs - SPA fallback confined to the mounted subtree, an ordinary 404 outside it, CSP and request identity`,
     );
-    expect(message).not.toContain('whole-server shell');
+    expect(message).not.toContain('whole-server SPA fallback');
     expect(meta).toEqual({ component: 'ownership', callerOwnedHost: false, mounted: true, terminalWildcard: false });
   });
 });

--- a/website/src/content/docs/guides/content-security-policy.md
+++ b/website/src/content/docs/guides/content-security-policy.md
@@ -51,7 +51,7 @@ const nonce = crypto.randomBytes(16).toString('base64');
 Content-Security-Policy: script-src 'self' 'nonce-abc123...'
 
 // Passes to the renderer, in the render options
-renderStream(writable, callbacks, data, location, modules, meta, signal, { cspNonce, ... });
+renderStream(writable, callbacks, data, location, modules, meta, signal, { cspNonce: nonce });
 ```
 
 ### Automatic Application

--- a/website/src/content/docs/reference/taujs-config.md
+++ b/website/src/content/docs/reference/taujs-config.md
@@ -292,11 +292,15 @@ warning naming this field, so a proxied topology fails visibly rather than silen
 
 ### `introspection.redaction`
 
-What τjs withholds from the development introspection record - the episodes, observations and
-log annex written under `node_modules/.taujs/` and served to the overlay. Redaction here is
-**structural**: τjs never scans values looking for things that resemble secrets.
+What τjs withholds from the development introspection record written under
+`node_modules/.taujs/` and served to the overlay. Redaction here is **structural**: τjs never
+scans values looking for things that resemble secrets, and each rule acts on the one record
+type that carries the data it filters. Episodes get URL hygiene; the log annex gets
+metadata-key dropping; observations (service edges) are structural records - service and
+method names, counts, timestamps and capped sample request ids - that carry neither query
+values nor metadata, so these two redaction rules have no observation fields to act on.
 
-Two rules apply, and both are unconditional:
+Two rules apply, and both are unconditional for the records they act on:
 
 - **Query values are never captured, for any key.** A URL is stored as its pathname, the
   surviving query key names, and a flag - never as a raw string. For `/reset?token=abc&ref=x`


### PR DESCRIPTION
02938df  test(renderer-composition): built-server guard fails loudly instead of skipping
f6534e0  docs(website): redaction reference states which rule acts on which record
77cff70  docs(website): CSP nonce fence names the variable it defines
116ddf6  docs(server): renderer-neutral README pointing at taujs.dev
259ff4b  fix: state released introspection and boot output in the ruled vocabulary
